### PR TITLE
bgpd, lib: fix a few scan-build catches

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9497,7 +9497,7 @@ DEFUN (show_ip_bgp_instance_neighbor_advertised_route,
   char *vrf = NULL;
   char *rmap_name = NULL;
   char *peerstr = NULL;
-  int rcvd;
+  int rcvd = 0;
 
   struct peer *peer;
 

--- a/lib/command.c
+++ b/lib/command.c
@@ -304,6 +304,9 @@ cmd_concat_strvec (vector v)
     if (vector_slot (v, i))
       strsize += strlen ((char *) vector_slot (v, i)) + 1;
 
+  if (strsize == 0)
+    return XSTRDUP (MTYPE_TMP, "");
+
   char *concatenated = calloc (sizeof (char), strsize);
   for (unsigned int i = 0; i < vector_active (v); i++)
   {

--- a/lib/command_match.c
+++ b/lib/command_match.c
@@ -482,7 +482,7 @@ add_nexthops (struct list *list, struct graph_node *node,
       child = vector_slot (node->to, i);
       size_t j;
       struct cmd_token *token = child->data;
-      if (!token->allowrepeat)
+      if (!token->allowrepeat && stack)
         {
           for (j = 0; j < stackpos; j++)
             if (child == stack[j])

--- a/lib/routemap.c
+++ b/lib/routemap.c
@@ -989,9 +989,11 @@ vty_show_route_map_entry (struct vty *vty, struct route_map *map)
 
   /* Print the name of the protocol */
   if (zlog_default)
+  {
     vty_out (vty, "%s", zlog_proto_names[zlog_default->protocol]);
-  if (zlog_default->instance)
-    vty_out (vty, " %d", zlog_default->instance);
+    if (zlog_default->instance)
+      vty_out (vty, " %d", zlog_default->instance);
+  }
   vty_out (vty, ":%s", VTY_NEWLINE);
 
   for (index = map->head; index; index = index->next)
@@ -2766,17 +2768,16 @@ DEFUN (rmap_call,
   struct route_map_index *index = VTY_GET_CONTEXT (route_map_index);
   const char *rmap = argv[idx_word]->arg;
 
-  if (index)
+  assert(index);
+
+  if (index->nextrm)
     {
-      if (index->nextrm)
-	{
-	  route_map_upd8_dependency (RMAP_EVENT_CALL_DELETED,
-				     index->nextrm,
-				     index->map->name);
-	  XFREE (MTYPE_ROUTE_MAP_NAME, index->nextrm);
-	}
-      index->nextrm = XSTRDUP (MTYPE_ROUTE_MAP_NAME, rmap);
+      route_map_upd8_dependency (RMAP_EVENT_CALL_DELETED,
+                                 index->nextrm,
+                                 index->map->name);
+      XFREE (MTYPE_ROUTE_MAP_NAME, index->nextrm);
     }
+  index->nextrm = XSTRDUP (MTYPE_ROUTE_MAP_NAME, rmap);
 
   /* Execute event hook. */
   route_map_upd8_dependency (RMAP_EVENT_CALL_ADDED,


### PR DESCRIPTION
Fixes a couple null pointer derefs and uninit'd values.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>