### PR TITLE
Working/2.0/patch set 161218b

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -631,8 +631,9 @@ bgp_info_cmp (struct bgp *bgp, struct bgp_info *new, struct bgp_info *exist,
     {
       if (peer_sort (new->peer) == BGP_PEER_IBGP
 	  && peer_sort (exist->peer) == BGP_PEER_IBGP
-	  && CHECK_FLAG (mpath_cfg->ibgp_flags,
-			 BGP_FLAG_IBGP_MULTIPATH_SAME_CLUSTERLEN))
+	  && (mpath_cfg == NULL ||
+              CHECK_FLAG (mpath_cfg->ibgp_flags,
+                          BGP_FLAG_IBGP_MULTIPATH_SAME_CLUSTERLEN)))
 	{
 	  newm = BGP_CLUSTER_LIST_LENGTH(new->attr);
 	  existm = BGP_CLUSTER_LIST_LENGTH(exist->attr);
@@ -868,9 +869,8 @@ bgp_info_cmp_compatible (struct bgp *bgp, struct bgp_info *new, struct bgp_info 
                          afi_t afi, safi_t safi)
 {
   int paths_eq;
-  struct bgp_maxpaths_cfg mpath_cfg;
   int ret;
-  ret = bgp_info_cmp (bgp, new, exist, &paths_eq, &mpath_cfg, 0, __func__);
+  ret = bgp_info_cmp (bgp, new, exist, &paths_eq, NULL, 0, __func__);
 
   if (paths_eq)
     ret = 0;

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -30,6 +30,13 @@ struct bgp;
 #define BGP_INSTANCE_ALL_CMD "(view|vrf) all"
 #define BGP_INSTANCE_ALL_HELP_STR "BGP view\nBGP VRF\nAll Views/VRFs\n"
 
+#define AFI_SAFI_STR \
+  "Address family\n" \
+  "Address Family modifier\n" \
+  "Address Family modifier\n" \
+  "Address Family modifier\n" \
+  "Address Family modifier\n"
+
 extern void bgp_vty_init (void);
 extern const char *afi_safi_print (afi_t, safi_t);
 extern int bgp_config_write_update_delay (struct vty *, struct bgp *);
@@ -45,5 +52,8 @@ bgp_parse_afi(const char *str, afi_t *afi);
 
 extern int
 bgp_parse_safi(const char *str, safi_t *safi);
+
+extern safi_t
+bgp_vty_safi_from_arg(const char *safi_str);
 
 #endif /* _QUAGGA_BGP_VTY_H */

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -3778,7 +3778,7 @@ static struct cmd_node bgp_vnc_l2_group_node = {
   1
 };
 
-static struct rfapi_l2_group_cfg *
+struct rfapi_l2_group_cfg *
 bgp_rfapi_get_group_by_lni_label (
   struct bgp	*bgp,
   uint32_t	logical_net_id,

--- a/bgpd/rfapi/bgp_rfapi_cfg.h
+++ b/bgpd/rfapi/bgp_rfapi_cfg.h
@@ -300,6 +300,12 @@ bgp_rfapi_show_summary (struct bgp *bgp, struct vty *vty);
 extern struct rfapi_cfg *
 bgp_rfapi_get_config (struct bgp *bgp);
 
+extern struct rfapi_l2_group_cfg *
+bgp_rfapi_get_group_by_lni_label (
+  struct bgp	*bgp,
+  uint32_t	logical_net_id,
+  uint32_t	label);
+
 extern struct ecommunity *
 bgp_rfapi_get_ecommunity_by_lni_label (
   struct bgp	*bgp,

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -2842,11 +2842,37 @@ rfapi_register (
                * If mac address is set, add an RT based on the registered LNI
                */
               memset ((char *) &ecom_value, 0, sizeof (ecom_value));
-              ecom_value.val[1] = 0x02;
+              ecom_value.val[1] = ECOMMUNITY_ROUTE_TARGET;
               ecom_value.val[5] = (l2o->logical_net_id >> 16) & 0xff;
               ecom_value.val[6] = (l2o->logical_net_id >> 8) & 0xff;
               ecom_value.val[7] = (l2o->logical_net_id >> 0) & 0xff;
               rtlist = ecommunity_new();
+              ecommunity_add_val (rtlist, &ecom_value);
+            }
+          if (l2o->tag_id) 
+            {
+              as_t as      = bgp->as;
+              uint16_t val = l2o->tag_id;
+              memset ((char *) &ecom_value, 0, sizeof (ecom_value));
+              ecom_value.val[1] = ECOMMUNITY_ROUTE_TARGET;
+              if (as > BGP_AS_MAX)
+                {      
+                  ecom_value.val[0] = ECOMMUNITY_ENCODE_AS4;
+                  ecom_value.val[2] = (as >>24) & 0xff;
+                  ecom_value.val[3] = (as >>16) & 0xff;
+                  ecom_value.val[4] = (as >>8) & 0xff;
+                  ecom_value.val[5] =  as & 0xff;
+                }
+              else
+                {
+                  ecom_value.val[0] = ECOMMUNITY_ENCODE_AS;
+                  ecom_value.val[2] = (as >>8) & 0xff;
+                  ecom_value.val[3] = as & 0xff;
+                }
+              ecom_value.val[6] = (val >> 8) & 0xff;
+              ecom_value.val[7] = val & 0xff;
+              if (rtlist == NULL)
+                rtlist = ecommunity_new();
               ecommunity_add_val (rtlist, &ecom_value);
             }
         }

--- a/bgpd/rfapi/rfapi.h
+++ b/bgpd/rfapi/rfapi.h
@@ -89,6 +89,7 @@ struct rfapi_l2address_option
   uint32_t		logical_net_id;	/* ~= EVPN Ethernet Segment Id,
                                    must not be zero for mac regis. */
   uint8_t		local_nve_id;
+  uint16_t		tag_id;         /* EVPN Ethernet Tag ID, 0 = none */
 };
 
 typedef enum

--- a/bgpd/rfapi/rfapi_import.h
+++ b/bgpd/rfapi/rfapi_import.h
@@ -203,6 +203,9 @@ extern int rfapiEcommunityGetLNI (
   struct ecommunity	*ecom,
   uint32_t		*lni);
 
+extern int rfapiEcommunityGetEthernetTag (
+  struct ecommunity *ecom,
+  uint16_t * tag_id);
 
 /* enable for debugging; disable for performance */
 #if 0

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -707,6 +707,8 @@ rfapiRibBi2Ri(
         {
           (void) rfapiEcommunityGetLNI (bi->attr->extra->ecommunity,
                                         &vo->v.l2addr.logical_net_id);
+          (void) rfapiEcommunityGetEthernetTag (bi->attr->extra->ecommunity,
+                                                &vo->v.l2addr.tag_id);
         }
 
       /* local_nve_id comes from RD */

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -2546,7 +2546,7 @@ DEFUN (add_vnc_prefix_cost_life_lnh,
        "add vnc prefix (A.B.C.D/M|X:X::X:X/M) vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) cost <0-255> lifetime <1-4294967295> .LNH_OPTIONS",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify prefix related infomation\n"
+       "Add/modify prefix related information\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
        "VN address of NVE\n"
@@ -2572,7 +2572,7 @@ DEFUN (add_vnc_prefix_life_cost_lnh,
        "add vnc prefix (A.B.C.D/M|X:X::X:X/M) vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) lifetime <1-4294967295> cost <0-255> .LNH_OPTIONS",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify prefix related infomation\n"
+       "Add/modify prefix related information\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
        "VN address of NVE\n"
@@ -2598,7 +2598,7 @@ DEFUN (add_vnc_prefix_cost_lnh,
        "add vnc prefix (A.B.C.D/M|X:X::X:X/M) vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) cost <0-255> .LNH_OPTIONS",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify prefix related infomation\n"
+       "Add/modify prefix related information\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
        "VN address of NVE\n"
@@ -2622,7 +2622,7 @@ DEFUN (add_vnc_prefix_life_lnh,
        "add vnc prefix (A.B.C.D/M|X:X::X:X/M) vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) lifetime <1-4294967295> .LNH_OPTIONS",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify prefix related infomation\n"
+       "Add/modify prefix related information\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
        "VN address of NVE\n"
@@ -2646,7 +2646,7 @@ DEFUN (add_vnc_prefix_lnh,
        "add vnc prefix (A.B.C.D/M|X:X::X:X/M) vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) .LNH_OPTIONS",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify prefix related infomation\n"
+       "Add/modify prefix related information\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
        "VN address of NVE\n"
@@ -2671,7 +2671,7 @@ DEFUN (add_vnc_prefix_cost_life,
        "add vnc prefix (A.B.C.D/M|X:X::X:X/M) vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) cost <0-255> lifetime <1-4294967295>",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify prefix related infomation\n"
+       "Add/modify prefix related information\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
        "VN address of NVE\n"
@@ -2697,7 +2697,7 @@ DEFUN (add_vnc_prefix_life_cost,
        "add vnc prefix (A.B.C.D/M|X:X::X:X/M) vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) lifetime <1-4294967295> cost <0-255>",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify prefix related infomation\n"
+       "Add/modify prefix related information\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
        "VN address of NVE\n"
@@ -2723,7 +2723,7 @@ DEFUN (add_vnc_prefix_cost,
        "add vnc prefix (A.B.C.D/M|X:X::X:X/M) vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) cost <0-255>",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify prefix related infomation\n"
+       "Add/modify prefix related information\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
        "VN address of NVE\n"
@@ -2747,7 +2747,7 @@ DEFUN (add_vnc_prefix_life,
        "add vnc prefix (A.B.C.D/M|X:X::X:X/M) vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) lifetime <1-4294967295>",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify prefix related infomation\n"
+       "Add/modify prefix related information\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
        "VN address of NVE\n"
@@ -2771,7 +2771,7 @@ DEFUN (add_vnc_prefix,
        "add vnc prefix (A.B.C.D/M|X:X::X:X/M) vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X)",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify prefix related infomation\n"
+       "Add/modify prefix related information\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
        "VN address of NVE\n"
@@ -2796,7 +2796,7 @@ DEFUN (add_vnc_mac_vni_prefix_cost_life,
        "add vnc mac YY:YY:YY:YY:YY:YY virtual-network-identifier <1-4294967295> vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) prefix (A.B.C.D/M|X:X::X:X/M) cost <0-255> lifetime <1-4294967295>",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify mac address infomation\n"
+       "Add/modify mac address information\n"
        "MAC address\n"
        "Virtual Network Identifier follows\n"
        "Virtual Network Identifier\n"
@@ -2806,7 +2806,7 @@ DEFUN (add_vnc_mac_vni_prefix_cost_life,
        "UN address of NVE\n"
        "UN IPv4 interface address\n"
        "UN IPv6 interface address\n"
-       "Add/modify prefix related infomation\n"
+       "Add/modify prefix related information\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
        "Administrative cost   [default: 255]\n"
@@ -2826,7 +2826,7 @@ DEFUN (add_vnc_mac_vni_prefix_life,
        "add vnc mac YY:YY:YY:YY:YY:YY virtual-network-identifier <1-4294967295> vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) prefix (A.B.C.D/M|X:X::X:X/M) lifetime <1-4294967295>",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify mac address infomation\n"
+       "Add/modify mac address information\n"
        "MAC address\n"
        "Virtual Network Identifier follows\n"
        "Virtual Network Identifier\n"
@@ -2836,7 +2836,7 @@ DEFUN (add_vnc_mac_vni_prefix_life,
        "UN address of NVE\n"
        "UN IPv4 interface address\n"
        "UN IPv6 interface address\n"
-       "Add/modify prefix related infomation\n"
+       "Add/modify prefix related information\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
        "Registration lifetime [default: infinite]\n"
@@ -2853,7 +2853,7 @@ DEFUN (add_vnc_mac_vni_prefix_cost,
        "add vnc mac YY:YY:YY:YY:YY:YY virtual-network-identifier <1-4294967295> vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) prefix (A.B.C.D/M|X:X::X:X/M) cost <0-255>",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify mac address infomation\n"
+       "Add/modify mac address information\n"
        "MAC address\n"
        "Virtual Network Identifier follows\n"
        "Virtual Network Identifier\n"
@@ -2863,7 +2863,7 @@ DEFUN (add_vnc_mac_vni_prefix_cost,
        "UN address of NVE\n"
        "UN IPv4 interface address\n"
        "UN IPv6 interface address\n"
-       "Add/modify prefix related infomation\n"
+       "Add/modify prefix related information\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
        "Administrative cost   [default: 255]\n" "Administrative cost\n")
@@ -2879,7 +2879,7 @@ DEFUN (add_vnc_mac_vni_prefix,
        "add vnc mac YY:YY:YY:YY:YY:YY virtual-network-identifier <1-4294967295> vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) prefix (A.B.C.D/M|X:X::X:X/M)",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify mac address infomation\n"
+       "Add/modify mac address information\n"
        "MAC address\n"
        "Virtual Network Identifier follows\n"
        "Virtual Network Identifier\n"
@@ -2889,7 +2889,7 @@ DEFUN (add_vnc_mac_vni_prefix,
        "UN address of NVE\n"
        "UN IPv4 interface address\n"
        "UN IPv6 interface address\n"
-       "Add/modify prefix related infomation\n"
+       "Add/modify prefix related information\n"
        "IPv4 prefix\n" "IPv6 prefix\n")
 {
   /*                       pfx      vn       un       cost     life */
@@ -2903,7 +2903,7 @@ DEFUN (add_vnc_mac_vni_cost_life,
        "add vnc mac YY:YY:YY:YY:YY:YY virtual-network-identifier <1-4294967295> vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) cost <0-255> lifetime <1-4294967295>",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify mac address infomation\n"
+       "Add/modify mac address information\n"
        "MAC address\n"
        "Virtual Network Identifier follows\n"
        "Virtual Network Identifier\n"
@@ -2930,7 +2930,7 @@ DEFUN (add_vnc_mac_vni_cost,
        "add vnc mac YY:YY:YY:YY:YY:YY virtual-network-identifier <1-4294967295> vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) cost <0-255>",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify mac address infomation\n"
+       "Add/modify mac address information\n"
        "MAC address\n"
        "Virtual Network Identifier follows\n"
        "Virtual Network Identifier\n"
@@ -2954,7 +2954,7 @@ DEFUN (add_vnc_mac_vni_life,
        "add vnc mac YY:YY:YY:YY:YY:YY virtual-network-identifier <1-4294967295> vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X) lifetime <1-4294967295>",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify mac address infomation\n"
+       "Add/modify mac address information\n"
        "MAC address\n"
        "Virtual Network Identifier follows\n"
        "Virtual Network Identifier\n"
@@ -2979,7 +2979,7 @@ DEFUN (add_vnc_mac_vni,
        "add vnc mac YY:YY:YY:YY:YY:YY virtual-network-identifier <1-4294967295> vn (A.B.C.D|X:X::X:X) un (A.B.C.D|X:X::X:X)",
        "Add registration\n"
        "VNC Information\n"
-       "Add/modify mac address infomation\n"
+       "Add/modify mac address information\n"
        "MAC address\n"
        "Virtual Network Identifier follows\n"
        "Virtual Network Identifier\n"
@@ -3723,7 +3723,7 @@ DEFUN (clear_vnc_nve_vn_un,
        "clear vnc nve vn (*|A.B.C.D|X:X::X:X) un (*|A.B.C.D|X:X::X:X)",
        "clear\n"
        "VNC Information\n"
-       "Clear prefix registration infomation\n"
+       "Clear prefix registration information\n"
        "VN address of NVE\n"
        "VN IPv4 interface address\n"
        "VN IPv6 interface address\n"
@@ -3753,7 +3753,7 @@ DEFUN (clear_vnc_nve_un_vn,
        "clear vnc nve un (*|A.B.C.D|X:X::X:X) vn (*|A.B.C.D|X:X::X:X)",
        "clear\n"
        "VNC Information\n"
-       "Clear prefix registration infomation\n"
+       "Clear prefix registration information\n"
        "UN address of NVE\n"
        "UN IPv4 interface address\n"
        "UN IPv6 interface address\n"
@@ -3783,7 +3783,7 @@ DEFUN (clear_vnc_nve_vn,
        "clear vnc nve vn (*|A.B.C.D|X:X::X:X)",
        "clear\n"
        "VNC Information\n"
-       "Clear prefix registration infomation\n"
+       "Clear prefix registration information\n"
        "VN address of NVE\n"
        "VN IPv4 interface address\n" "VN IPv6 interface address\n")
 {
@@ -3808,7 +3808,7 @@ DEFUN (clear_vnc_nve_un,
        "clear vnc nve un (*|A.B.C.D|X:X::X:X)",
        "clear\n"
        "VNC Information\n"
-       "Clear prefix registration infomation\n"
+       "Clear prefix registration information\n"
        "UN address of NVE\n"
        "UN IPv4 interface address\n" "UN IPv6 interface address\n")
 {
@@ -3841,7 +3841,7 @@ DEFUN (clear_vnc_prefix_vn_un,
        "clear vnc prefix (*|A.B.C.D/M|X:X::X:X/M) vn (*|A.B.C.D|X:X::X:X) un (*|A.B.C.D|X:X::X:X)",
        "clear\n"
        "VNC Information\n"
-       "Clear prefix registration infomation\n"
+       "Clear prefix registration information\n"
        "All prefixes\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
@@ -3871,7 +3871,7 @@ DEFUN (clear_vnc_prefix_un_vn,
        "clear vnc prefix (*|A.B.C.D/M|X:X::X:X/M) un (*|A.B.C.D|X:X::X:X) vn (*|A.B.C.D|X:X::X:X)",
        "clear\n"
        "VNC Information\n"
-       "Clear prefix registration infomation\n"
+       "Clear prefix registration information\n"
        "All prefixes\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
@@ -3901,7 +3901,7 @@ DEFUN (clear_vnc_prefix_un,
        "clear vnc prefix (*|A.B.C.D/M|X:X::X:X/M) un (*|A.B.C.D|X:X::X:X)",
        "clear\n"
        "VNC Information\n"
-       "Clear prefix registration infomation\n"
+       "Clear prefix registration information\n"
        "All prefixes\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
@@ -3927,7 +3927,7 @@ DEFUN (clear_vnc_prefix_vn,
        "clear vnc prefix (*|A.B.C.D/M|X:X::X:X/M) vn (*|A.B.C.D|X:X::X:X)",
        "clear\n"
        "VNC Information\n"
-       "Clear prefix registration infomation\n"
+       "Clear prefix registration information\n"
        "All prefixes\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
@@ -3953,7 +3953,7 @@ DEFUN (clear_vnc_prefix_all,
        "clear vnc prefix (*|A.B.C.D/M|X:X::X:X/M) *",
        "clear\n"
        "VNC Information\n"
-       "Clear prefix registration infomation\n"
+       "Clear prefix registration information\n"
        "All prefixes\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n"
@@ -3983,7 +3983,7 @@ DEFUN (clear_vnc_mac_vn_un,
        "clear vnc mac (*|YY:YY:YY:YY:YY:YY) virtual-network-identifier (*|<1-4294967295>) vn (*|A.B.C.D|X:X::X:X) un (*|A.B.C.D|X:X::X:X)",
        "clear\n"
        "VNC Information\n"
-       "Clear mac registration infomation\n"
+       "Clear mac registration information\n"
        "All macs\n"
        "MAC address\n"
        "VNI keyword\n"
@@ -4018,7 +4018,7 @@ DEFUN (clear_vnc_mac_un_vn,
        "clear vnc mac (*|YY:YY:YY:YY:YY:YY) virtual-network-identifier (*|<1-4294967295>) un (*|A.B.C.D|X:X::X:X) vn (*|A.B.C.D|X:X::X:X)",
        "clear\n"
        "VNC Information\n"
-       "Clear mac registration infomation\n"
+       "Clear mac registration information\n"
        "All macs\n"
        "MAC address\n"
        "VNI keyword\n"
@@ -4052,7 +4052,7 @@ DEFUN (clear_vnc_mac_un,
        "clear vnc mac (*|YY:YY:YY:YY:YY:YY) virtual-network-identifier (*|<1-4294967295>) un (*|A.B.C.D|X:X::X:X)",
        "clear\n"
        "VNC Information\n"
-       "Clear mac registration infomation\n"
+       "Clear mac registration information\n"
        "All macs\n"
        "MAC address\n"
        "VNI keyword\n"
@@ -4081,7 +4081,7 @@ DEFUN (clear_vnc_mac_vn,
        "clear vnc mac (*|YY:YY:YY:YY:YY:YY) virtual-network-identifier (*|<1-4294967295>) vn (*|A.B.C.D|X:X::X:X)",
        "clear\n"
        "VNC Information\n"
-       "Clear mac registration infomation\n"
+       "Clear mac registration information\n"
        "All macs\n"
        "MAC address\n"
        "VNI keyword\n"
@@ -4110,7 +4110,7 @@ DEFUN (clear_vnc_mac_all,
        "clear vnc mac (*|YY:YY:YY:YY:YY:YY) virtual-network-identifier (*|<1-4294967295>) *",
        "clear\n"
        "VNC Information\n"
-       "Clear mac registration infomation\n"
+       "Clear mac registration information\n"
        "All macs\n"
        "MAC address\n"
        "VNI keyword\n"
@@ -4140,7 +4140,7 @@ DEFUN (clear_vnc_mac_vn_un_prefix,
        "clear vnc mac (*|YY:YY:YY:YY:YY:YY) virtual-network-identifier (*|<1-4294967295>) vn (*|A.B.C.D|X:X::X:X) un (*|A.B.C.D|X:X::X:X) prefix (*|A.B.C.D/M|X:X::X:X/M)",
        "clear\n"
        "VNC Information\n"
-       "Clear mac registration infomation\n"
+       "Clear mac registration information\n"
        "All macs\n"
        "MAC address\n"
        "VNI keyword\n"
@@ -4155,7 +4155,7 @@ DEFUN (clear_vnc_mac_vn_un_prefix,
        "All UN addresses\n"
        "UN IPv4 interface address\n"
        "UN IPv6 interface address\n"
-       "Clear prefix registration infomation\n"
+       "Clear prefix registration information\n"
        "All prefixes\n"
        "IPv4 prefix\n"
        "IPv6 prefix\n")
@@ -4179,7 +4179,7 @@ DEFUN (clear_vnc_mac_un_vn_prefix,
        "clear vnc mac (*|YY:YY:YY:YY:YY:YY) virtual-network-identifier (*|<1-4294967295>) un (*|A.B.C.D|X:X::X:X) vn (*|A.B.C.D|X:X::X:X) prefix (*|A.B.C.D/M|X:X::X:X/M) prefix (*|A.B.C.D/M|X:X::X:X/M)",
        "clear\n"
        "VNC Information\n"
-       "Clear mac registration infomation\n"
+       "Clear mac registration information\n"
        "All macs\n"
        "MAC address\n"
        "VNI keyword\n"
@@ -4213,7 +4213,7 @@ DEFUN (clear_vnc_mac_un_prefix,
        "clear vnc mac (*|YY:YY:YY:YY:YY:YY) virtual-network-identifier (*|<1-4294967295>) un (*|A.B.C.D|X:X::X:X) prefix (*|A.B.C.D/M|X:X::X:X/M)",
        "clear\n"
        "VNC Information\n"
-       "Clear mac registration infomation\n"
+       "Clear mac registration information\n"
        "All macs\n"
        "MAC address\n"
        "VNI keyword\n"
@@ -4243,7 +4243,7 @@ DEFUN (clear_vnc_mac_vn_prefix,
        "clear vnc mac (*|YY:YY:YY:YY:YY:YY) virtual-network-identifier (*|<1-4294967295>) vn (*|A.B.C.D|X:X::X:X) prefix (*|A.B.C.D/M|X:X::X:X/M)",
        "clear\n"
        "VNC Information\n"
-       "Clear mac registration infomation\n"
+       "Clear mac registration information\n"
        "All macs\n"
        "MAC address\n"
        "VNI keyword\n"
@@ -4273,7 +4273,7 @@ DEFUN (clear_vnc_mac_all_prefix,
        "clear vnc mac (*|YY:YY:YY:YY:YY:YY) virtual-network-identifier (*|<1-4294967295>) prefix (*|A.B.C.D/M|X:X::X:X/M)",
        "clear\n"
        "VNC Information\n"
-       "Clear mac registration infomation\n"
+       "Clear mac registration information\n"
        "All macs\n"
        "MAC address\n"
        "VNI keyword\n"

--- a/doc/vnc.texi
+++ b/doc/vnc.texi
@@ -726,7 +726,7 @@ provided to other protocols, either via zebra or directly to BGP.
 It is important to note that when exporting routes to other protocols,
 the downstream protocol must also be configured to import the routes.
 For example, when VNC routes are exported to unicast BGP, the BGP
-configuration must include a corresponding @code{redistribute vpn}
+configuration must include a corresponding @code{redistribute vnc-direct}
 statement.
 
 @deffn {VNC} {export bgp|zebra mode none|group-nve|registering-nve|ce}
@@ -1115,7 +1115,7 @@ The configuration for @code{VNC-GW 1} is shown below.
 router bgp 64512
  bgp router-id 192.168.1.101
  bgp cluster-id 1.2.3.4
- redistribute vpn
+ redistribute vnc-direct
  neighbor 192.168.1.102 remote-as 64512
  no neighbor 192.168.1.102 activate
  neighbor 192.168.1.103 remote-as 64512

--- a/lib/command.c
+++ b/lib/command.c
@@ -1066,6 +1066,7 @@ cmd_ipv6_prefix_match (const char *str)
   const char *delim = "/\0";
   char *dupe, *prefix, *mask, *context, *endptr;
   int nmask = -1;
+  enum match_type ret;
 
   if (str == NULL)
     return partly_match;
@@ -1079,21 +1080,26 @@ cmd_ipv6_prefix_match (const char *str)
   prefix = strtok_r(dupe, delim, &context);
   mask   = strtok_r(NULL, delim, &context);
 
+  ret = exact_match;
   if (!mask)
-    return partly_match;
-
-  /* validate prefix */
-  if (inet_pton(AF_INET6, prefix, &sin6_dummy.sin6_addr) != 1)
-    return no_match;
-
-  /* validate mask */
-  nmask = strtol (mask, &endptr, 10);
-  if (*endptr != '\0' || nmask < 0 || nmask > 128)
-    return no_match;
+    ret = partly_match;
+  else
+    {
+      /* validate prefix */
+      if (inet_pton(AF_INET6, prefix, &sin6_dummy.sin6_addr) != 1)
+        ret = no_match;
+      else
+        {
+          /* validate mask */
+          nmask = strtol (mask, &endptr, 10);
+          if (*endptr != '\0' || nmask < 0 || nmask > 128)
+            ret = no_match;
+        }
+    }
 
   XFREE(MTYPE_TMP, dupe);
 
-  return exact_match;
+  return ret;
 }
 
 #endif /* HAVE_IPV6  */

--- a/lib/log.c
+++ b/lib/log.c
@@ -1077,10 +1077,10 @@ proto_redistnum(int afi, const char *s)
 	return ZEBRA_ROUTE_BGP;
       else if (strncmp (s, "ta", 2) == 0)
 	return ZEBRA_ROUTE_TABLE;
-      else if (strncmp (s, "v", 1) == 0)
-	return ZEBRA_ROUTE_VNC;
-      else if (strncmp (s, "vd", 1) == 0)
+      else if (strcmp (s, "vnc-direct") == 0)
 	return ZEBRA_ROUTE_VNC_DIRECT;
+      else if (strcmp (s, "vnc") == 0)
+	return ZEBRA_ROUTE_VNC;
     }
   if (afi == AFI_IP6)
     {
@@ -1100,10 +1100,10 @@ proto_redistnum(int afi, const char *s)
 	return ZEBRA_ROUTE_BGP;
       else if (strncmp (s, "ta", 2) == 0)
 	return ZEBRA_ROUTE_TABLE;
-      else if (strncmp (s, "v", 1) == 0)
-	return ZEBRA_ROUTE_VNC;
-      else if (strncmp (s, "vd", 1) == 0)
+      else if (strcmp (s, "vnc-direct") == 0)
 	return ZEBRA_ROUTE_VNC_DIRECT;
+      else if (strcmp (s, "vnc") == 0)
+	return ZEBRA_ROUTE_VNC;
     }
   return -1;
 }

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -665,7 +665,7 @@ str2prefix_ipv6 (const char *str, struct prefix_ipv6 *p)
       strncpy (cp, str, pnt - str);
       *(cp + (pnt - str)) = '\0';
       ret = inet_pton (AF_INET6, cp, &p->prefix);
-      free (cp);
+      XFREE (MTYPE_TMP, cp);
       if (ret == 0)
 	return 0;
       plen = (u_char) atoi (++pnt);

--- a/lib/route_types.pl
+++ b/lib/route_types.pl
@@ -56,7 +56,7 @@ while (<STDIN>) {
 
 	# else: 7-field line
 	my @f = split(/,/, $_);
-	unless (@f == 7) {
+	unless (@f == 7 || @f == 8) {
 		die "invalid input on route_types line $.\n";
 	}
 
@@ -73,6 +73,7 @@ while (<STDIN>) {
 		"ipv4" => int($f[4]),
 		"ipv6" => int($f[5]),
 		"shorthelp" => $f[6],
+		"restrict2" => $f[7],
 	};
 	push @protos, $proto;
 	$daemons{$f[2]} = {
@@ -137,6 +138,8 @@ sub collect {
 	my (@names, @help) = ((), ());
 	for my $p (@protos) {
 		next if ($protodetail{$p}->{"daemon"} eq $daemon && $daemon ne "zebra");
+		next if ($protodetail{$p}->{"restrict2"} ne "" && 
+		         $protodetail{$p}->{"restrict2"} ne $daemon);
 		next unless (($ipv4 && $protodetail{$p}->{"ipv4"})
 				|| ($ipv6 && $protodetail{$p}->{"ipv6"}));
 		push @names, $protodetail{$p}->{"cname"};

--- a/lib/route_types.txt
+++ b/lib/route_types.txt
@@ -64,9 +64,9 @@ ZEBRA_ROUTE_LDP,        ldp,       ldpd,   'L', 0, 0, "LDP"
 #vnc when sent to zebra 
 ZEBRA_ROUTE_VNC,        vnc,       NULL,   'v', 1, 1, "VNC"
 # vnc when sent to bgp
-ZEBRA_ROUTE_VNC_DIRECT, vpn,       NULL,   'V', 1, 1, "VPN"
-# vnc when sent to bgp (remote next hop?)
-ZEBRA_ROUTE_VNC_DIRECT_RH, vpn-rh, NULL,   'V', 0, 0, "VPN"
+ZEBRA_ROUTE_VNC_DIRECT, vnc-direct,NULL,   'V', 1, 1, "VNC-Direct", bgpd
+# vnc when sent to bgp (resolve NVE mode)
+ZEBRA_ROUTE_VNC_DIRECT_RH, vnc-rn, NULL,   'V', 0, 0, "VNC-RN"
 #  bgp unicast -> vnc 
 ZEBRA_ROUTE_BGP_DIRECT, bgp-direct, NULL,  'b', 0, 0, "BGP-Direct"
 #  bgp unicast -> vnc 
@@ -90,4 +90,4 @@ ZEBRA_ROUTE_VNC,    "Virtual Network Control (VNC)"
 ZEBRA_ROUTE_OLSR,   "Optimised Link State Routing (OLSR)"
 ZEBRA_ROUTE_TABLE,  "Non-main Kernel Routing Table"
 ZEBRA_ROUTE_LDP,    "Label Distribution Protocol (LDP)"
-ZEBRA_ROUTE_VNC_DIRECT,    "VPN routes(VPN)"
+ZEBRA_ROUTE_VNC_DIRECT,    "VNC direct (not via zebra) routes"


### PR DESCRIPTION
This patch set includes changes resulting from initial regression runs with stable/2.0
Issues found include:
valgrind reported memory loss (this set doesn't fix them all)
missing vpn&encap commands (see #14)
some RFAPI/VNC patches were missing
- fix for issue reported in #9 
- Other changes made in November

Includes changes requested by @donaldsharp and @eqvinox 