### PR TITLE
ospf6d: resolve problem with area range lsid creation

### DIFF
--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -424,12 +424,9 @@ ospf6_abr_originate_summary_to_area (struct ospf6_route *route,
       else
 	{
 	  summary->path.origin.type = htons (OSPF6_LSTYPE_INTER_PREFIX);
-	  if (route->type == OSPF6_DEST_TYPE_RANGE)
-	    summary->path.origin.id  = route->linkstate_id;
-	  else
-	    summary->path.origin.id =
-	      ospf6_new_ls_id (summary->path.origin.type,
-			       summary->path.origin.adv_router, area->lsdb);
+	  summary->path.origin.id =
+	    ospf6_new_ls_id (summary->path.origin.type,
+			     summary->path.origin.adv_router, area->lsdb);
 	}
       summary = ospf6_route_add (summary, summary_table);
     }

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -465,8 +465,6 @@ DEFUN (area_range,
       range->prefix = prefix;
       range->path.area_id = oa->area_id;
       range->path.cost = OSPF_AREA_RANGE_COST_UNSPEC;
-      range->linkstate_id =
-	(u_int32_t) htonl(ospf6_new_range_ls_id (oa->range_table));
     }
 
   if (argc > 2)
@@ -577,8 +575,6 @@ DEFUN (no_area_range,
       /* purge the old aggregated summary LSA */
       ospf6_abr_originate_summary(range);
     }
-  ospf6_release_range_ls_id(oa->range_table,
-			    (u_int32_t) ntohl(range->linkstate_id));
   ospf6_route_remove (range, oa->range_table);
 
   return CMD_SUCCESS;

--- a/ospf6d/ospf6_lsdb.c
+++ b/ospf6d/ospf6_lsdb.c
@@ -547,24 +547,6 @@ ospf6_lsdb_show (struct vty *vty, enum ospf_lsdb_show_level level,
     }
 }
 
-/* Decide new Link State ID to originate for the range. */
-u_int32_t
-ospf6_new_range_ls_id (struct ospf6_route_table *range_table)
-{
-  u_int32_t id;
-
-  bf_assign_index(range_table->idspace, id);
-  return (id);
-}
-
-/* Release the LS ID back to the ID pool */
-void
-ospf6_release_range_ls_id (struct ospf6_route_table *range_table,
-			   u_int32_t id)
-{
-  bf_release_index(range_table->idspace, id);
-}
-
 u_int32_t
 ospf6_new_ls_id (u_int16_t type, u_int32_t adv_router,
                  struct ospf6_lsdb *lsdb)

--- a/ospf6d/ospf6_lsdb.h
+++ b/ospf6d/ospf6_lsdb.h
@@ -81,9 +81,6 @@ extern void ospf6_lsdb_show (struct vty *vty,
 
 extern u_int32_t ospf6_new_ls_id (u_int16_t type, u_int32_t adv_router,
                                   struct ospf6_lsdb *lsdb);
-extern u_int32_t ospf6_new_range_ls_id (struct ospf6_route_table *range_table);
-extern void ospf6_release_range_ls_id (struct ospf6_route_table *range_table,
-				       u_int32_t id);
 extern u_int32_t ospf6_new_ls_seqnum (u_int16_t type, u_int32_t id,
                                       u_int32_t adv_router,
                                       struct ospf6_lsdb *lsdb);


### PR DESCRIPTION
The problem reported was that routers downstream from the ABR would have
prefixes in the IPv6 rib that should have been summarized.  Testing showed
that the prefixes were absent in the lsdb but not removed from the rib.

The problem (and others) stemmed from determining the link-state id to use
for the area-range statement only from other entries in the range-table. Since
the area range statement creates inter-prefix LSAs (summaries) which are in all
aspects identical to other inter-prefix LSAs, the number space for the lsid
needs to be unique across all inter-prefix LSAs, not just unique between area
range statements.  This fix removes the use of range-table specific lsids and
acquires the lsid just as any other inter-prefix LSA.

Ticket: CM-13626
Signed-off-by: Don Slice
Reviewed By: CCR-5489
Testing Done: Manual testing, repeated runs of the test that previously failed,
ospf-smoke