### PR TITLE
Graceful Restart Route Preservation 

### DIFF
--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -1537,7 +1537,10 @@ bgp_open_capability (struct stream *s, struct peer *peer)
             {
               stream_putw (s, afi);
               stream_putc (s, (safi == SAFI_MPLS_VPN) ? SAFI_MPLS_LABELED_VPN : safi);
-              stream_putc (s, 0); //Forwarding is not retained as of now.
+              if (bgp_flag_check(peer->bgp, BGP_FLAG_GR_PRESERVE_FWD))
+                stream_putc (s, RESTART_F_BIT);
+              else
+                stream_putc (s, 0);
             }
     }
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -1673,6 +1673,31 @@ DEFUN (no_bgp_graceful_restart_restart_time,
   return CMD_SUCCESS;
 }
 
+DEFUN (bgp_graceful_restart_preserve_fw,
+       bgp_graceful_restart_preserve_fw_cmd,
+       "bgp graceful-restart preserve-fw-state",
+       "BGP specific commands\n"
+       "Graceful restart capability parameters\n"
+       "Sets F-bit indication that fib is preserved while doing Graceful Restart\n")
+{
+  VTY_DECLVAR_CONTEXT(bgp, bgp);
+  bgp_flag_set(bgp, BGP_FLAG_GR_PRESERVE_FWD);
+  return CMD_SUCCESS;
+}
+
+DEFUN (no_bgp_graceful_restart_preserve_fw,
+       no_bgp_graceful_restart_preserve_fw_cmd,
+       "no bgp graceful-restart preserve-fw-state",
+       NO_STR
+       "BGP specific commands\n"
+       "Graceful restart capability parameters\n"
+       "Unsets F-bit indication that fib is preserved while doing Graceful Restart\n")
+{
+  VTY_DECLVAR_CONTEXT(bgp, bgp);
+  bgp_flag_unset(bgp, BGP_FLAG_GR_PRESERVE_FWD);
+  return CMD_SUCCESS;
+}
+
 /* "bgp fast-external-failover" configuration. */
 DEFUN (bgp_fast_external_failover,
        bgp_fast_external_failover_cmd,
@@ -9852,6 +9877,9 @@ bgp_vty_init (void)
   install_element (BGP_NODE, &bgp_graceful_restart_restart_time_cmd);
   install_element (BGP_NODE, &no_bgp_graceful_restart_restart_time_cmd);
 
+  install_element (BGP_NODE, &bgp_graceful_restart_preserve_fw_cmd);
+  install_element (BGP_NODE, &no_bgp_graceful_restart_preserve_fw_cmd);
+ 
   /* "bgp fast-external-failover" commands */
   install_element (BGP_NODE, &bgp_fast_external_failover_cmd);
   install_element (BGP_NODE, &no_bgp_fast_external_failover_cmd);

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7371,6 +7371,10 @@ bgp_config_write (struct vty *vty)
       if (bgp_flag_check (bgp, BGP_FLAG_GRACEFUL_RESTART))
        vty_out (vty, " bgp graceful-restart%s", VTY_NEWLINE);
 
+      /* BGP graceful-restart Preserve State F bit. */
+      if (bgp_flag_check (bgp, BGP_FLAG_GR_PRESERVE_FWD))
+       vty_out (vty, " bgp graceful-restart preserve-fw-state%s", VTY_NEWLINE);
+
       /* BGP bestpath method. */
       if (bgp_flag_check (bgp, BGP_FLAG_ASPATH_IGNORE))
 	vty_out (vty, " bgp bestpath as-path ignore%s", VTY_NEWLINE);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -289,6 +289,7 @@ struct bgp
 #define BGP_FLAG_MULTIPATH_RELAX_AS_SET   (1 << 17)
 #define BGP_FLAG_FORCE_STATIC_PROCESS     (1 << 18)
 #define BGP_FLAG_SHOW_HOSTNAME            (1 << 19)
+#define BGP_FLAG_GR_PRESERVE_FWD          (1 << 20)
 
   /* BGP Per AF flags */
   u_int16_t af_flags[AFI_MAX][SAFI_MAX];


### PR DESCRIPTION
Hi,

This series of 2 patches gives an API to configure BGP so that the F bit of BGP Open message in graceful restart capability is set. 
This applies to all enabled addresses families present on the BGP instance.
Cheers,

Philippe
