### PR TITLE
Atol borked

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -3237,12 +3237,13 @@ DEFUN (neighbor_local_as,
 {
   struct peer *peer;
   int ret;
-
+  as_t as;
   peer = peer_and_group_lookup_vty (vty, argv[0]);
   if (! peer)
     return CMD_WARNING;
 
-  ret = peer_local_as_set (peer, atoi (argv[1]), 0, 0);
+  VTY_GET_INTEGER_RANGE ("Local AS", as, argv[1], 1, BGP_AS4_MAX);
+  ret = peer_local_as_set (peer, as, 0, 0);
   return bgp_vty_return (vty, ret);
 }
 
@@ -3257,12 +3258,14 @@ DEFUN (neighbor_local_as_no_prepend,
 {
   struct peer *peer;
   int ret;
+  as_t as;
 
   peer = peer_and_group_lookup_vty (vty, argv[0]);
   if (! peer)
     return CMD_WARNING;
 
-  ret = peer_local_as_set (peer, atoi (argv[1]), 1, 0);
+  VTY_GET_INTEGER_RANGE ("Local AS", as, argv[1], 1, BGP_AS4_MAX);
+  ret = peer_local_as_set (peer, as, 1, 0);
   return bgp_vty_return (vty, ret);
 }
 
@@ -3278,12 +3281,14 @@ DEFUN (neighbor_local_as_no_prepend_replace_as,
 {
   struct peer *peer;
   int ret;
+  as_t as;
 
   peer = peer_and_group_lookup_vty (vty, argv[0]);
   if (! peer)
     return CMD_WARNING;
 
-  ret = peer_local_as_set (peer, atoi (argv[1]), 1, 1);
+  VTY_GET_INTEGER_RANGE ("Local AS", as, argv[1], 1, BGP_AS4_MAX);
+  ret = peer_local_as_set (peer, as, 1, 1);
   return bgp_vty_return (vty, ret);
 }
 

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -104,7 +104,7 @@ zebra_static_ipv4 (struct vty *vty, safi_t safi, int add_cmd,
 
   /* tag */
   if (tag_str)
-    tag = atol(tag_str);
+    VTY_GET_INTEGER_RANGE("tag", tag, tag_str, 0, 4294967295);
 
   /* VRF id */
   zvrf = zebra_vrf_lookup_by_name (vrf_id_str);
@@ -2707,11 +2707,11 @@ DEFUN (show_ip_route_tag,
 
   if (argc > 1)
     {
-      tag = atol(argv[1]);
+      VTY_GET_INTEGER_RANGE("tag", tag, argv[1], 0, 4294967295);
       VRF_GET_ID (vrf_id, argv[0]);
     }
   else
-    tag = atol(argv[0]);
+    VTY_GET_INTEGER_RANGE("tag", tag, argv[0], 0, 4294967295);
 
   table = zebra_vrf_table (AFI_IP, SAFI_UNICAST, vrf_id);
   if (! table)
@@ -3341,7 +3341,7 @@ DEFUN (show_ip_route_vrf_all_tag,
   route_tag_t tag = 0;
 
   if (argv[0])
-    tag = atol(argv[0]);
+    VTY_GET_INTEGER_RANGE("tag", tag, argv[0], 0, 4294967295);
 
   RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
     {
@@ -3777,7 +3777,7 @@ static_ipv6_func (struct vty *vty, int add_cmd, const char *dest_str,
 
   /* tag */
   if (tag_str)
-    tag = atol(tag_str);
+    VTY_GET_INTEGER_RANGE("tag", tag, tag_str, 0, 4294967295);
 
   /* When gateway is valid IPv6 addrees, then gate is treated as
      nexthop address other case gate is treated as interface name. */
@@ -5026,10 +5026,10 @@ DEFUN (show_ipv6_route_tag,
   if (argc > 1)
     {
       VRF_GET_ID (vrf_id, argv[0]);
-      tag = atol(argv[1]);
+      VTY_GET_INTEGER_RANGE("tag", tag, argv[1], 0, 4294967295);
     }
   else
-    tag = atol(argv[0]);
+    VTY_GET_INTEGER_RANGE("tag", tag, argv[0], 0, 4294967295);
 
   table = zebra_vrf_table (AFI_IP6, SAFI_UNICAST, vrf_id);
   if (! table)
@@ -5469,7 +5469,7 @@ DEFUN (show_ipv6_route_vrf_all_tag,
   route_tag_t tag = 0;
 
   if (argv[0])
-    tag = atol(argv[0]);
+    VTY_GET_INTEGER_RANGE("tag", tag, argv[0], 0, 4294967295);
 
   RB_FOREACH (vrf, vrf_name_head, &vrfs_by_name)
     {


### PR DESCRIPTION
On arm platforms when using atoi or atol to read in numbers specified on the cli that are > 2billion they will not be read in correctly.  This fixes that issue for these 2 commands:
ip route ..... tag <value>
neighbor ..... local-as <value>