### PR TITLE
Working/master/afi safi vty/a

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8804,37 +8804,18 @@ bgp_table_stats_vty (struct vty *vty, const char *name,
       vty_out (vty, "%% No such BGP instance exist%s", VTY_NEWLINE);
       return CMD_WARNING;
     }
-  if (strncmp (afi_str, "ipv", 3) == 0)
-    {
-      if (strncmp (afi_str, "ipv4", 4) == 0)
-        afi = AFI_IP;
-      else if (strncmp (afi_str, "ipv6", 4) == 0)
-        afi = AFI_IP6;
-      else
-        {
-          vty_out (vty, "%% Invalid address family %s%s",
-                   afi_str, VTY_NEWLINE);
-          return CMD_WARNING;
-        }
-      if (strncmp (safi_str, "m", 1) == 0)
-        safi = SAFI_MULTICAST;
-      else if (strncmp (safi_str, "u", 1) == 0)
-        safi = SAFI_UNICAST;
-      else if (strncmp (safi_str, "e", 1) == 0)
-        safi = SAFI_ENCAP;
-      else if (strncmp (safi_str, "vpnv4", 5) == 0 || strncmp (safi_str, "vpnv6", 5) == 0)
-        safi = SAFI_MPLS_VPN;
-      else
-        {
-          vty_out (vty, "%% Invalid subsequent address family %s%s",
-                   safi_str, VTY_NEWLINE);
-            return CMD_WARNING;
-      }
-    }
-  else
+  afi  = bgp_vty_afi_from_arg(afi_str);
+  if (afi == AFI_MAX)
     {
       vty_out (vty, "%% Invalid address family \"%s\"%s",
                afi_str, VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  safi = bgp_vty_safi_from_arg(safi_str);
+  if (safi == SAFI_MAX)
+    {
+      vty_out (vty, "%% Invalid subsequent address family %s%s",
+               safi_str, VTY_NEWLINE);
       return CMD_WARNING;
     }
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -8700,22 +8700,13 @@ bgp_show_update_groups(struct vty *vty, const char *name,
 
 DEFUN (show_ip_bgp_updgrps,
        show_ip_bgp_updgrps_cmd,
-       "show [ip] bgp [<view|vrf> WORD] [<ipv4 ["BGP_SAFI_CMD_STR"]|ipv6 ["BGP_SAFI_CMD_STR"]|encap [unicast]|vpnv4 [unicast]>] update-groups [SUBGROUP-ID]",
+       "show [ip] bgp [<view|vrf> WORD] ["BGP_AFI_CMD_STR" ["BGP_SAFI_CMD_STR"]] update-groups [SUBGROUP-ID]",
        SHOW_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
-       "Address Family\n"
+       BGP_AFI_HELP_STR
        BGP_SAFI_HELP_STR
-       "Address Family\n"
-       BGP_SAFI_HELP_STR
-       "Address Family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
-       "Address Family\n"
-       "Address Family modifier\n"
        "Detailed info about dynamic update groups\n"
        "Specific subgroup to display detailed info for\n")
 {
@@ -8732,20 +8723,11 @@ DEFUN (show_ip_bgp_updgrps,
   /* [<view|vrf> WORD] */
   if (argv_find (argv, argc, "view", &idx) || argv_find (argv, argc, "vrf", &idx))
     vrf = argv[++idx]->arg;
-  /* [<ipv4 ["BGP_SAFI_CMD_STR"]|ipv6 ["BGP_SAFI_CMD_STR"]|encap [unicast]|vpnv4 [unicast]>] */
-  if (argv_find (argv, argc, "ipv4", &idx) || argv_find (argv, argc, "ipv6", &idx))
-  {
-    afi = strmatch(argv[idx]->text, "ipv6") ? AFI_IP6 : AFI_IP;
-    if (argv_find (argv, argc, "unicast", &idx) || argv_find (argv, argc, "multicast", &idx))
-      safi = bgp_vty_safi_from_arg (argv[idx]->text);
-  }
-  else if (argv_find (argv, argc, "encap", &idx) || argv_find (argv, argc, "vpnv4", &idx))
-  {
-    afi = AFI_IP;
-    safi = bgp_vty_safi_from_arg (argv[idx]->text);
-    // advance idx if necessary
-    argv_find (argv, argc, "unicast", &idx);
-  }
+  /* ["BGP_AFI_CMD_STR" ["BGP_SAFI_CMD_STR"]] */
+  if (argv_find_and_parse_afi (argv, argc, &idx, &afi))
+    {
+      argv_find_and_parse_safi (argv, argc, &idx, &safi);
+    }
 
   /* get subgroup id, if provided */
   idx = argc - 1;

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -39,6 +39,7 @@ struct bgp;
 
 extern void bgp_vty_init (void);
 extern const char *afi_safi_print (afi_t, safi_t);
+extern const char *afi_safi_json (afi_t, safi_t);
 extern int bgp_config_write_update_delay (struct vty *, struct bgp *);
 extern int bgp_config_write_wpkt_quanta(struct vty *vty, struct bgp *bgp);
 extern int bgp_config_write_listen(struct vty *vty, struct bgp *bgp);

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -26,12 +26,16 @@ struct bgp;
 #define BGP_INSTANCE_HELP_STR "BGP view\nBGP VRF\nView/VRF name\n"
 #define BGP_INSTANCE_ALL_HELP_STR "BGP view\nBGP VRF\nAll Views/VRFs\n"
 
-#define AFI_SAFI_STR \
-  "Address family\n" \
-  "Address Family modifier\n" \
-  "Address Family modifier\n" \
-  "Address Family modifier\n" \
+#define BGP_AFI_CMD_STR         "<ipv4|ipv6>"
+#define BGP_AFI_HELP_STR        "Address Family\nAddress Family\n"
+#define BGP_SAFI_CMD_STR        "<unicast|multicast|vpn|encap>"
+#define BGP_SAFI_HELP_STR       \
+  "Address Family modifier\n"   \
+  "Address Family modifier\n"   \
+  "Address Family modifier\n"   \
   "Address Family modifier\n"
+#define BGP_AFI_SAFI_CMD_STR    BGP_AFI_CMD_STR" "BGP_SAFI_CMD_STR
+#define BGP_AFI_SAFI_HELP_STR   BGP_AFI_HELP_STR BGP_SAFI_HELP_STR
 
 extern void bgp_vty_init (void);
 extern const char *afi_safi_print (afi_t, safi_t);
@@ -49,7 +53,16 @@ bgp_parse_afi(const char *str, afi_t *afi);
 extern int
 bgp_parse_safi(const char *str, safi_t *safi);
 
+extern afi_t
+bgp_vty_afi_from_arg(const char *afi_str);
+
 extern safi_t
 bgp_vty_safi_from_arg(const char *safi_str);
+
+extern int
+argv_find_and_parse_afi(struct cmd_token **argv, int argc, int *index, afi_t *afi);
+
+extern int
+argv_find_and_parse_safi(struct cmd_token **argv, int argc, int *index, safi_t *safi);
 
 #endif /* _QUAGGA_BGP_VTY_H */


### PR DESCRIPTION
Some Issue 14 related cleanup:
    bgpd: fixup safi as afi confusion in show update-groups
    bgpd: restore wildcard handling in show summary (Issue#14)
    bgpd: restore some missing afi/safi commands (Issue #14)
          Added defines and parse utility functions
          Fix vty code that treated vpn&encap as AFIs
          and some other related vty printing/handline issues
