### PR TITLE
Monotonic

### DIFF
--- a/bgpd/bgp_dump.c
+++ b/bgpd/bgp_dump.c
@@ -364,11 +364,7 @@ bgp_dump_route_node_record (int afi, struct bgp_node *rn,
     stream_putw (obuf, info->peer->table_dump_index);
 
     /* Originated */
-#ifdef HAVE_CLOCK_MONOTONIC
     stream_putl (obuf, time(NULL) - (bgp_clock() - info->uptime));
-#else
-    stream_putl (obuf, info->uptime);
-#endif /* HAVE_CLOCK_MONOTONIC */
 
     /* Dump attribute. */
     /* Skip prefix & AFI/SAFI for MP_NLRI */

--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -450,12 +450,8 @@ bgp_show_nexthops (struct vty *vty, struct bgp *bgp, int detail)
 		  if (CHECK_FLAG(bnc->flags, BGP_NEXTHOP_CONNECTED))
 		    vty_out (vty, "  Must be Connected%s", VTY_NEWLINE);
 		}
-#ifdef HAVE_CLOCK_MONOTONIC
 	      tbuf = time(NULL) - (bgp_clock() - bnc->last_update);
 	      vty_out (vty, "  Last update: %s", ctime(&tbuf));
-#else
-	      vty_out (vty, "  Last update: %s", ctime(&bnc->uptime));
-#endif /* HAVE_CLOCK_MONOTONIC */
 	      vty_out(vty, "%s", VTY_NEWLINE);
 	    }
 	}

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6537,9 +6537,7 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
   char buf1[BUFSIZ];
   struct attr *attr;
   int sockunion_vty_out (struct vty *, union sockunion *);
-#ifdef HAVE_CLOCK_MONOTONIC
   time_t tbuf;
-#endif
   json_object *json_bestpath = NULL;
   json_object *json_cluster_list = NULL;
   json_object *json_cluster_list_list = NULL;
@@ -7164,7 +7162,6 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
         }
 
       /* Line 8 display Uptime */
-#ifdef HAVE_CLOCK_MONOTONIC
       tbuf = time(NULL) - (bgp_clock() - binfo->uptime);
       if (json_paths)
         {
@@ -7175,17 +7172,6 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
         }
       else
         vty_out (vty, "      Last update: %s", ctime(&tbuf));
-#else
-      if (json_paths)
-        {
-          json_last_update = json_object_new_object();
-          json_object_int_add(json_last_update, "epoch", tbuf);
-          json_object_string_add(json_last_update, "string", ctime(&binfo->uptime));
-          json_object_object_add(json_path, "lastUpdate", json_last_update);
-        }
-      else
-        vty_out (vty, "      Last update: %s", ctime(&binfo->uptime));
-#endif /* HAVE_CLOCK_MONOTONIC */
     }
 
   /* We've constructed the json object for this path, add it to the json

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1458,13 +1458,9 @@ peer_group_af_configured (struct peer_group *group)
 static inline char *
 timestamp_string (time_t ts)
 {
-#ifdef HAVE_CLOCK_MONOTONIC
   time_t tbuf;
   tbuf = time(NULL) - (bgp_clock() - ts);
   return ctime(&tbuf);
-#else
-  return ctime(&ts);
-#endif /* HAVE_CLOCK_MONOTONIC */
 }
 
 static inline int

--- a/pimd/pim_main.c
+++ b/pimd/pim_main.c
@@ -272,12 +272,6 @@ int main(int argc, char** argv, char** envp) {
   zlog_notice("PIM_UNEXPECTED_KERNEL_UPCALL: report unexpected kernel upcall");
 #endif
 
-#ifdef HAVE_CLOCK_MONOTONIC
-  zlog_notice("HAVE_CLOCK_MONOTONIC");
-#else
-  zlog_notice("!HAVE_CLOCK_MONOTONIC");
-#endif
-
   while (thread_fetch(master, &thread))
     thread_call(&thread);
 


### PR DESCRIPTION
The HAVE_CLOCK_MONOTONIC #define prevents builds from happening in thread.c, both pimd and bgpd have code that doesn't need it.  Remove the dead code, since we require a MONOTONIC clock