### PR TITLE
VPNv6 improvements

### DIFF
--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -113,7 +113,6 @@ bgp_info_nexthop_cmp (struct bgp_info *bi1, struct bgp_info *bi2)
   ae2 = bi2->attr->extra;
 
   compare = IPV4_ADDR_CMP (&bi1->attr->nexthop, &bi2->attr->nexthop);
-
   if (!compare && ae1 && ae2)
     {
       if (ae1->mp_nexthop_len == ae2->mp_nexthop_len)
@@ -127,6 +126,7 @@ bgp_info_nexthop_cmp (struct bgp_info *bi1, struct bgp_info *bi2)
               break;
 #ifdef HAVE_IPV6
             case BGP_ATTR_NHLEN_IPV6_GLOBAL:
+            case BGP_ATTR_NHLEN_VPNV6_GLOBAL:
               compare = IPV6_ADDR_CMP (&ae1->mp_nexthop_global,
                                        &ae2->mp_nexthop_global);
               break;

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -520,7 +520,7 @@ DEFUN (no_vpnv4_network,
 
 DEFUN (vpnv6_network,
        vpnv6_network_cmd,
-       "network X:X::X:X/M rd ASN:nn_or_IP-address:nn tag WORD",
+       "network X:X::X:X/M rd ASN:nn_or_IP-address:nn tag WORD [route-map WORD]",
        "Specify a network to announce via BGP\n"
        "IPv6 prefix <network>/<length>, e.g., 3ffe::/16\n"
        "Specify Route Distinguisher\n"
@@ -531,26 +531,11 @@ DEFUN (vpnv6_network,
   int idx_ipv6_prefix = 1;
   int idx_ext_community = 3;
   int idx_word = 5;
-  return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, NULL);
-}
-
-DEFUN (vpnv6_network_route_map,
-       vpnv6_network_route_map_cmd,
-       "network X:X::X:X/M rd ASN:nn_or_IP-address:nn tag WORD route-map WORD",
-       "Specify a network to announce via BGP\n"
-       "IPv6 prefix <network>/<length>, e.g., 3ffe::/16\n"
-       "Specify Route Distinguisher\n"
-       "VPN Route Distinguisher\n"
-       "BGP tag\n"
-       "tag value\n"
-       "route map\n"
-       "route map name\n")
-{
-  int idx_ipv6_prefix = 1;
-  int idx_ext_community = 3;
-  int idx_word = 5;
   int idx_word_2 = 7;
-  return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, argv[idx_word_2]->arg);
+  if (argv[idx_word_2])
+    return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, argv[idx_word_2]->arg);
+  else
+    return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, NULL);
 }
 
 /* For testing purpose, static route of MPLS-VPN. */
@@ -1395,7 +1380,6 @@ bgp_mplsvpn_init (void)
   install_element (BGP_VPNV4_NODE, &no_vpnv4_network_cmd);
 
   install_element (BGP_VPNV6_NODE, &vpnv6_network_cmd);
-  install_element (BGP_VPNV6_NODE, &vpnv6_network_route_map_cmd);
   install_element (BGP_VPNV6_NODE, &no_vpnv6_network_cmd);
 
   install_element (VIEW_NODE, &show_bgp_ip_vpn_rd_cmd);

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -494,6 +494,59 @@ DEFUN (no_vpnv4_network,
   return bgp_static_unset_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv4_prefixlen]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg);
 }
 
+DEFUN (vpnv6_network,
+       vpnv6_network_cmd,
+       "network X:X::X:X/M rd ASN:nn_or_IP-address:nn tag WORD",
+       "Specify a network to announce via BGP\n"
+       "IPv6 prefix <network>/<length>, e.g., 3ffe::/16\n"
+       "Specify Route Distinguisher\n"
+       "VPN Route Distinguisher\n"
+       "BGP tag\n"
+       "tag value\n")
+{
+  int idx_ipv6_prefix = 1;
+  int idx_ext_community = 3;
+  int idx_word = 5;
+  return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, NULL);
+}
+
+DEFUN (vpnv6_network_route_map,
+       vpnv6_network_route_map_cmd,
+       "network X:X::X:X/M rd ASN:nn_or_IP-address:nn tag WORD route-map WORD",
+       "Specify a network to announce via BGP\n"
+       "IPv6 prefix <network>/<length>, e.g., 3ffe::/16\n"
+       "Specify Route Distinguisher\n"
+       "VPN Route Distinguisher\n"
+       "BGP tag\n"
+       "tag value\n"
+       "route map\n"
+       "route map name\n")
+{
+  int idx_ipv6_prefix = 1;
+  int idx_ext_community = 3;
+  int idx_word = 5;
+  int idx_word_2 = 7;
+  return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, argv[idx_word_2]->arg);
+}
+
+/* For testing purpose, static route of MPLS-VPN. */
+DEFUN (no_vpnv6_network,
+       no_vpnv6_network_cmd,
+       "no network X:X::X:X/M rd ASN:nn_or_IP-address:nn tag WORD",
+       NO_STR
+       "Specify a network to announce via BGP\n"
+       "IPv6 prefix <network>/<length>, e.g., 3ffe::/16\n"
+       "Specify Route Distinguisher\n"
+       "VPN Route Distinguisher\n"
+       "BGP tag\n"
+       "tag value\n")
+{
+  int idx_ipv6_prefix = 2;
+  int idx_ext_community = 4;
+  int idx_word = 6;
+  return bgp_static_unset_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg);
+}
+
 static int
 show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd, u_char use_json)
 {
@@ -1305,6 +1358,11 @@ bgp_mplsvpn_init (void)
 
   install_element (VIEW_NODE, &show_bgp_ipv4_vpn_cmd);
   install_element (VIEW_NODE, &show_bgp_ipv4_vpn_rd_cmd);
+
+  install_element (BGP_VPNV6_NODE, &vpnv6_network_cmd);
+  install_element (BGP_VPNV6_NODE, &vpnv6_network_route_map_cmd);
+  install_element (BGP_VPNV6_NODE, &no_vpnv6_network_cmd);
+
   install_element (VIEW_NODE, &show_bgp_ipv6_vpn_cmd);
   install_element (VIEW_NODE, &show_bgp_ipv6_vpn_rd_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_cmd);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2320,6 +2320,7 @@ bgp_update_martian_nexthop (struct bgp *bgp, afi_t afi, safi_t safi, struct attr
 #ifdef HAVE_IPV6
         case BGP_ATTR_NHLEN_IPV6_GLOBAL:
         case BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL:
+        case BGP_ATTR_NHLEN_VPNV6_GLOBAL:
           ret = (IN6_IS_ADDR_UNSPECIFIED(&attre->mp_nexthop_global) ||
                  IN6_IS_ADDR_LOOPBACK(&attre->mp_nexthop_global)    ||
                  IN6_IS_ADDR_MULTICAST(&attre->mp_nexthop_global));


### PR DESCRIPTION
Hi all,

This series of 4 commits is fixing an issue related to VPNv6 ECMP feature. 
It also changes the vty regarding network configuration command under bgp vpnv6 address family subnode.
It adds also some show ip bgp vpnv6 commands, in the same manner it has been done for 'show ip bgp vpnv4 commands'. By the way, for the last commit, unless for backward compatibility reasons, I am not sure about the need for keeping this show ip bgp vpnv4 subnode ( may confused), and also vpnv6 subnode.

Testing failed, but I don't see relationship with the commits changed.
make[2]: *** No rule to make target `quagga.pdf'.  Stop.

Thanks,

Philippe