### PR TITLE
Rework time related code

### DIFF
--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -22,6 +22,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 
 #include "prefix.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "buffer.h"
 #include "stream.h"
 #include "command.h"
@@ -348,7 +349,7 @@ time_t bgp_clock (void)
 {
   struct timeval tv;
 
-  quagga_gettime(QUAGGA_CLK_MONOTONIC, &tv);
+  timeutil_gettime(TU_CLK_MONOTONIC, &tv);
   return tv.tv_sec;
 }
 

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -24,6 +24,7 @@
 #include <zebra.h>
 
 #include "thread.h"
+#include "timeutil.h"
 #include "linklist.h"
 #include "vty.h"
 #include "log.h"
@@ -1179,7 +1180,7 @@ isis_run_spf (struct isis_area *area, int level, int family, u_char *sysid)
   unsigned long long start_time, end_time;
 
   /* Get time that can't roll backwards. */
-  quagga_gettime(QUAGGA_CLK_MONOTONIC, &time_now);
+  timeutil_gettime(TU_CLK_MONOTONIC, &time_now);
   start_time = time_now.tv_sec;
   start_time = (start_time * 1000000) + time_now.tv_usec;
 
@@ -1277,7 +1278,7 @@ out:
   spftree->pending = 0;
   spftree->runcount++;
   spftree->last_run_timestamp = time (NULL);
-  quagga_gettime(QUAGGA_CLK_MONOTONIC, &time_now);
+  timeutil_gettime(TU_CLK_MONOTONIC, &time_now);
   end_time = time_now.tv_sec;
   end_time = (end_time * 1000000) + time_now.tv_usec;
   spftree->last_run_duration = end_time - start_time;

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -27,7 +27,8 @@ libzebra_la_SOURCES = \
 	qobj.c \
 	event_counter.c \
 	strlcpy.c \
-	strlcat.c
+	strlcat.c \
+	timeutil.c
 
 BUILT_SOURCES = route_types.h gitversion.h command_parse.h command_lex.h
 
@@ -46,7 +47,8 @@ pkginclude_HEADERS = \
 	ptm_lib.h csv.h bfd.h vrf.h ns.h systemd.h bitfield.h \
 	fifo.h memory_vty.h mpls.h imsg.h openbsd-queue.h openbsd-tree.h \
 	skiplist.h qobj.h \
-	event_counter.h
+	event_counter.h \
+	timeutil.h
 
 noinst_HEADERS = \
 	plist_int.h

--- a/lib/bfd.c
+++ b/lib/bfd.c
@@ -27,6 +27,7 @@
 #include "memory.h"
 #include "prefix.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "stream.h"
 #include "zclient.h"
 #include "table.h"
@@ -368,7 +369,7 @@ bfd_last_update (time_t last_update, char *buf, size_t len)
     }
 
   /* Get current time. */
-  quagga_gettime(QUAGGA_CLK_MONOTONIC, &tv);
+  timeutil_gettime(TU_CLK_MONOTONIC, &tv);
   curr = tv.tv_sec;
   diff = curr - last_update;
   tm = gmtime (&diff);

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -529,7 +529,7 @@ thread_master_free (struct thread_master *m)
 unsigned long
 thread_timer_remain_second (struct thread *thread)
 {
-  relative_time = frr_monotonic (NULL);
+  relative_time = timeutil_monotonic (NULL);
   
   if (thread->u.sands.tv_sec - relative_time.tv_sec > 0)
     return thread->u.sands.tv_sec - relative_time.tv_sec;
@@ -543,7 +543,7 @@ thread_timer_remain_second (struct thread *thread)
 struct timeval
 thread_timer_remain(struct thread *thread)
 {
-  relative_time = frr_monotonic (NULL);
+  relative_time = timeutil_monotonic (NULL);
 
   return timeval_subtract(thread->u.sands, relative_time);
 }
@@ -736,7 +736,7 @@ funcname_thread_add_timer_timeval (struct thread_master *m,
   thread = thread_get (m, type, func, arg, debugargpass);
 
   /* Do we need jitter here? */
-  relative_time = frr_monotonic (NULL);
+  relative_time = timeutil_monotonic (NULL);
   alarm_time.tv_sec = relative_time.tv_sec + time_relative->tv_sec;
   alarm_time.tv_usec = relative_time.tv_usec + time_relative->tv_usec;
   thread->u.sands = timeval_adjust(alarm_time);
@@ -1181,7 +1181,7 @@ thread_fetch (struct thread_master *m, struct thread *fetch)
       /* Calculate select wait timer if nothing else to do */
       if (m->ready.count == 0)
         {
-          relative_time = frr_monotonic (NULL);
+          relative_time = timeutil_monotonic (NULL);
           timer_wait = thread_timer_wait (m->timer, &timer_val);
           timer_wait_bg = thread_timer_wait (m->background, &timer_val_bg);
           
@@ -1204,7 +1204,7 @@ thread_fetch (struct thread_master *m, struct thread *fetch)
       /* Check foreground timers.  Historically, they have had higher
          priority than I/O threads, so let's push them onto the ready
 	 list in front of the I/O threads. */
-      relative_time = frr_monotonic (NULL);
+      relative_time = timeutil_monotonic (NULL);
       thread_timer_process (m->timer, &relative_time);
       
       /* Got IO, process it */
@@ -1250,7 +1250,7 @@ thread_consumed_time (RUSAGE_T *now, RUSAGE_T *start, unsigned long *cputime)
 int
 thread_should_yield (struct thread *thread)
 {
-  relative_time = frr_monotonic (NULL);
+  relative_time = timeutil_monotonic (NULL);
   return (timeval_elapsed(recent_relative_time(), thread->real) >
           thread->yield);
 }
@@ -1264,7 +1264,7 @@ thread_set_yield_time (struct thread *thread, unsigned long yield_time)
 void
 thread_getrusage (RUSAGE_T *r)
 {
-  relative_time = frr_monotonic (NULL);
+  relative_time = timeutil_monotonic (NULL);
   getrusage(RUSAGE_SELF, &(r->cpu));
   r->real = recent_relative_time();
 }

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -124,14 +124,6 @@ struct cpu_thread_history
   const char *funcname;
 };
 
-/* Clocks supported by Quagga */
-enum quagga_clkid {
-  QUAGGA_CLK_MONOTONIC = 1,	/* monotonic, against an indeterminate base */
-};
-
-/* Struct timeval's tv_usec one second value.  */
-#define TIMER_SECOND_MICRO 1000000L
-
 /* Thread types. */
 #define THREAD_READ           0
 #define THREAD_WRITE          1
@@ -238,7 +230,6 @@ extern void thread_call (struct thread *);
 extern unsigned long thread_timer_remain_second (struct thread *);
 extern struct timeval thread_timer_remain(struct thread*);
 extern int thread_should_yield (struct thread *);
-extern unsigned long timeval_elapsed (struct timeval a, struct timeval b);
 /* set yield time for thread */
 extern void thread_set_yield_time (struct thread *, unsigned long);
 
@@ -246,25 +237,14 @@ extern void thread_set_yield_time (struct thread *, unsigned long);
 extern void thread_getrusage (RUSAGE_T *);
 extern void thread_cmd_init (void);
 
-/* replacements for the system gettimeofday(), clock_gettime() and
- * time() functions, providing support for non-decrementing clock on
- * all systems, and fully monotonic on /some/ systems.
- */
-extern int quagga_gettime (enum quagga_clkid, struct timeval *);
-extern time_t quagga_monotime (void);
-
 /* Returns elapsed real (wall clock) time. */
 extern unsigned long thread_consumed_time(RUSAGE_T *after, RUSAGE_T *before,
 					  unsigned long *cpu_time_elapsed);
 
-/* Global variable containing a recent result from gettimeofday.  This can
-   be used instead of calling gettimeofday if a recent value is sufficient.
-   This is guaranteed to be refreshed before a thread is called. */
-extern struct timeval recent_time;
-/* Similar to recent_time, but a monotonically increasing time value */
-extern struct timeval recent_relative_time (void);
-
 /* only for use in logging functions! */
 extern struct thread *thread_current;
+
+/* Recently updated monotonic time */
+extern struct timeval recent_relative_time (void);
 
 #endif /* _ZEBRA_THREAD_H */

--- a/lib/timeutil.c
+++ b/lib/timeutil.c
@@ -27,6 +27,9 @@
  * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
  * 02111-1307, USA.
  */
+#include <zebra.h>
+
+#include <errno.h>
 #include "timeutil.h"
 
 /* XXX:
@@ -152,6 +155,10 @@ timeval_elapsed (struct timeval a, struct timeval b)
 struct timeval
 frr_monotonic (int *status)
 {
+  int stat = 0;
+  if (!status)
+    status = &stat;
+
   struct timeval result = { 0 };
 
 #ifdef HAVE_CLOCK_MONOTONIC
@@ -200,4 +207,10 @@ frr_gettime (enum frr_clkid clkid, struct timeval *tv)
         break;
     }
   return status;
+}
+
+time_t
+frr_monotime ()
+{
+  return frr_monotonic (NULL).tv_sec;
 }

--- a/lib/timeutil.c
+++ b/lib/timeutil.c
@@ -153,7 +153,7 @@ timeval_elapsed (struct timeval a, struct timeval b)
 }
 
 struct timeval
-frr_monotonic (int *status)
+timeutil_monotonic (int *status)
 {
   int stat = 0;
   if (!status)
@@ -190,15 +190,15 @@ frr_monotonic (int *status)
 }
 
 int
-frr_gettime (enum frr_clkid clkid, struct timeval *tv)
+timeutil_gettime (enum timeutil_clkid clkid, struct timeval *tv)
 {
   int status = 0;
   switch (clkid)
     {
-      case FRR_CLK_MONOTONIC:
-        *tv = frr_monotonic (&status);
+      case TU_CLK_MONOTONIC:
+        *tv = timeutil_monotonic (&status);
         break;
-      case FRR_CLK_REALTIME:
+      case TU_CLK_REALTIME:
         status = gettimeofday (tv, NULL);
         break;
       default:
@@ -210,7 +210,7 @@ frr_gettime (enum frr_clkid clkid, struct timeval *tv)
 }
 
 time_t
-frr_monotime ()
+timeutil_monotime ()
 {
-  return frr_monotonic (NULL).tv_sec;
+  return timeutil_monotonic (NULL).tv_sec;
 }

--- a/lib/timeutil.c
+++ b/lib/timeutil.c
@@ -1,0 +1,203 @@
+/*
+ * Utility functions for working with time.
+ *
+ * This module implements:
+ *   - Arithmetic operations on struct timespec and struct timeval
+ *   - Conversion functions between struct timespec and struct timeval
+ *   - Portability wrappers for platform-dependent time calls
+ *
+ * --
+ * Copyright (C) 2017 Cumulus Networks, Inc.
+ * Copyright (C) 1998, 2000, Kunihiro Ishiguro <kunihiro@zebra.org>
+ *
+ * This file is part of Free Range Routing.
+ *
+ * Free Range Routing is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any later
+ * version.
+ *
+ * Free Range Routing is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Free Range Routing; see the file COPYING.  If not, write to the Free
+ * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+#include "timeutil.h"
+
+/* XXX:
+ * MacOS Sierra adds support for clock_gettime() and provides a monotonic
+ * system clock. This platform specific include and associated #ifdef switch
+ * later on in this file can be removed in the future. */
+#if defined(__APPLE__)
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#endif
+
+
+struct timespec
+timeval2timespec (struct timeval tv)
+{
+  struct timespec ts;
+  ts.tv_sec = tv.tv_sec;
+  ts.tv_nsec = tv.tv_usec * 1000;
+  return ts;
+}
+
+struct timeval
+timespec2timeval (struct timespec ts)
+{
+  struct timeval tv;
+  tv.tv_sec = ts.tv_sec;
+  tv.tv_usec = ts.tv_nsec / 1000;
+  return tv;
+}
+
+struct timespec
+timespec_adjust (struct timespec ts)
+{
+  while (ts.tv_nsec >= NANOS_IN_SECOND)
+    {
+      ts.tv_nsec -= NANOS_IN_SECOND;
+      ts.tv_sec++;
+    }
+
+  while (ts.tv_nsec < 0)
+    {
+      ts.tv_nsec += NANOS_IN_SECOND;
+      ts.tv_sec--;
+    }
+
+  if (ts.tv_sec < 0)
+    ts.tv_sec = ts.tv_nsec = 0;
+
+  return ts;
+}
+
+struct timeval
+timeval_adjust (struct timeval tv)
+{
+  while (tv.tv_usec >= MICROS_IN_SECOND)
+    {
+      tv.tv_usec -= MICROS_IN_SECOND;
+      tv.tv_sec++;
+    }
+
+  while (tv.tv_usec < 0)
+    {
+      tv.tv_usec += MICROS_IN_SECOND;
+      tv.tv_sec--;
+    }
+
+  if (tv.tv_sec < 0)
+      tv.tv_sec = tv.tv_usec = 0;
+
+  return tv;
+}
+
+struct timespec
+timespec_subtract (struct timespec a, struct timespec b)
+{
+  struct timespec ret;
+
+  ret.tv_nsec = a.tv_nsec - b.tv_nsec;
+  ret.tv_sec = a.tv_sec - b.tv_sec;
+
+  return timespec_adjust (ret);
+}
+
+struct timeval
+timeval_subtract (struct timeval a, struct timeval b)
+{
+  struct timeval ret;
+
+  ret.tv_usec = a.tv_usec - b.tv_usec;
+  ret.tv_sec = a.tv_sec - b.tv_sec;
+
+  return timeval_adjust (ret);
+}
+
+int
+timespec_cmp (struct timespec a, struct timespec b)
+{
+  return (a.tv_sec == b.tv_sec ?
+          a.tv_nsec - b.tv_nsec : a.tv_sec - b.tv_sec);
+}
+
+int
+timeval_cmp (struct timeval a, struct timeval b)
+{
+  return (a.tv_sec == b.tv_sec ?
+          a.tv_usec - b.tv_usec : a.tv_sec - b.tv_sec);
+}
+
+unsigned long
+timespec_elapsed (struct timespec a, struct timespec b)
+{
+  return (((a.tv_sec - b.tv_sec) * NANOS_IN_SECOND)
+          + (a.tv_nsec - b.tv_nsec));
+}
+
+unsigned long
+timeval_elapsed (struct timeval a, struct timeval b)
+{
+  return (((a.tv_sec - b.tv_sec) * MICROS_IN_SECOND)
+          + (a.tv_usec - b.tv_usec));
+}
+
+struct timeval
+frr_monotonic (int *status)
+{
+  struct timeval result = { 0 };
+
+#ifdef HAVE_CLOCK_MONOTONIC
+  {
+    struct timespec tp;
+    *status = clock_gettime (CLOCK_MONOTONIC, &tp);
+    result = timespec2timeval (tp);
+  }
+#elif defined(__APPLE__)
+  {
+    uint64_t ticks;
+    uint64_t useconds;
+    static mach_timebase_info_data_t timebase_info;
+
+    ticks = mach_absolute_time();
+    if (timebase_info.denom == 0)
+      mach_timebase_info(&timebase_info);
+
+    useconds = ticks * timebase_info.numer / timebase_info.denom / 1000;
+    result.tv_sec = useconds / 1000000;
+    result.tv_usec = useconds % 1000000;
+  }
+
+#else /* !HAVE_CLOCK_MONOTONIC && !__APPLE__ */
+#error no monotonic clock on this system
+#endif /* HAVE_CLOCK_MONOTONIC */
+
+  return result;
+}
+
+int
+frr_gettime (enum frr_clkid clkid, struct timeval *tv)
+{
+  int status = 0;
+  switch (clkid)
+    {
+      case FRR_CLK_MONOTONIC:
+        *tv = frr_monotonic (&status);
+        break;
+      case FRR_CLK_REALTIME:
+        status = gettimeofday (tv, NULL);
+        break;
+      default:
+        errno = EINVAL;
+        status = -1;
+        break;
+    }
+  return status;
+}

--- a/lib/timeutil.h
+++ b/lib/timeutil.h
@@ -206,4 +206,15 @@ frr_monotonic (int *);
 int
 frr_gettime (enum frr_clkid clkid, struct timeval *tv);
 
+/**
+ * Get the system monotonic time.
+ *
+ * This is just a convenience wrapper for frr_monotonic that has a similar
+ * signature to time().
+ *
+ * @return system monotonic time in seconds
+ */
+time_t
+frr_monotime (void);
+
 #endif /* _TIMEUTIL_H */

--- a/lib/timeutil.h
+++ b/lib/timeutil.h
@@ -37,13 +37,13 @@
 #define MICROS_IN_SECOND 1000000    // one million
 #define MILLIS_IN_SECOND 1000       // one thousand
 
-/* Clocks supported by FRR. */
-enum frr_clkid {
+/* Supported clocks. */
+enum timeutil_clkid {
   /* Monotonically increasing clock. Indeterminate base. Analagous to
    * CLOCK_MONOTONIC for clock_gettime(). */
-  FRR_CLK_MONOTONIC = 1,
+  TU_CLK_MONOTONIC = 1,
   /* Realtime (wall) clock. Analagous to CLOCK_REALTIME for clock_gettime(). */
-  FRR_CLK_REALTIME  = 2,
+  TU_CLK_REALTIME = 2,
 };
 
 /**
@@ -62,7 +62,7 @@ timeval2timespec (struct timeval);
 /**
  * Converts a timeval to a timespec.
  *
- * tv_nsec is divided by 1000 and rounded to the nearest microsecond.
+ * tv_nsec is divided by 1000 and truncated to the nearest microsecond.
  *
  * @param timespec to convert
  * @return the resultant timeval
@@ -178,24 +178,24 @@ timeval_elapsed (struct timeval a, struct timeval b);
  * Get the system monotonic time.
  *
  * This is the platform equivalent of clock_gettime (CLOCK_MONOTONIC, ...);
- * It should be used in place of that function within FRR because
+ * It should be used in place of that function within the codebase because
  * clock_gettime() is not available on all supported platforms.
  *
  * @param[out] status code
  *              0 => success
  *             -1 => check errno
- * @return a timeval representing the system monotonic time 0 for success
+ * @return a timeval representing the system monotonic time
  */
 struct timeval
-frr_monotonic (int *);
+timeutil_monotonic (int *);
 
 /**
  * Get the system time.
  *
  * This is a portability wrapper for clock_gettime(), which is not available on
- * all platforms. The available clocks are enumerated and documented in frr_clkid.
- * This wrapper should be used in place of clock_gettime() in all FRR code in order
- * to maintain portability.
+ * all platforms. The available clocks are enumerated and documented in
+ * timeutil_clkid. This wrapper should be used in place of clock_gettime()
+ * across the codebase in order to maintain portability.
  *
  * @param[in] clkid the clock ID
  * @param[out] tv the timeval to store the result in
@@ -204,17 +204,17 @@ frr_monotonic (int *);
  *         -1 => check errno
  */
 int
-frr_gettime (enum frr_clkid clkid, struct timeval *tv);
+timeutil_gettime (enum timeutil_clkid clkid, struct timeval *tv);
 
 /**
  * Get the system monotonic time.
  *
- * This is just a convenience wrapper for frr_monotonic that has a similar
+ * This is just a convenience wrapper for timeutil_monotonic that has a similar
  * signature to time().
  *
  * @return system monotonic time in seconds
  */
 time_t
-frr_monotime (void);
+timeutil_monotime (void);
 
 #endif /* _TIMEUTIL_H */

--- a/lib/timeutil.h
+++ b/lib/timeutil.h
@@ -1,0 +1,209 @@
+/*
+ * Utility functions for working with time.
+ *
+ * This module implements:
+ *   - Arithmetic operations on struct timespec and struct timeval
+ *   - Conversion functions between struct timespec and struct timeval
+ *   - Portability wrappers for platform-dependent time calls
+ *
+ * --
+ * Copyright (C) 2017 Cumulus Networks, Inc.
+ * Copyright (C) 1998, 2000, Kunihiro Ishiguro <kunihiro@zebra.org>
+ *
+ * This file is part of Free Range Routing.
+ *
+ * Free Range Routing is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any later
+ * version.
+ *
+ * Free Range Routing is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Free Range Routing; see the file COPYING.  If not, write to the Free
+ * Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+ * 02111-1307, USA.
+ */
+#ifndef _TIMEUTIL_H
+#define _TIMEUTIL_H
+
+#include <sys/time.h>
+#include <time.h>
+
+#define NANOS_IN_SECOND  1000000000 // one billion
+#define MICROS_IN_SECOND 1000000    // one million
+#define MILLIS_IN_SECOND 1000       // one thousand
+
+/* Clocks supported by FRR. */
+enum frr_clkid {
+  /* Monotonically increasing clock. Indeterminate base. Analagous to
+   * CLOCK_MONOTONIC for clock_gettime(). */
+  FRR_CLK_MONOTONIC = 1,
+  /* Realtime (wall) clock. Analagous to CLOCK_REALTIME for clock_gettime(). */
+  FRR_CLK_REALTIME  = 2,
+};
+
+/**
+ * Converts a timespec to a timeval.
+ *
+ * The caller must ensure that (tv_usec * 1000) is in the range of a signed
+ * long. It is recommended to adjust a timeval by calling timeval_adjust()
+ * before passing it to this function.
+ *
+ * @param timeval to convert
+ * @return the resultant timespec
+ */
+struct timespec
+timeval2timespec (struct timeval);
+
+/**
+ * Converts a timeval to a timespec.
+ *
+ * tv_nsec is divided by 1000 and rounded to the nearest microsecond.
+ *
+ * @param timespec to convert
+ * @return the resultant timeval
+ */
+struct timeval
+timespec2timeval (struct timespec);
+
+/**
+ * Adjusts a timespec so that tv_nsec is in the range [0, NANOS_IN_SECOND).
+ *
+ * tv_nsec is reduced in increments of NANOS_IN_SECOND until it is in range.
+ * Each reduction of tv_nsec increments tv_sec by 1.
+ *
+ * If the timespec represents a negative value, its fields are set to 0.
+ *
+ * @param timespec to adjust
+ * @return the adjusted timespec
+ */
+struct timespec
+timespec_adjust (struct timespec);
+
+/**
+ * Adjusts a timeval so that tv_usec is in the range [0, MICROS_IN_SECOND).
+ *
+ * tv_nsec is reduced in increments of MICROS_IN_SECOND until it is in range.
+ * Each reduction of tv_usec increments tv_sec by 1.
+ *
+ * If the timeval represents a negative value, its fields are set to 0.
+ *
+ * @param timeval to adjust
+ * @return the adjusted timeval
+ */
+struct timeval
+timeval_adjust (struct timeval);
+
+/**
+ * Computes the difference between two timespecs.
+ *
+ * Timespec b is subtracted from timespec a. The result is then adjusted with a
+ * call to timespec_adjust().
+ *
+ * @param a minuend timespec
+ * @param b subtrahend timespec
+ * @return timespec_adjust (a - b)
+ */
+struct timespec
+timespec_subtract (struct timespec a, struct timespec b);
+
+/**
+ * Computes the difference between two timevals.
+ *
+ * Timeval b is subtracted from timeval a. The result is then adjusted with a
+ * call to timeval_adjust().
+ *
+ * @param a minuend timeval
+ * @param b subtrahend timeval
+ * @return timeval_adjust (a - b)
+ */
+struct timeval
+timeval_subtract (struct timeval a, struct timeval b);
+
+/**
+ * Compares two timespecs.
+ *
+ * Return values:
+ *   a > b ==> positive
+ *   a < b ==> negative
+ *   a = b ==> 0
+ *
+ * @param a first timespec
+ * @param b second timespec
+ * @return comparison result as described
+ */
+int
+timespec_cmp (struct timespec a, struct timespec n);
+
+/**
+ * Compares two timevals.
+ *
+ * Return values:
+ *   a > b ==> positive
+ *   a < b ==> negative
+ *   a = b ==> 0
+ *
+ * @param a first timeval
+ * @param b second timeval
+ * @return comparison result as described
+ */
+int
+timeval_cmp (struct timeval a, struct timeval b);
+
+/**
+ * Computes the elapsed time between two timespecs in seconds.
+ *
+ * @param a first timespec
+ * @param b second timespec
+ * @return elapsed time in seconds
+ */
+unsigned long
+timespec_elapsed (struct timespec a, struct timespec b);
+
+/**
+ * Computes the elapsed time between two timevals in seconds.
+ *
+ * @param a first timeval
+ * @param b second timeval
+ * @return elapsed time in seconds
+ */
+unsigned long
+timeval_elapsed (struct timeval a, struct timeval b);
+
+/**
+ * Get the system monotonic time.
+ *
+ * This is the platform equivalent of clock_gettime (CLOCK_MONOTONIC, ...);
+ * It should be used in place of that function within FRR because
+ * clock_gettime() is not available on all supported platforms.
+ *
+ * @param[out] status code
+ *              0 => success
+ *             -1 => check errno
+ * @return a timeval representing the system monotonic time 0 for success
+ */
+struct timeval
+frr_monotonic (int *);
+
+/**
+ * Get the system time.
+ *
+ * This is a portability wrapper for clock_gettime(), which is not available on
+ * all platforms. The available clocks are enumerated and documented in frr_clkid.
+ * This wrapper should be used in place of clock_gettime() in all FRR code in order
+ * to maintain portability.
+ *
+ * @param[in] clkid the clock ID
+ * @param[out] tv the timeval to store the result in
+ * @return status code
+ *          0 => success
+ *         -1 => check errno
+ */
+int
+frr_gettime (enum frr_clkid clkid, struct timeval *tv);
+
+#endif /* _TIMEUTIL_H */

--- a/ospf6d/ospf6_abr.c
+++ b/ospf6d/ospf6_abr.c
@@ -29,6 +29,7 @@
 #include "linklist.h"
 #include "command.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "plist.h"
 #include "filter.h"
 
@@ -436,7 +437,7 @@ ospf6_abr_originate_summary_to_area (struct ospf6_route *route,
   else
     {
       summary->type = route->type;
-      quagga_gettime (QUAGGA_CLK_MONOTONIC, &summary->changed);
+      timeutil_gettime (TU_CLK_MONOTONIC, &summary->changed);
     }
 
   summary->path.router_bits = route->path.router_bits;

--- a/ospf6d/ospf6_area.c
+++ b/ospf6d/ospf6_area.c
@@ -25,6 +25,7 @@
 #include "memory.h"
 #include "linklist.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "vty.h"
 #include "command.h"
 #include "if.h"
@@ -389,11 +390,11 @@ ospf6_area_show (struct vty *vty, struct ospf6_area *oa)
   if (oa->ts_spf.tv_sec || oa->ts_spf.tv_usec)
     {
       result = timeval_elapsed (recent_relative_time (), oa->ts_spf);
-      if (result/TIMER_SECOND_MICRO > 0)
+      if (result/MICROS_IN_SECOND > 0)
 	{
 	  vty_out (vty, "SPF last executed %ld.%lds ago%s",
-		   result/TIMER_SECOND_MICRO,
-		   result%TIMER_SECOND_MICRO, VTY_NEWLINE);
+		   result/MICROS_IN_SECOND,
+		   result%MICROS_IN_SECOND, VTY_NEWLINE);
 	}
       else
 	{

--- a/ospf6d/ospf6_bfd.c
+++ b/ospf6d/ospf6_bfd.c
@@ -28,6 +28,7 @@
 #include "memory.h"
 #include "prefix.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "buffer.h"
 #include "stream.h"
 #include "zclient.h"
@@ -245,7 +246,7 @@ ospf6_bfd_interface_dest_update (int command, struct zclient *zclient,
 
       old_status = bfd_info->status;
       bfd_info->status = status;
-      quagga_gettime (QUAGGA_CLK_MONOTONIC, &tv);
+      timeutil_gettime (TU_CLK_MONOTONIC, &tv);
       bfd_info->last_update = tv.tv_sec;
 
       if ((status == BFD_STATUS_DOWN) && (old_status == BFD_STATUS_UP))

--- a/ospf6d/ospf6_flood.c
+++ b/ospf6d/ospf6_flood.c
@@ -23,6 +23,7 @@
 
 #include "log.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "linklist.h"
 #include "vty.h"
 #include "command.h"
@@ -224,7 +225,7 @@ ospf6_install_lsa (struct ospf6_lsa *lsa)
       ospf6_flood_clear (old);
     }
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+  timeutil_gettime (TU_CLK_MONOTONIC, &now);
   if (! OSPF6_LSA_IS_MAXAGE (lsa))
     lsa->expire = thread_add_timer (master, ospf6_lsa_expire, lsa,
                                     OSPF_LSA_MAXAGE + lsa->birth.tv_sec - now.tv_sec);
@@ -862,7 +863,7 @@ ospf6_receive_lsa (struct ospf6_neighbor *from,
       if (old)
         {
           struct timeval now, res;
-          quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+          timeutil_gettime (TU_CLK_MONOTONIC, &now);
           timersub (&now, &old->installed, &res);
           time_delta_ms = (res.tv_sec * 1000) + (int)(res.tv_usec/1000);
           if (time_delta_ms < from->ospf6_if->area->ospf6->lsa_minarrival)
@@ -875,7 +876,7 @@ ospf6_receive_lsa (struct ospf6_neighbor *from,
             }
         }
 
-      quagga_gettime (QUAGGA_CLK_MONOTONIC, &new->received);
+      timeutil_gettime (TU_CLK_MONOTONIC, &new->received);
 
       if (is_debug)
         zlog_debug ("Install, Flood, Possibly acknowledge the received LSA");

--- a/ospf6d/ospf6_interface.c
+++ b/ospf6d/ospf6_interface.c
@@ -26,6 +26,7 @@
 #include "log.h"
 #include "command.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "prefix.h"
 #include "plist.h"
 #include "zclient.h"
@@ -961,7 +962,7 @@ ospf6_interface_show (struct vty *vty, struct interface *ifp)
   vty_out (vty, "  Number of I/F scoped LSAs is %u%s",
            oi->lsdb->count, VNL);
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+  timeutil_gettime (TU_CLK_MONOTONIC, &now);
 
   timerclear (&res);
   if (oi->thread_send_lsupdate)

--- a/ospf6d/ospf6_intra.c
+++ b/ospf6d/ospf6_intra.c
@@ -24,6 +24,7 @@
 #include "log.h"
 #include "linklist.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "memory.h"
 #include "if.h"
 #include "prefix.h"
@@ -1485,11 +1486,11 @@ ospf6_brouter_debug_print (struct ospf6_route *brouter)
   ospf6_linkstate_prefix2str (&brouter->prefix, destination,
                               sizeof (destination));
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+  timeutil_gettime (TU_CLK_MONOTONIC, &now);
   timersub (&now, &brouter->installed, &res);
   timerstring (&res, installed, sizeof (installed));
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+  timeutil_gettime (TU_CLK_MONOTONIC, &now);
   timersub (&now, &brouter->changed, &res);
   timerstring (&res, changed, sizeof (changed));
 

--- a/ospf6d/ospf6_lsa.c
+++ b/ospf6d/ospf6_lsa.c
@@ -29,6 +29,7 @@
 #include "command.h"
 #include "memory.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "checksum.h"
 
 #include "ospf6_proto.h"
@@ -207,8 +208,8 @@ ospf6_lsa_age_set (struct ospf6_lsa *lsa)
 
   assert (lsa && lsa->header);
 
-  if (quagga_gettime (QUAGGA_CLK_MONOTONIC, &now) < 0)
-    zlog_warn ("LSA: quagga_gettime failed, may fail LSA AGEs: %s",
+  if (timeutil_gettime (TU_CLK_MONOTONIC, &now) < 0)
+    zlog_warn ("LSA: timeutil_gettime failed, may fail LSA AGEs: %s",
                safe_strerror (errno));
 
   lsa->birth.tv_sec = now.tv_sec - ntohs (lsa->header->age);
@@ -230,8 +231,8 @@ ospf6_lsa_age_current (struct ospf6_lsa *lsa)
   assert (lsa->header);
 
   /* current time */
-  if (quagga_gettime (QUAGGA_CLK_MONOTONIC, &now) < 0)
-    zlog_warn ("LSA: quagga_gettime failed, may fail LSA AGEs: %s",
+  if (timeutil_gettime (TU_CLK_MONOTONIC, &now) < 0)
+    zlog_warn ("LSA: timeutil_gettime failed, may fail LSA AGEs: %s",
                safe_strerror (errno));
 
   if (ntohs (lsa->header->age) >= OSPF_LSA_MAXAGE)
@@ -513,7 +514,7 @@ ospf6_lsa_show (struct vty *vty, struct ospf6_lsa *lsa)
   inet_ntop (AF_INET, &lsa->header->adv_router,
              adv_router, sizeof (adv_router));
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+  timeutil_gettime (TU_CLK_MONOTONIC, &now);
   timersub (&now, &lsa->installed, &res);
   timerstring (&res, duration, sizeof (duration));
 

--- a/ospf6d/ospf6_message.c
+++ b/ospf6d/ospf6_message.c
@@ -26,6 +26,7 @@
 #include "vty.h"
 #include "command.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "linklist.h"
 
 #include "ospf6_proto.h"
@@ -1818,7 +1819,7 @@ ospf6_dbdesc_send (struct thread *thread)
       (on->dbdesc_seqnum == 0))
     {
       struct timeval tv;
-      if (quagga_gettime (QUAGGA_CLK_MONOTONIC, &tv) < 0)
+      if (timeutil_gettime (TU_CLK_MONOTONIC, &tv) < 0)
         tv.tv_sec = 1;
       on->dbdesc_seqnum = tv.tv_sec;
     }

--- a/ospf6d/ospf6_neighbor.c
+++ b/ospf6d/ospf6_neighbor.c
@@ -24,6 +24,7 @@
 #include "log.h"
 #include "memory.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "linklist.h"
 #include "vty.h"
 #include "command.h"
@@ -97,7 +98,7 @@ ospf6_neighbor_create (u_int32_t router_id, struct ospf6_interface *oi)
   on->ospf6_if = oi;
   on->state = OSPF6_NEIGHBOR_DOWN;
   on->state_change = 0;
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &on->last_changed);
+  timeutil_gettime (TU_CLK_MONOTONIC, &on->last_changed);
   on->router_id = router_id;
 
   on->summary_list = ospf6_lsdb_create (on);
@@ -163,7 +164,7 @@ ospf6_neighbor_state_change (u_char next_state, struct ospf6_neighbor *on, int e
     return;
 
   on->state_change++;
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &on->last_changed);
+  timeutil_gettime (TU_CLK_MONOTONIC, &on->last_changed);
 
   /* log */
   if (IS_OSPF6_DEBUG_NEIGHBOR (STATE))
@@ -645,7 +646,7 @@ ospf6_neighbor_show (struct vty *vty, struct ospf6_neighbor *on)
   }
 #endif /*HAVE_GETNAMEINFO*/
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+  timeutil_gettime (TU_CLK_MONOTONIC, &now);
 
   /* Dead time */
   h = m = s = 0;
@@ -707,7 +708,7 @@ ospf6_neighbor_show_drchoice (struct vty *vty, struct ospf6_neighbor *on)
   inet_ntop (AF_INET, &on->drouter, drouter, sizeof (drouter));
   inet_ntop (AF_INET, &on->bdrouter, bdrouter, sizeof (bdrouter));
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+  timeutil_gettime (TU_CLK_MONOTONIC, &now);
   timersub (&now, &on->last_changed, &res);
   timerstring (&res, duration, sizeof (duration));
 
@@ -731,7 +732,7 @@ ospf6_neighbor_show_detail (struct vty *vty, struct ospf6_neighbor *on)
   inet_ntop (AF_INET, &on->drouter, drouter, sizeof (drouter));
   inet_ntop (AF_INET, &on->bdrouter, bdrouter, sizeof (bdrouter));
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+  timeutil_gettime (TU_CLK_MONOTONIC, &now);
   timersub (&now, &on->last_changed, &res);
   timerstring (&res, duration, sizeof (duration));
 

--- a/ospf6d/ospf6_route.c
+++ b/ospf6d/ospf6_route.c
@@ -28,6 +28,7 @@
 #include "vty.h"
 #include "command.h"
 #include "linklist.h"
+#include "timeutil.h"
 
 #include "ospf6_proto.h"
 #include "ospf6_lsa.h"
@@ -600,7 +601,7 @@ ospf6_route_add (struct ospf6_route *route,
   else if (IS_OSPF6_DEBUG_ROUTE (TABLE))
     zlog_debug ("%s: route add: %s", ospf6_route_table_name (table), buf);
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+  timeutil_gettime (TU_CLK_MONOTONIC, &now);
 
   node = route_node_get (table->table, &route->prefix);
   route->rnode = node;
@@ -1020,7 +1021,7 @@ ospf6_route_show (struct vty *vty, struct ospf6_route *route)
   struct listnode *node;
   struct ospf6_nexthop *nh;
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+  timeutil_gettime (TU_CLK_MONOTONIC, &now);
   timersub (&now, &route->changed, &res);
   timerstring (&res, duration, sizeof (duration));
 
@@ -1068,7 +1069,7 @@ ospf6_route_show_detail (struct vty *vty, struct ospf6_route *route)
   struct listnode *node;
   struct ospf6_nexthop *nh;
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+  timeutil_gettime (TU_CLK_MONOTONIC, &now);
 
   /* destination */
   if (route->type == OSPF6_DEST_TYPE_LINKSTATE)

--- a/ospf6d/ospf6_spf.c
+++ b/ospf6d/ospf6_spf.c
@@ -31,6 +31,7 @@
 #include "pqueue.h"
 #include "linklist.h"
 #include "thread.h"
+#include "timeutil.h"
 
 #include "ospf6_lsa.h"
 #include "ospf6_lsdb.h"
@@ -603,7 +604,7 @@ ospf6_spf_calculation_thread (struct thread *t)
   ospf6->t_spf_calc = NULL;
 
   /* execute SPF calculation */
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &start);
+  timeutil_gettime (TU_CLK_MONOTONIC, &start);
 
   if (ospf6_is_router_abr (ospf6))
     ospf6_abr_range_reset_cost (ospf6);
@@ -644,7 +645,7 @@ ospf6_spf_calculation_thread (struct thread *t)
   if (ospf6_is_router_abr (ospf6))
     ospf6_abr_defaults_to_stub (ospf6);
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &end);
+  timeutil_gettime (TU_CLK_MONOTONIC, &end);
   timersub (&end, &start, &runtime);
 
   ospf6->ts_spf_duration = runtime;

--- a/ospf6d/ospf6_top.c
+++ b/ospf6d/ospf6_top.c
@@ -28,6 +28,7 @@
 #include "prefix.h"
 #include "table.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "command.h"
 
 #include "ospf6_proto.h"
@@ -124,7 +125,7 @@ ospf6_create (void)
   o = XCALLOC (MTYPE_OSPF6_TOP, sizeof (struct ospf6));
 
   /* initialize */
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &o->starttime);
+  timeutil_gettime (TU_CLK_MONOTONIC, &o->starttime);
   o->area_list = list_new ();
   o->area_list->cmp = ospf6_area_cmp;
   o->lsdb = ospf6_lsdb_create (o);
@@ -891,7 +892,7 @@ ospf6_show (struct vty *vty, struct ospf6 *o)
            router_id, VNL);
 
   /* running time */
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+  timeutil_gettime (TU_CLK_MONOTONIC, &now);
   timersub (&now, &o->starttime, &running);
   timerstring (&running, duration, sizeof (duration));
   vty_out (vty, " Running %s%s", duration, VNL);

--- a/ospfd/ospf_ase.c
+++ b/ospfd/ospf_ase.c
@@ -23,6 +23,7 @@
 #include <zebra.h>
 
 #include "thread.h"
+#include "timeutil.h"
 #include "memory.h"
 #include "hash.h"
 #include "linklist.h"
@@ -649,7 +650,7 @@ ospf_ase_calculate_timer (struct thread *t)
     {
       ospf->ase_calc = 0;
 
-      quagga_gettime(QUAGGA_CLK_MONOTONIC, &start_time);
+      timeutil_gettime(TU_CLK_MONOTONIC, &start_time);
 
       /* Calculate external route for each AS-external-LSA */
       LSDB_LOOP (EXTERNAL_LSDB (ospf), rn, lsa)
@@ -681,7 +682,7 @@ ospf_ase_calculate_timer (struct thread *t)
       ospf->old_external_route = ospf->new_external_route;
       ospf->new_external_route = route_table_init ();
 
-      quagga_gettime(QUAGGA_CLK_MONOTONIC, &stop_time);
+      timeutil_gettime(TU_CLK_MONOTONIC, &stop_time);
 
       zlog_info ("SPF Processing Time(usecs): External Routes: %lld\n",
 		 (stop_time.tv_sec - start_time.tv_sec)*1000000LL+

--- a/ospfd/ospf_bfd.c
+++ b/ospfd/ospf_bfd.c
@@ -28,6 +28,7 @@
 #include "memory.h"
 #include "prefix.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "buffer.h"
 #include "stream.h"
 #include "zclient.h"
@@ -249,7 +250,7 @@ ospf_bfd_interface_dest_update (int command, struct zclient *zclient,
 
       old_status = bfd_info->status;
       bfd_info->status = status;
-      quagga_gettime (QUAGGA_CLK_MONOTONIC, &tv);
+      timeutil_gettime (TU_CLK_MONOTONIC, &tv);
       bfd_info->last_update = tv.tv_sec;
 
       if ((status == BFD_STATUS_DOWN) && (old_status == BFD_STATUS_UP))

--- a/ospfd/ospf_lsa.c
+++ b/ospfd/ospf_lsa.c
@@ -30,6 +30,7 @@
 #include "stream.h"
 #include "log.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "hash.h"
 #include "sockunion.h"		/* for inet_aton() */
 #include "checksum.h"
@@ -153,7 +154,7 @@ ospf_lsa_refresh_delay (struct ospf_lsa *lsa)
   struct timeval delta, now;
   int delay = 0;
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+  timeutil_gettime (TU_CLK_MONOTONIC, &now);
   delta = tv_sub (now, lsa->tv_orig);
 
   if (tv_cmp (delta, msec2tv (OSPF_MIN_LS_INTERVAL)) < 0)
@@ -3701,7 +3702,7 @@ ospf_refresher_register_lsa (struct ospf *ospf, struct ospf_lsa *lsa)
        */
       delay = (random() % (max_delay - min_delay)) + min_delay;
 
-      current_index = ospf->lsa_refresh_queue.index + (quagga_monotime ()
+      current_index = ospf->lsa_refresh_queue.index + (timeutil_monotime ()
                 - ospf->lsa_refresher_started)/OSPF_LSA_REFRESHER_GRANULARITY;
       
       index = (current_index + delay/OSPF_LSA_REFRESHER_GRANULARITY)
@@ -3765,7 +3766,7 @@ ospf_lsa_refresh_walker (struct thread *t)
      modulus. */
   ospf->lsa_refresh_queue.index =
    ((unsigned long)(ospf->lsa_refresh_queue.index +
-		    (quagga_monotime () - ospf->lsa_refresher_started)
+		    (timeutil_monotime () - ospf->lsa_refresher_started)
 		    / OSPF_LSA_REFRESHER_GRANULARITY))
 		    % OSPF_LSA_REFRESHER_SLOTS;
 
@@ -3806,7 +3807,7 @@ ospf_lsa_refresh_walker (struct thread *t)
 
   ospf->t_lsa_refresher = thread_add_timer (master, ospf_lsa_refresh_walker,
 					   ospf, ospf->lsa_refresh_interval);
-  ospf->lsa_refresher_started = quagga_monotime ();
+  ospf->lsa_refresher_started = timeutil_monotime ();
 
   for (ALL_LIST_ELEMENTS (lsa_to_refresh, node, nnode, lsa))
     {

--- a/ospfd/ospf_packet.c
+++ b/ospfd/ospf_packet.c
@@ -23,6 +23,7 @@
 #include <zebra.h>
 
 #include "thread.h"
+#include "timeutil.h"
 #include "memory.h"
 #include "linklist.h"
 #include "prefix.h"
@@ -1470,7 +1471,7 @@ ospf_db_desc (struct ip *iph, struct ospf_header *ospfh,
 	  else
 	    {
 	      struct timeval t, now;
-	      quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+	      timeutil_gettime (TU_CLK_MONOTONIC, &now);
 	      t = tv_sub (now, nbr->last_send_ts);
 	      if (tv_cmp (t, int2tv (nbr->v_inactivity)) < 0)
 		{
@@ -2076,7 +2077,7 @@ ospf_ls_upd (struct ospf *ospf, struct ip *iph, struct ospf_header *ospfh,
 	    {
 	      struct timeval now;
 	      
-	      quagga_gettime (QUAGGA_CLK_MONOTONIC, &now);
+	      timeutil_gettime (TU_CLK_MONOTONIC, &now);
 	      
 	      if (tv_cmp (tv_sub (now, current->tv_orig), 
 			  msec2tv (ospf->min_ls_arrival)) >= 0)
@@ -3577,7 +3578,7 @@ ospf_db_desc_send (struct ospf_neighbor *nbr)
   if (nbr->last_send)
     ospf_packet_free (nbr->last_send);
   nbr->last_send = ospf_packet_dup (op);
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &nbr->last_send_ts);
+  timeutil_gettime (TU_CLK_MONOTONIC, &nbr->last_send_ts);
 }
 
 /* Re-send Database Description. */

--- a/ospfd/ospf_spf.c
+++ b/ospfd/ospf_spf.c
@@ -21,6 +21,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include <zebra.h>
 
 #include "thread.h"
+#include "timeutil.h"
 #include "memory.h"
 #include "hash.h"
 #include "linklist.h"
@@ -1279,7 +1280,7 @@ ospf_spf_calculate (struct ospf_area *area, struct route_table *new_table,
   /* Increment SPF Calculation Counter. */
   area->spf_calculation++;
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &area->ospf->ts_spf);
+  timeutil_gettime (TU_CLK_MONOTONIC, &area->ospf->ts_spf);
   area->ts_spf = area->ospf->ts_spf;
 
   if (IS_DEBUG_OSPF_EVENT)
@@ -1311,7 +1312,7 @@ ospf_spf_calculate_timer (struct thread *thread)
 
   ospf->t_spf_calc = NULL;
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &spf_start_time);
+  timeutil_gettime (TU_CLK_MONOTONIC, &spf_start_time);
   /* Allocate new table tree. */
   new_table = route_table_init ();
   new_rtrs = route_table_init ();
@@ -1338,7 +1339,7 @@ ospf_spf_calculate_timer (struct thread *thread)
       areas_processed++;
     }
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &stop_time);
+  timeutil_gettime (TU_CLK_MONOTONIC, &stop_time);
   spf_time = timeval_elapsed (stop_time, spf_start_time);
 
   ospf_vl_shut_unapproved (ospf);
@@ -1347,14 +1348,14 @@ ospf_spf_calculate_timer (struct thread *thread)
 
   ospf_ia_routing (ospf, new_table, new_rtrs);
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &stop_time);
+  timeutil_gettime (TU_CLK_MONOTONIC, &stop_time);
   ia_time = timeval_elapsed (stop_time, start_time);
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &start_time);
+  timeutil_gettime (TU_CLK_MONOTONIC, &start_time);
   ospf_prune_unreachable_networks (new_table);
   ospf_prune_unreachable_routers (new_rtrs);
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &stop_time);
+  timeutil_gettime (TU_CLK_MONOTONIC, &stop_time);
   prune_time = timeval_elapsed (stop_time, start_time);
   /* AS-external-LSA calculation should not be performed here. */
 
@@ -1365,12 +1366,12 @@ ospf_spf_calculate_timer (struct thread *thread)
 
   ospf_ase_calculate_timer_add (ospf);
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &start_time);
+  timeutil_gettime (TU_CLK_MONOTONIC, &start_time);
 
   /* Update routing table. */
   ospf_route_install (ospf, new_table);
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &stop_time);
+  timeutil_gettime (TU_CLK_MONOTONIC, &stop_time);
   rt_time = timeval_elapsed (stop_time, start_time);
   /* Update ABR/ASBR routing table */
   if (ospf->old_rtrs)
@@ -1383,14 +1384,14 @@ ospf_spf_calculate_timer (struct thread *thread)
   ospf->old_rtrs = ospf->new_rtrs;
   ospf->new_rtrs = new_rtrs;
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &start_time);
+  timeutil_gettime (TU_CLK_MONOTONIC, &start_time);
   if (IS_OSPF_ABR (ospf))
     ospf_abr_task (ospf);
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &stop_time);
+  timeutil_gettime (TU_CLK_MONOTONIC, &stop_time);
   abr_time = timeval_elapsed (stop_time, start_time);
 
-  quagga_gettime (QUAGGA_CLK_MONOTONIC, &stop_time);
+  timeutil_gettime (TU_CLK_MONOTONIC, &stop_time);
   total_spf_time = timeval_elapsed (stop_time, spf_start_time);
   ospf->ts_spf_duration.tv_sec = total_spf_time/1000000;
   ospf->ts_spf_duration.tv_usec = total_spf_time % 1000000;

--- a/ospfd/ospfd.c
+++ b/ospfd/ospfd.c
@@ -21,6 +21,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include <zebra.h>
 
 #include "thread.h"
+#include "timeutil.h"
 #include "vty.h"
 #include "command.h"
 #include "linklist.h"
@@ -273,7 +274,7 @@ ospf_new (u_short instance)
   new->lsa_refresh_interval = OSPF_LSA_REFRESH_INTERVAL_DEFAULT;
   new->t_lsa_refresher = thread_add_timer (master, ospf_lsa_refresh_walker,
 					   new, new->lsa_refresh_interval);
-  new->lsa_refresher_started = quagga_monotime ();
+  new->lsa_refresher_started = timeutil_monotime ();
 
   if ((new->fd = ospf_sock_init()) < 0)
     {
@@ -1583,7 +1584,7 @@ ospf_timers_refresh_set (struct ospf *ospf, int interval)
     return 1;
 
   time_left = ospf->lsa_refresh_interval -
-    (quagga_monotime () - ospf->lsa_refresher_started);
+    (timeutil_monotime () - ospf->lsa_refresher_started);
   
   if (time_left > interval)
     {
@@ -1602,7 +1603,7 @@ ospf_timers_refresh_unset (struct ospf *ospf)
   int time_left;
 
   time_left = ospf->lsa_refresh_interval -
-    (quagga_monotime () - ospf->lsa_refresher_started);
+    (timeutil_monotime () - ospf->lsa_refresher_started);
 
   if (time_left > OSPF_LSA_REFRESH_INTERVAL_DEFAULT)
     {

--- a/tests/test-timer-performance.c
+++ b/tests/test-timer-performance.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 
 #include "thread.h"
+#include "timeutil.h"
 #include "pqueue.h"
 #include "prng.h"
 
@@ -61,7 +62,7 @@ int main(int argc, char **argv)
   for (i = 0; i < SCHEDULE_TIMERS; i++)
     thread_cancel(timers[i]);
 
-  quagga_gettime(QUAGGA_CLK_MONOTONIC, &tv_start);
+  timeutil_gettime(TU_CLK_MONOTONIC, &tv_start);
 
   for (i = 0; i < SCHEDULE_TIMERS; i++)
     {
@@ -72,7 +73,7 @@ int main(int argc, char **argv)
                                         NULL, interval_msec);
     }
 
-  quagga_gettime(QUAGGA_CLK_MONOTONIC, &tv_lap);
+  timeutil_gettime(TU_CLK_MONOTONIC, &tv_lap);
 
   for (i = 0; i < REMOVE_TIMERS; i++)
     {
@@ -84,7 +85,7 @@ int main(int argc, char **argv)
       timers[index] = NULL;
     }
 
-  quagga_gettime(QUAGGA_CLK_MONOTONIC, &tv_stop);
+  timeutil_gettime(TU_CLK_MONOTONIC, &tv_stop);
 
   t_schedule = 1000 * (tv_lap.tv_sec - tv_start.tv_sec);
   t_schedule += (tv_lap.tv_usec - tv_start.tv_usec) / 1000;

--- a/zebra/zebra_fpm.c
+++ b/zebra/zebra_fpm.c
@@ -27,6 +27,7 @@
 #include "log.h"
 #include "stream.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "network.h"
 #include "command.h"
 
@@ -304,8 +305,8 @@ zfpm_get_time (void)
 {
   struct timeval tv;
 
-  if (quagga_gettime (QUAGGA_CLK_MONOTONIC, &tv) < 0)
-    zlog_warn ("FPM: quagga_gettime failed!!");
+  if (timeutil_gettime (TU_CLK_MONOTONIC, &tv) < 0)
+    zlog_warn ("FPM: timeutil_gettime failed!!");
 
   return tv.tv_sec;
 }

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -30,6 +30,7 @@
 #include "sockunion.h"
 #include "linklist.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "workqueue.h"
 #include "prefix.h"
 #include "routemap.h"
@@ -924,7 +925,7 @@ send_client (struct rnh *rnh, struct zserv *client, rnh_type_t type, vrf_id_t vr
     }
   stream_putw_at (s, 0, stream_get_endp (s));
 
-  client->nh_last_upd_time = quagga_monotime();
+  client->nh_last_upd_time = timeutil_monotime();
   client->last_write_cmd = cmd;
   return zebra_server_send_message(client);
 }

--- a/zebra/zserv.c
+++ b/zebra/zserv.c
@@ -25,6 +25,7 @@
 #include "command.h"
 #include "if.h"
 #include "thread.h"
+#include "timeutil.h"
 #include "stream.h"
 #include "memory.h"
 #include "zebra_memory.h"
@@ -100,7 +101,7 @@ zserv_flush_data(struct thread *thread)
       break;
     }
 
-  client->last_write_time = quagga_monotime();
+  client->last_write_time = timeutil_monotime();
   return 0;
 }
 
@@ -134,7 +135,7 @@ zebra_server_send_message(struct zserv *client)
       break;
     }
 
-  client->last_write_time = quagga_monotime();
+  client->last_write_time = timeutil_monotime();
   return 0;
 }
 
@@ -826,7 +827,7 @@ zserv_rnh_register (struct zserv *client, int sock, u_short length,
 
   s = client->ibuf;
 
-  client->nh_reg_time = quagga_monotime();
+  client->nh_reg_time = timeutil_monotime();
 
   while (l < length)
     {
@@ -914,7 +915,7 @@ zserv_rnh_unregister (struct zserv *client, int sock, u_short length,
       rnh = zebra_lookup_rnh(&p, zvrf_id (zvrf), type);
       if (rnh)
 	{
-	  client->nh_dereg_time = quagga_monotime();
+	  client->nh_dereg_time = timeutil_monotime();
 	  zebra_remove_rnh_client(rnh, client, type);
 	}
     }
@@ -1826,7 +1827,7 @@ zebra_client_create (int sock)
   /* Set table number. */
   client->rtm_table = zebrad.rtm_table_default;
 
-  client->connect_time = quagga_monotime();
+  client->connect_time = timeutil_monotime();
   /* Initialize flags */
   for (afi = AFI_IP; afi < AFI_MAX; afi++)
     for (i = 0; i < ZEBRA_ROUTE_MAX; i++)
@@ -1952,7 +1953,7 @@ zebra_client_read (struct thread *thread)
     zlog_debug ("zebra message received [%s] %d in VRF %u",
 	       zserv_command_string (command), length, vrf_id);
 
-  client->last_read_time = quagga_monotime();
+  client->last_read_time = timeutil_monotime();
   client->last_read_cmd = command;
 
   zvrf = zebra_vrf_lookup_by_id (vrf_id);
@@ -2263,7 +2264,7 @@ zserv_time_buf(time_t *time1, char *buf, int buflen)
       return (buf);
     }
 
-  now = quagga_monotime();
+  now = timeutil_monotime();
   now -= *time1;
   tm = gmtime(&now);
 


### PR DESCRIPTION
This is a set of changes that aim to clean up timing code.
Summary of changes:

- Move all time related code into its own module
- Make sane the public interface for time code
- Remove global state from time code
- Decouple thread.c time caching from time code
- Add conversion functions between timespec and timeval
- Add arithmetic functions for timespec and timeval
- Remove false comment about quagga_get_relative updating recent_time on systems where gettimeofday() is used to compute a relative system time, since this never happens
- Fix bug on _APPLE_ where the argument to quagga_get_relative is not actually set with the computed system monotonic time
- Remove thread.[ch] global variable recent_time because it is never used
- Add TU_CLK_REALTIME to supported clocks
- Document new and existing functionality
- Rename quagga_* time functions to timeutil_* time functions
- Refactor codebase to use timeutil.h where necessary