### PR TITLE
Updated: stable/2.0 pull to pick up bgp afi/safi vty changes (Issues #14 and #61)

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -198,7 +198,7 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
 
       if (prefixlen < VPN_PREFIXLEN_MIN_BYTES*8)
 	{
-	  zlog_err ("%s [Error] Update packet error / VPNv4 (prefix length %d less than VPNv4 min length)",
+	  zlog_err ("%s [Error] Update packet error / VPN (prefix length %d less than VPN min length)",
 	            peer->host, prefixlen);
 	  return -1;
 	}
@@ -206,7 +206,7 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
       /* sanity check against packet data */
       if ((pnt + psize) > lim)
         {
-          zlog_err ("%s [Error] Update packet error / VPNv4 (prefix length %d exceeds packet size %u)",
+          zlog_err ("%s [Error] Update packet error / VPN (prefix length %d exceeds packet size %u)",
                     peer->host,
                     prefixlen, (uint)(lim-pnt));
           return -1;
@@ -215,7 +215,7 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
       /* sanity check against storage for the IP address portion */
       if ((psize - VPN_PREFIXLEN_MIN_BYTES) > (ssize_t) sizeof(p.u))
         {
-          zlog_err ("%s [Error] Update packet error / VPNv4 (psize %d exceeds storage size %zu)",
+          zlog_err ("%s [Error] Update packet error / VPN (psize %d exceeds storage size %zu)",
                     peer->host,
                     prefixlen - VPN_PREFIXLEN_MIN_BYTES*8, sizeof(p.u));
           return -1;
@@ -224,7 +224,7 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
       /* Sanity check against max bitlen of the address family */
       if ((psize - VPN_PREFIXLEN_MIN_BYTES) > prefix_blen (&p))
         {
-          zlog_err ("%s [Error] Update packet error / VPNv4 (psize %d exceeds family (%u) max byte len %u)",
+          zlog_err ("%s [Error] Update packet error / VPN (psize %d exceeds family (%u) max byte len %u)",
                     peer->host,
                     prefixlen - VPN_PREFIXLEN_MIN_BYTES*8, 
                     p.family, prefix_blen (&p));
@@ -295,7 +295,7 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
   /* Packet length consistency check. */
   if (pnt != lim)
     {
-      zlog_err ("%s [Error] Update packet error / VPNv4 (%zu data remaining after parsing)",
+      zlog_err ("%s [Error] Update packet error / VPN (%zu data remaining after parsing)",
                 peer->host, lim - pnt);
       return -1;
     }
@@ -484,6 +484,7 @@ DEFUN (no_vpnv4_network,
   return bgp_static_unset_safi (SAFI_MPLS_VPN, vty, argv[0], argv[1], argv[2]);
 }
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 static int
 show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd, u_char use_json)
 {
@@ -650,6 +651,7 @@ show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd, u
     }
   return CMD_SUCCESS;
 }
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 enum bgp_show_type
 {
@@ -954,6 +956,7 @@ DEFUN (show_bgp_ipv6_vpn_rd,
   return bgp_show_mpls_vpn (vty, AFI_IP6, &prd, bgp_show_type_normal, NULL, 0, use_json (argc, argv));
 }
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (show_ip_bgp_vpnv4_all,
        show_ip_bgp_vpnv4_all_cmd,
        "show ip bgp vpnv4 all",
@@ -1269,6 +1272,7 @@ DEFUN (show_ip_bgp_vpnv4_rd_neighbor_advertised_routes,
 
   return show_adj_route_vpn (vty, peer, &prd, uj);
 }
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 void
 bgp_mplsvpn_init (void)
@@ -1281,6 +1285,7 @@ bgp_mplsvpn_init (void)
   install_element (VIEW_NODE, &show_bgp_ipv4_vpn_rd_cmd);
   install_element (VIEW_NODE, &show_bgp_ipv6_vpn_cmd);
   install_element (VIEW_NODE, &show_bgp_ipv6_vpn_rd_cmd);
+#ifdef KEEP_OLD_VPNV4_COMMANDS
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_rd_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_tags_cmd);
@@ -1289,4 +1294,6 @@ bgp_mplsvpn_init (void)
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_rd_neighbor_routes_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_neighbor_advertised_routes_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_rd_neighbor_advertised_routes_cmd);
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
+
 }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8157,13 +8157,12 @@ DEFUN (show_ip_bgp,
 
 DEFUN (show_ip_bgp_ipv4,
        show_ip_bgp_ipv4_cmd,
-       "show ip bgp ipv4 (unicast|multicast) {json}",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "JavaScript Object Notation\n")
 {
   u_char uj = use_json(argc, argv);
@@ -8175,12 +8174,11 @@ DEFUN (show_ip_bgp_ipv4,
 
 ALIAS (show_ip_bgp_ipv4,
        show_bgp_ipv4_safi_cmd,
-       "show bgp ipv4 (unicast|multicast) {json}",
+       "show bgp ipv4 "BGP_SAFI_CMD_STR" {json}",
        SHOW_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "JavaScript Object Notation\n")
 
 DEFUN (show_ip_bgp_route,
@@ -8216,10 +8214,10 @@ DEFUN (show_ip_bgp_route_pathtype,
 
 DEFUN (show_bgp_ipv4_safi_route_pathtype,
        show_bgp_ipv4_safi_route_pathtype_cmd,
-       "show bgp ipv4 (unicast|multicast|vpn|encap) A.B.C.D (bestpath|multipath) {json}",
+       "show bgp ipv4 "BGP_SAFI_CMD_STR" A.B.C.D (bestpath|multipath) {json}",
        SHOW_STR
        BGP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "IP prefix <network>/<length>, e.g., 35.0.0.0/8\n"
        "Display only the bestpath\n"
        "Display only multipaths\n"
@@ -8275,11 +8273,11 @@ DEFUN (show_bgp_ipv6_prefix,
 
 DEFUN (show_ip_bgp_ipv4_route,
        show_ip_bgp_ipv4_route_cmd,
-       "show ip bgp ipv4 (unicast|multicast|vpn|encap) A.B.C.D {json}",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" A.B.C.D {json}",
        SHOW_STR
        IP_STR
        BGP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "Network in the BGP routing table to display\n"
        "JavaScript Object Notation\n")
 {
@@ -8292,10 +8290,10 @@ DEFUN (show_ip_bgp_ipv4_route,
 
 ALIAS (show_ip_bgp_ipv4_route,
        show_bgp_ipv4_safi_route_cmd,
-       "show bgp ipv4 (unicast|multicast|vpn|encap) A.B.C.D {json}",
+       "show bgp ipv4 "BGP_SAFI_CMD_STR" A.B.C.D {json}",
        SHOW_STR
        BGP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "Network in the BGP routing table to display\n"
        "JavaScript Object Notation\n")
 
@@ -8489,11 +8487,11 @@ DEFUN (show_ip_bgp_prefix_pathtype,
 
 DEFUN (show_ip_bgp_ipv4_prefix,
        show_ip_bgp_ipv4_prefix_cmd,
-       "show ip bgp ipv4 (unicast|multicast|vpn|encap) A.B.C.D/M {json}",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" A.B.C.D/M {json}",
        SHOW_STR
        IP_STR
        BGP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "IP prefix <network>/<length>, e.g., 35.0.0.0/8\n"
        "JavaScript Object Notation\n")
 {
@@ -8506,20 +8504,20 @@ DEFUN (show_ip_bgp_ipv4_prefix,
 
 ALIAS (show_ip_bgp_ipv4_prefix,
        show_bgp_ipv4_safi_prefix_cmd,
-       "show bgp ipv4 (unicast|multicast|vpn|encap) A.B.C.D/M {json}",
+       "show bgp ipv4 "BGP_SAFI_CMD_STR" A.B.C.D/M {json}",
        SHOW_STR
        BGP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "IP prefix <network>/<length>, e.g., 35.0.0.0/8\n"
        "JavaScript Object Notation\n")
 
 DEFUN (show_ip_bgp_ipv4_prefix_pathtype,
        show_ip_bgp_ipv4_prefix_pathtype_cmd,
-       "show ip bgp ipv4 (unicast|multicast|vpn|encap) A.B.C.D/M (bestpath|multipath) {json}",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" A.B.C.D/M (bestpath|multipath) {json}",
        SHOW_STR
        IP_STR
        BGP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "IP prefix <network>/<length>, e.g., 35.0.0.0/8\n"
        "Display only the bestpath\n"
        "Display only multipaths\n"
@@ -8539,10 +8537,10 @@ DEFUN (show_ip_bgp_ipv4_prefix_pathtype,
 
 ALIAS (show_ip_bgp_ipv4_prefix_pathtype,
        show_bgp_ipv4_safi_prefix_pathtype_cmd,
-       "show bgp ipv4 (unicast|multicast|vpn|encap) A.B.C.D/M (bestpath|multipath) {json}",
+       "show bgp ipv4 "BGP_SAFI_CMD_STR" A.B.C.D/M (bestpath|multipath) {json}",
        SHOW_STR
        BGP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "IP prefix <network>/<length>, e.g., 35.0.0.0/8\n"
        "Display only the bestpath\n"
        "Display only multipaths\n"
@@ -8710,13 +8708,11 @@ ALIAS (show_bgp,
 
 DEFUN (show_bgp_ipv6_safi,
        show_bgp_ipv6_safi_cmd,
-       "show bgp ipv6 (unicast|multicast) {json}",
+       "show bgp ipv6 "BGP_SAFI_CMD_STR" {json}",
        SHOW_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
-       AFI_SAFI_STR
+       BGP_SAFI_HELP_STR
        "JavaScript Object Notation\n")
 {
   u_char uj = use_json(argc, argv);
@@ -8761,10 +8757,10 @@ DEFUN (show_bgp_route,
 
 DEFUN (show_bgp_ipv6_safi_route,
        show_bgp_ipv6_safi_route_cmd,
-       "show bgp ipv6 (unicast|multicast|vpn|encap) X:X::X:X {json}",
+       "show bgp ipv6 "BGP_SAFI_CMD_STR" X:X::X:X {json}",
        SHOW_STR
        BGP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "Network in the BGP routing table to display\n"
        "JavaScript Object Notation\n")
 {
@@ -8805,10 +8801,10 @@ ALIAS (show_bgp_route_pathtype,
 
 DEFUN (show_bgp_ipv6_safi_route_pathtype,
        show_bgp_ipv6_safi_route_pathtype_cmd,
-       "show bgp ipv6 (unicast|multicast|vpn|encap) X:X::X:X (bestpath|multipath) {json}",
+       "show bgp ipv6 "BGP_SAFI_CMD_STR" X:X::X:X (bestpath|multipath) {json}",
        SHOW_STR
        BGP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "Network in the BGP routing table to display\n"
        "Display only the bestpath\n"
        "Display only multipaths\n"
@@ -8852,10 +8848,10 @@ DEFUN (show_bgp_prefix,
 
 DEFUN (show_bgp_ipv6_safi_prefix,
        show_bgp_ipv6_safi_prefix_cmd,
-       "show bgp ipv6 (unicast|multicast|vpn|encap) X:X::X:X/M {json}",
+       "show bgp ipv6 "BGP_SAFI_CMD_STR" X:X::X:X/M {json}",
        SHOW_STR
        BGP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "IPv6 prefix <network>/<length>, e.g., 3ffe::/16\n"
        "JavaScript Object Notation\n")
 {
@@ -8896,10 +8892,10 @@ ALIAS (show_bgp_prefix_pathtype,
 
 DEFUN (show_bgp_ipv6_safi_prefix_pathtype,
        show_bgp_ipv6_safi_prefix_pathtype_cmd,
-       "show bgp ipv6 (unicast|multicast|vpn|encap) X:X::X:X/M (bestpath|multipath) {json}",
+       "show bgp ipv6 "BGP_SAFI_CMD_STR" X:X::X:X/M (bestpath|multipath) {json}",
        SHOW_STR
        BGP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "IPv6 prefix <network>/<length>, e.g., 3ffe::/16\n"
        "Display only the bestpath\n"
        "Display only multipaths\n"
@@ -9322,22 +9318,19 @@ ALIAS (show_ip_bgp_flap_regexp,
 
 DEFUN (show_ip_bgp_ipv4_regexp, 
        show_ip_bgp_ipv4_regexp_cmd,
-       "show ip bgp ipv4 (unicast|multicast) regexp .LINE",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" regexp .LINE",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes matching the AS path regular expression\n"
        "A regular-expression to match the BGP AS paths\n")
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_show_regexp (vty, argc, argv, AFI_IP, SAFI_MULTICAST,
-			    bgp_show_type_regexp);
-
-  return bgp_show_regexp (vty, argc, argv, AFI_IP, SAFI_UNICAST,
-			  bgp_show_type_regexp);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_show_regexp (vty, argc, argv, AFI_IP, safi,
+                          bgp_show_type_regexp);
 }
 
 #ifdef HAVE_IPV6
@@ -9472,22 +9465,19 @@ ALIAS (show_ip_bgp_flap_prefix_list,
 
 DEFUN (show_ip_bgp_ipv4_prefix_list, 
        show_ip_bgp_ipv4_prefix_list_cmd,
-       "show ip bgp ipv4 (unicast|multicast) prefix-list WORD",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" prefix-list WORD",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes conforming to the prefix-list\n"
        "IP prefix-list name\n")
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_show_prefix_list (vty, NULL, argv[1], AFI_IP, SAFI_MULTICAST,
-			         bgp_show_type_prefix_list);
-
-  return bgp_show_prefix_list (vty, NULL, argv[1], AFI_IP, SAFI_UNICAST,
-			       bgp_show_type_prefix_list);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_show_prefix_list (vty, NULL, argv[1], AFI_IP, safi,
+                               bgp_show_type_prefix_list);
 }
 
 #ifdef HAVE_IPV6
@@ -9621,22 +9611,19 @@ ALIAS (show_ip_bgp_flap_filter_list,
 
 DEFUN (show_ip_bgp_ipv4_filter_list, 
        show_ip_bgp_ipv4_filter_list_cmd,
-       "show ip bgp ipv4 (unicast|multicast) filter-list WORD",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" filter-list WORD",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes conforming to the filter-list\n"
        "Regular expression access list name\n")
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_show_filter_list (vty, NULL, argv[1], AFI_IP, SAFI_MULTICAST,
-			         bgp_show_type_filter_list);
-  
-  return bgp_show_filter_list (vty, NULL, argv[1], AFI_IP, SAFI_UNICAST,
-			       bgp_show_type_filter_list);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_show_filter_list (vty, NULL, argv[1], AFI_IP, safi,
+                               bgp_show_type_filter_list);
 }
 
 #ifdef HAVE_IPV6
@@ -9707,61 +9694,53 @@ DEFUN (show_ip_bgp_dampening_info,
 
 DEFUN (show_ip_bgp_ipv4_dampening_parameters,
        show_ip_bgp_ipv4_dampening_parameters_cmd,
-       "show ip bgp ipv4 (unicast|multicast) dampening parameters",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" dampening parameters",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display detailed information about dampening\n"
        "Display detail of configured dampening parameters\n")
 {
-    if (strncmp(argv[0], "m", 1) == 0)
-      return bgp_show_dampening_parameters (vty, AFI_IP, SAFI_MULTICAST);
-
-    return bgp_show_dampening_parameters (vty, AFI_IP, SAFI_UNICAST);
+    safi_t safi;
+    safi = bgp_vty_safi_from_arg(argv[0]);
+    return bgp_show_dampening_parameters (vty, AFI_IP, safi);
 }
 
 
 DEFUN (show_ip_bgp_ipv4_dampening_flap_stats,
        show_ip_bgp_ipv4_dampening_flap_stats_cmd,
-       "show ip bgp ipv4 (unicast|multicast) dampening flap-statistics",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" dampening flap-statistics",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display detailed information about dampening\n"
        "Display flap statistics of routes\n")
 {
-    if (strncmp(argv[0], "m", 1) == 0)
-      return bgp_show (vty, NULL, AFI_IP, SAFI_MULTICAST,
+    safi_t safi;
+    safi = bgp_vty_safi_from_arg(argv[0]);
+    return bgp_show (vty, NULL, AFI_IP, safi,
                      bgp_show_type_flap_statistics, NULL, 0);
-
-    return bgp_show (vty, NULL, AFI_IP, SAFI_MULTICAST,
-                 bgp_show_type_flap_statistics, NULL, 0);
 }
 
 DEFUN (show_ip_bgp_ipv4_dampening_dampd_paths,
        show_ip_bgp_ipv4_dampening_dampd_paths_cmd,
-       "show ip bgp ipv4 (unicast|multicast) dampening dampened-paths",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" dampening dampened-paths",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display detailed information about dampening\n"
        "Display paths suppressed due to dampening\n")
 {
-    if (strncmp(argv[0], "m", 1) == 0)
-      return bgp_show (vty, NULL, AFI_IP, SAFI_MULTICAST,
+    safi_t safi;
+    safi = bgp_vty_safi_from_arg(argv[0]);
+    return bgp_show (vty, NULL, AFI_IP, safi,
                      bgp_show_type_dampend_paths, NULL, 0);
-
-    return bgp_show (vty, NULL, AFI_IP, SAFI_MULTICAST,
-                 bgp_show_type_dampend_paths, NULL, 0);
 }
 
 static int
@@ -9843,22 +9822,19 @@ ALIAS (show_ip_bgp_flap_route_map,
 
 DEFUN (show_ip_bgp_ipv4_route_map, 
        show_ip_bgp_ipv4_route_map_cmd,
-       "show ip bgp ipv4 (unicast|multicast) route-map WORD",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" route-map WORD",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes matching the route-map\n"
        "A route-map to match on\n")
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_show_route_map (vty, NULL, argv[1], AFI_IP, SAFI_MULTICAST,
-			       bgp_show_type_route_map);
-
-  return bgp_show_route_map (vty, NULL, argv[1], AFI_IP, SAFI_UNICAST,
-			     bgp_show_type_route_map);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_show_route_map (vty, NULL, argv[1], AFI_IP, safi,
+                             bgp_show_type_route_map);
 }
 
 DEFUN (show_bgp_route_map, 
@@ -9919,21 +9895,18 @@ ALIAS (show_ip_bgp_flap_cidr_only,
 
 DEFUN (show_ip_bgp_ipv4_cidr_only,
        show_ip_bgp_ipv4_cidr_only_cmd,
-       "show ip bgp ipv4 (unicast|multicast) cidr-only",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" cidr-only",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display only routes with non-natural netmasks\n")
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_show (vty, NULL, AFI_IP, SAFI_MULTICAST,
-		     bgp_show_type_cidr_only, NULL, 0);
-
-  return bgp_show (vty, NULL, AFI_IP, SAFI_UNICAST,
-		   bgp_show_type_cidr_only, NULL, 0);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_show (vty, NULL, AFI_IP, safi,
+                   bgp_show_type_cidr_only, NULL, 0);
 }
 
 DEFUN (show_ip_bgp_community_all,
@@ -9950,21 +9923,18 @@ DEFUN (show_ip_bgp_community_all,
 
 DEFUN (show_ip_bgp_ipv4_community_all,
        show_ip_bgp_ipv4_community_all_cmd,
-       "show ip bgp ipv4 (unicast|multicast) community",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes matching the communities\n")
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_show (vty, NULL, AFI_IP, SAFI_MULTICAST,
-		     bgp_show_type_community_all, NULL, 0);
- 
-  return bgp_show (vty, NULL, AFI_IP, SAFI_UNICAST,
-		   bgp_show_type_community_all, NULL, 0);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_show (vty, NULL, AFI_IP, safi,
+                   bgp_show_type_community_all, NULL, 0);
 }
 
 #ifdef HAVE_IPV6
@@ -10156,34 +10126,31 @@ ALIAS (show_ip_bgp_community,
 
 DEFUN (show_ip_bgp_ipv4_community,
        show_ip_bgp_ipv4_community_cmd,
-       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export)",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
        "Do not advertise to any peer (well-known community)\n"
        "Do not export to next AS (well-known community)\n")
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_show_community (vty, NULL, argc, argv, 0, AFI_IP, SAFI_MULTICAST);
- 
-  return bgp_show_community (vty, NULL, argc, argv, 0, AFI_IP, SAFI_UNICAST);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_show_community (vty, NULL, argc, argv, 0, AFI_IP, safi);
 }
 
 ALIAS (show_ip_bgp_ipv4_community,
        show_ip_bgp_ipv4_community2_cmd,
-       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -10196,13 +10163,12 @@ ALIAS (show_ip_bgp_ipv4_community,
 	
 ALIAS (show_ip_bgp_ipv4_community,
        show_ip_bgp_ipv4_community3_cmd,
-       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -10219,13 +10185,12 @@ ALIAS (show_ip_bgp_ipv4_community,
 	
 ALIAS (show_ip_bgp_ipv4_community,
        show_ip_bgp_ipv4_community4_cmd,
-       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -10246,14 +10211,11 @@ ALIAS (show_ip_bgp_ipv4_community,
 
 DEFUN (show_bgp_instance_afi_safi_community_all,
        show_bgp_instance_afi_safi_community_all_cmd,
-       "show bgp " BGP_INSTANCE_CMD " (ipv4|ipv6) (unicast|multicast) community",
+       "show bgp " BGP_INSTANCE_CMD " "BGP_AFI_SAFI_CMD_STR" community",
        SHOW_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
-       "Address family\n"
-       "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_AFI_SAFI_HELP_STR
        "Display routes matching the communities\n")
 {
   int afi;
@@ -10268,14 +10230,14 @@ DEFUN (show_bgp_instance_afi_safi_community_all,
       return CMD_WARNING;
     }
 
-  afi = (strncmp (argv[2], "ipv6", 4) == 0) ? AFI_IP6 : AFI_IP;
-  safi = (strncmp (argv[3], "m", 1) == 0) ? SAFI_MULTICAST : SAFI_UNICAST;
+  afi = bgp_vty_safi_from_arg(argv[2]);
+  safi = bgp_vty_safi_from_arg(argv[3]);
   return bgp_show (vty, bgp, afi, safi, bgp_show_type_community_all, NULL, 0);
 }
 
 DEFUN (show_bgp_instance_afi_safi_community,
        show_bgp_instance_afi_safi_community_cmd,
-       "show bgp " BGP_INSTANCE_CMD " (ipv4|ipv6) (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export)",
+       "show bgp " BGP_INSTANCE_CMD " "BGP_AFI_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
@@ -10292,14 +10254,14 @@ DEFUN (show_bgp_instance_afi_safi_community,
   int afi;
   int safi;
 
-  afi = (strncmp (argv[2], "ipv6", 4) == 0) ? AFI_IP6 : AFI_IP;
-  safi = (strncmp (argv[3], "m", 1) == 0) ? SAFI_MULTICAST : SAFI_UNICAST;
+  afi = bgp_vty_safi_from_arg(argv[2]);
+  safi = bgp_vty_safi_from_arg(argv[3]);
   return bgp_show_community (vty, argv[1], argc-4, &argv[4], 0, afi, safi);
 }
 
 ALIAS (show_bgp_instance_afi_safi_community,
        show_bgp_instance_afi_safi_community2_cmd,
-       "show bgp " BGP_INSTANCE_CMD " (ipv4|ipv6) (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
+       "show bgp " BGP_INSTANCE_CMD " "BGP_AFI_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
@@ -10319,7 +10281,7 @@ ALIAS (show_bgp_instance_afi_safi_community,
 
 ALIAS (show_bgp_instance_afi_safi_community,
        show_bgp_instance_afi_safi_community3_cmd,
-       "show bgp " BGP_INSTANCE_CMD " (ipv4|ipv6) (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
+       "show bgp " BGP_INSTANCE_CMD " "BGP_AFI_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
@@ -10343,7 +10305,7 @@ ALIAS (show_bgp_instance_afi_safi_community,
 
 ALIAS (show_bgp_instance_afi_safi_community,
        show_bgp_instance_afi_safi_community4_cmd,
-       "show bgp " BGP_INSTANCE_CMD " (ipv4|ipv6) (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
+       "show bgp " BGP_INSTANCE_CMD " "BGP_AFI_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
@@ -10450,13 +10412,12 @@ ALIAS (show_ip_bgp_community_exact,
 
 DEFUN (show_ip_bgp_ipv4_community_exact,
        show_ip_bgp_ipv4_community_exact_cmd,
-       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) exact-match",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) exact-match",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -10464,21 +10425,19 @@ DEFUN (show_ip_bgp_ipv4_community_exact,
        "Do not export to next AS (well-known community)\n"
        "Exact match of the communities")
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_show_community (vty, NULL, argc, argv, 1, AFI_IP, SAFI_MULTICAST);
- 
-  return bgp_show_community (vty, NULL, argc, argv, 1, AFI_IP, SAFI_UNICAST);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_show_community (vty, NULL, argc, argv, 1, AFI_IP, safi);
 }
 
 ALIAS (show_ip_bgp_ipv4_community_exact,
        show_ip_bgp_ipv4_community2_exact_cmd,
-       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) exact-match",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) exact-match",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -10492,13 +10451,12 @@ ALIAS (show_ip_bgp_ipv4_community_exact,
 
 ALIAS (show_ip_bgp_ipv4_community_exact,
        show_ip_bgp_ipv4_community3_exact_cmd,
-       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) exact-match",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) exact-match",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -10516,13 +10474,12 @@ ALIAS (show_ip_bgp_ipv4_community_exact,
        
 ALIAS (show_ip_bgp_ipv4_community_exact,
        show_ip_bgp_ipv4_community4_exact_cmd,
-       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) exact-match",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) exact-match",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -11222,21 +11179,19 @@ DEFUN (show_ip_bgp_instance_community_list,
 
 DEFUN (show_ip_bgp_ipv4_community_list,
        show_ip_bgp_ipv4_community_list_cmd,
-       "show ip bgp ipv4 (unicast|multicast) community-list (<1-500>|WORD)",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community-list (<1-500>|WORD)",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes matching the community-list\n"
        "community-list number\n"
        "community-list name\n")
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_show_community_list (vty, NULL, argv[1], 0, AFI_IP, SAFI_MULTICAST);
-  
-  return bgp_show_community_list (vty, NULL, argv[1], 0, AFI_IP, SAFI_UNICAST);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_show_community_list (vty, NULL, argv[1], 0, AFI_IP, safi);
 }
 
 DEFUN (show_ip_bgp_community_list_exact,
@@ -11255,22 +11210,20 @@ DEFUN (show_ip_bgp_community_list_exact,
 
 DEFUN (show_ip_bgp_ipv4_community_list_exact,
        show_ip_bgp_ipv4_community_list_exact_cmd,
-       "show ip bgp ipv4 (unicast|multicast) community-list (<1-500>|WORD) exact-match",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community-list (<1-500>|WORD) exact-match",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Display routes matching the community-list\n"
        "community-list number\n"
        "community-list name\n"
        "Exact match of the communities\n")
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_show_community_list (vty, NULL, argv[1], 1, AFI_IP, SAFI_MULTICAST);
- 
-  return bgp_show_community_list (vty, NULL, argv[1], 1, AFI_IP, SAFI_UNICAST);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_show_community_list (vty, NULL, argv[1], 1, AFI_IP, safi);
 }
 
 #ifdef HAVE_IPV6
@@ -11462,22 +11415,19 @@ ALIAS (show_ip_bgp_flap_prefix_longer,
 
 DEFUN (show_ip_bgp_ipv4_prefix_longer,
        show_ip_bgp_ipv4_prefix_longer_cmd,
-       "show ip bgp ipv4 (unicast|multicast) A.B.C.D/M longer-prefixes",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" A.B.C.D/M longer-prefixes",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "IP prefix <network>/<length>, e.g., 35.0.0.0/8\n"
        "Display route and more specific routes\n")
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_show_prefix_longer (vty, NULL, argv[1], AFI_IP, SAFI_MULTICAST,
-				   bgp_show_type_prefix_longer);
-
-  return bgp_show_prefix_longer (vty, NULL, argv[1], AFI_IP, SAFI_UNICAST,
-				 bgp_show_type_prefix_longer);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_show_prefix_longer (vty, NULL, argv[1], AFI_IP, safi,
+                                 bgp_show_type_prefix_longer);
 }
 
 DEFUN (show_ip_bgp_flap_address,
@@ -11939,37 +11889,18 @@ bgp_table_stats_vty (struct vty *vty, const char *name,
       vty_out (vty, "%% No such BGP instance exists%s", VTY_NEWLINE);
       return CMD_WARNING;
     }
-  if (strncmp (afi_str, "ipv", 3) == 0)
-    {
-      if (strncmp (afi_str, "ipv4", 4) == 0)
-        afi = AFI_IP;
-      else if (strncmp (afi_str, "ipv6", 4) == 0)
-        afi = AFI_IP6;
-      else
-        {
-          vty_out (vty, "%% Invalid address family %s%s",
-                   afi_str, VTY_NEWLINE);
-          return CMD_WARNING;
-        }
-      if (strncmp (safi_str, "m", 1) == 0)
-        safi = SAFI_MULTICAST;
-      else if (strncmp (safi_str, "u", 1) == 0)
-        safi = SAFI_UNICAST;
-      else if (strncmp (safi_str, "e", 1) == 0)
-        safi = SAFI_ENCAP;
-      else if (strncmp (safi_str, "vpnv4", 5) == 0 || strncmp (safi_str, "vpnv6", 5) == 0)
-        safi = SAFI_MPLS_VPN;
-      else
-        {
-          vty_out (vty, "%% Invalid subsequent address family %s%s",
-                   safi_str, VTY_NEWLINE);
-            return CMD_WARNING;
-      }
-    }
-  else
+  afi  = bgp_vty_afi_from_arg(afi_str);
+  if (afi == AFI_MAX)
     {
       vty_out (vty, "%% Invalid address family \"%s\"%s",
                afi_str, VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  safi = bgp_vty_safi_from_arg(safi_str);
+  if (safi == SAFI_MAX)
+    {
+      vty_out (vty, "%% Invalid subsequent address family %s%s",
+               safi_str, VTY_NEWLINE);
       return CMD_WARNING;
     }
 
@@ -11978,15 +11909,10 @@ bgp_table_stats_vty (struct vty *vty, const char *name,
 
 DEFUN (show_bgp_statistics,
        show_bgp_statistics_cmd,
-       "show bgp (ipv4|ipv6) (encap|multicast|unicast|vpn) statistics",
+       "show bgp "BGP_AFI_SAFI_CMD_STR" statistics",
        SHOW_STR
        BGP_STR
-       "Address family\n"
-       "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_INSTANCE_HELP_STR
        "BGP RIB advertisement statistics\n")
 {
   return bgp_table_stats_vty (vty, NULL, argv[0], argv[1]);
@@ -11994,16 +11920,11 @@ DEFUN (show_bgp_statistics,
 
 DEFUN (show_bgp_statistics_view,
        show_bgp_statistics_view_cmd,
-       "show bgp " BGP_INSTANCE_CMD " (ipv4|ipv6) (unicast|multicast|vpn|encap) statistics",
+       "show bgp " BGP_INSTANCE_CMD " "BGP_AFI_SAFI_CMD_STR" statistics",
        SHOW_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
-       "Address family\n"
-       "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_AFI_SAFI_HELP_STR
        "BGP RIB advertisement statistics\n")
 {
   return bgp_table_stats_vty (vty, NULL, argv[1], argv[2]);
@@ -12296,13 +12217,12 @@ DEFUN (show_bgp_instance_ipv6_neighbor_prefix_counts,
 
 DEFUN (show_ip_bgp_ipv4_neighbor_prefix_counts,
        show_ip_bgp_ipv4_neighbor_prefix_counts_cmd,
-       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) prefix-counts {json}",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) prefix-counts {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -12317,10 +12237,9 @@ DEFUN (show_ip_bgp_ipv4_neighbor_prefix_counts,
   if (! peer)
     return CMD_WARNING;
 
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_peer_counts (vty, peer, AFI_IP, SAFI_MULTICAST, uj);
-
-  return bgp_peer_counts (vty, peer, AFI_IP, SAFI_UNICAST, uj);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_peer_counts (vty, peer, AFI_IP, safi, uj);
 }
 
 DEFUN (show_ip_bgp_vpnv4_neighbor_prefix_counts,
@@ -12330,8 +12249,7 @@ DEFUN (show_ip_bgp_vpnv4_neighbor_prefix_counts,
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -12674,13 +12592,12 @@ ALIAS (show_ip_bgp_instance_neighbor_advertised_route,
        "JavaScript Object Notation\n")
 DEFUN (show_ip_bgp_ipv4_neighbor_advertised_route,
        show_ip_bgp_ipv4_neighbor_advertised_route_cmd,
-       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) advertised-routes {json}",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) advertised-routes {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -12690,6 +12607,8 @@ DEFUN (show_ip_bgp_ipv4_neighbor_advertised_route,
 {
   struct peer *peer;
   const char *rmap_name = NULL;
+  safi_t safi;
+
   u_char uj = use_json(argc, argv); 
 
   peer = peer_lookup_in_view (vty, NULL, argv[1], uj);
@@ -12699,21 +12618,18 @@ DEFUN (show_ip_bgp_ipv4_neighbor_advertised_route,
   if ((argc == 4) || (argc == 3 && argv[2] && strcmp(argv[2], "json") != 0))
     rmap_name = argv[2];
 
-  if (strncmp (argv[0], "m", 1) == 0)
-    return peer_adj_routes (vty, peer, AFI_IP, SAFI_MULTICAST, 0, rmap_name, uj);
-  else
-    return peer_adj_routes (vty, peer, AFI_IP, SAFI_UNICAST, 0, rmap_name, uj);
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return peer_adj_routes (vty, peer, AFI_IP, safi, 0, rmap_name, uj);
 }
 
 ALIAS (show_ip_bgp_ipv4_neighbor_advertised_route,
        show_ip_bgp_ipv4_neighbor_advertised_route_rmap_cmd,
-       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) advertised-routes route-map WORD {json}",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) advertised-routes route-map WORD {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -12965,13 +12881,12 @@ ALIAS (show_ip_bgp_instance_neighbor_received_routes,
 
 DEFUN (show_ip_bgp_ipv4_neighbor_received_routes,
        show_ip_bgp_ipv4_neighbor_received_routes_cmd,
-       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) received-routes {json}",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) received-routes {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -12981,6 +12896,7 @@ DEFUN (show_ip_bgp_ipv4_neighbor_received_routes,
 {
   struct peer *peer;
   const char *rmap_name = NULL;
+  safi_t safi;
   u_char uj = use_json(argc, argv);
 
   peer = peer_lookup_in_view (vty, NULL, argv[1], uj);
@@ -12990,21 +12906,18 @@ DEFUN (show_ip_bgp_ipv4_neighbor_received_routes,
   if (argc == 4 || (argc == 3 && argv[2] && strcmp(argv[2], "json") != 0))
     rmap_name = argv[2];
 
-  if (strncmp (argv[0], "m", 1) == 0)
-    return peer_adj_routes (vty, peer, AFI_IP, SAFI_MULTICAST, 1, rmap_name, uj);
-  else
-    return peer_adj_routes (vty, peer, AFI_IP, SAFI_UNICAST, 1, rmap_name, uj);
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return peer_adj_routes (vty, peer, AFI_IP, safi, 1, rmap_name, uj);
 }
 
 ALIAS (show_ip_bgp_ipv4_neighbor_received_routes,
        show_ip_bgp_ipv4_neighbor_received_routes_rmap_cmd,
-       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) received-routes route-map WORD {json}",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) received-routes route-map WORD {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -13014,14 +12927,11 @@ ALIAS (show_ip_bgp_ipv4_neighbor_received_routes,
 
 DEFUN (show_bgp_instance_afi_safi_neighbor_adv_recd_routes,
        show_bgp_instance_afi_safi_neighbor_adv_recd_routes_cmd,
-       "show bgp " BGP_INSTANCE_CMD " (ipv4|ipv6) (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) (advertised-routes|received-routes) {json}",
+       "show bgp " BGP_INSTANCE_CMD " "BGP_AFI_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) (advertised-routes|received-routes) {json}",
        SHOW_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
-       "Address family\n"
-       "Address family\n"
-       "Address family modifier\n"
-       "Address family modifier\n"
+       BGP_AFI_SAFI_HELP_STR
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -13041,8 +12951,8 @@ DEFUN (show_bgp_instance_afi_safi_neighbor_adv_recd_routes,
   if (! peer)
     return CMD_WARNING;
 
-  afi = (strncmp (argv[2], "ipv6", 4) == 0) ? AFI_IP6 : AFI_IP;
-  safi = (strncmp (argv[3], "m", 1) == 0) ? SAFI_MULTICAST : SAFI_UNICAST;
+  afi = bgp_vty_safi_from_arg(argv[2]);
+  safi = bgp_vty_safi_from_arg(argv[3]);
   in = (strncmp (argv[5], "r", 1) == 0) ? 1 : 0;
 
   return peer_adj_routes (vty, peer, afi, safi, in, NULL, uj);
@@ -13137,13 +13047,12 @@ DEFUN (show_ip_bgp_neighbor_received_prefix_filter,
 
 DEFUN (show_ip_bgp_ipv4_neighbor_received_prefix_filter,
        show_ip_bgp_ipv4_neighbor_received_prefix_filter_cmd,
-       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) received prefix-filter {json}",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) received prefix-filter {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -13200,38 +13109,16 @@ DEFUN (show_ip_bgp_ipv4_neighbor_received_prefix_filter,
         }
     }
 
-  if (strncmp (argv[0], "m", 1) == 0)
     {
-      sprintf (name, "%s.%d.%d", peer->host, AFI_IP, SAFI_MULTICAST);
+      safi_t safi;
+      safi = bgp_vty_safi_from_arg(argv[0]);
+      sprintf (name, "%s.%d.%d", peer->host, AFI_IP, safi);
       count =  prefix_bgp_show_prefix_list (NULL, AFI_IP, name, uj);
       if (count)
         {
           if (!uj)
-            vty_out (vty, "Address family: IPv4 Multicast%s", VTY_NEWLINE);
-          prefix_bgp_show_prefix_list (vty, AFI_IP, name, uj);
-        }
-      else
-        {
-          if (uj)
-            {
-              json_object *json_no = NULL;
-              json_no = json_object_new_object();
-              json_object_boolean_true_add(json_no, "noFuntionalOutput");
-              vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
-              json_object_free(json_no);
-            }
-          else
-            vty_out (vty, "No functional output%s", VTY_NEWLINE);
-        }
-    }
-  else 
-    {
-      sprintf (name, "%s.%d.%d", peer->host, AFI_IP, SAFI_UNICAST);
-      count =  prefix_bgp_show_prefix_list (NULL, AFI_IP, name, uj);
-      if (count)
-        {
-          if (!uj)
-            vty_out (vty, "Address family: IPv4 Unicast%s", VTY_NEWLINE);
+            vty_out (vty, "Address family: %s%s", 
+                     afi_safi_print (AFI_IP, safi), VTY_NEWLINE);
           prefix_bgp_show_prefix_list (vty, AFI_IP, name, uj);
         }
       else
@@ -13660,13 +13547,12 @@ DEFUN (show_ip_bgp_neighbor_damp,
 
 DEFUN (show_ip_bgp_ipv4_neighbor_routes,
        show_ip_bgp_ipv4_neighbor_routes_cmd,
-       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) routes {json}",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) routes {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -13675,18 +13561,16 @@ DEFUN (show_ip_bgp_ipv4_neighbor_routes,
        "JavaScript Object Notation\n")
 {
   struct peer *peer;
+  safi_t safi;
   u_char uj = use_json(argc, argv);
 
   peer = peer_lookup_in_view (vty, NULL, argv[1], uj);
   if (! peer)
     return CMD_WARNING;
  
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_show_neighbor_route (vty, peer, AFI_IP, SAFI_MULTICAST,
-				    bgp_show_type_neighbor, uj);
-
-  return bgp_show_neighbor_route (vty, peer, AFI_IP, SAFI_UNICAST,
-				  bgp_show_type_neighbor, uj);
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_show_neighbor_route (vty, peer, AFI_IP, safi,
+                                  bgp_show_type_neighbor, uj);
 }
 
 #ifdef HAVE_IPV6

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8297,22 +8297,6 @@ ALIAS (show_ip_bgp_ipv4_route,
        "Network in the BGP routing table to display\n"
        "JavaScript Object Notation\n")
 
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-DEFUN (show_ip_bgp_vpnv4_all_route,
-       show_ip_bgp_vpnv4_all_route_cmd,
-       "show ip bgp vpnv4 all A.B.C.D {json}",
-       SHOW_STR
-       IP_STR
-       BGP_STR
-       "Display VPNv4 NLRI specific information\n"
-       "Display information about all VPNv4 NLRIs\n"
-       "Network in the BGP routing table to display\n"
-       "JavaScript Object Notation\n")
-{
-  return bgp_show_route (vty, NULL, argv[0], AFI_IP, SAFI_MPLS_VPN, NULL, 0, BGP_PATH_ALL, use_json(argc, argv));
-}
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
-
 DEFUN (show_bgp_ipv4_safi_rd_route,
        show_bgp_ipv4_safi_rd_route_cmd,
        "show bgp ipv4 (encap|vpn) rd ASN:nn_or_IP-address:nn A.B.C.D {json}",
@@ -8432,33 +8416,6 @@ DEFUN (show_bgp_ipv6_safi_rd_prefix,
   return bgp_show_route (vty, NULL, argv[2], AFI_IP6, safi, &prd, 1, BGP_PATH_ALL, use_json (argc, argv));
 }
 
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-DEFUN (show_ip_bgp_vpnv4_rd_route,
-       show_ip_bgp_vpnv4_rd_route_cmd,
-       "show ip bgp vpnv4 rd ASN:nn_or_IP-address:nn A.B.C.D {json}",
-       SHOW_STR
-       IP_STR
-       BGP_STR
-       "Display VPNv4 NLRI specific information\n"
-       "Display information for a route distinguisher\n"
-       "VPN Route Distinguisher\n"
-       "Network in the BGP routing table to display\n"
-       "JavaScript Object Notation\n")
-{
-  int ret;
-  struct prefix_rd prd;
-  u_char uj= use_json(argc, argv);
-
-  ret = str2prefix_rd (argv[0], &prd);
-  if (! ret)
-    {
-      vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
-      return CMD_WARNING;
-    }
-  return bgp_show_route (vty, NULL, argv[1], AFI_IP, SAFI_MPLS_VPN, &prd, 0, BGP_PATH_ALL, uj);
-}
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
-
 DEFUN (show_ip_bgp_prefix,
        show_ip_bgp_prefix_cmd,
        "show ip bgp A.B.C.D/M {json}",
@@ -8550,45 +8507,6 @@ ALIAS (show_ip_bgp_ipv4_prefix_pathtype,
        "Display only multipaths\n"
        "JavaScript Object Notation\n")
 
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-DEFUN (show_ip_bgp_vpnv4_all_prefix,
-       show_ip_bgp_vpnv4_all_prefix_cmd,
-       "show ip bgp vpnv4 all A.B.C.D/M {json}",
-       SHOW_STR
-       IP_STR
-       BGP_STR
-       "Display VPNv4 NLRI specific information\n"
-       "Display information about all VPNv4 NLRIs\n"
-       "IP prefix <network>/<length>, e.g., 35.0.0.0/8\n"
-       "JavaScript Object Notation\n")
-{
-  return bgp_show_route (vty, NULL, argv[0], AFI_IP, SAFI_MPLS_VPN, NULL, 1, BGP_PATH_ALL, use_json(argc, argv));
-}
-
-DEFUN (show_ip_bgp_vpnv4_rd_prefix,
-       show_ip_bgp_vpnv4_rd_prefix_cmd,
-       "show ip bgp vpnv4 rd ASN:nn_or_IP-address:nn A.B.C.D/M {json}",
-       SHOW_STR
-       IP_STR
-       BGP_STR
-       "Display VPNv4 NLRI specific information\n"
-       "Display information for a route distinguisher\n"
-       "VPN Route Distinguisher\n"
-       "IP prefix <network>/<length>, e.g., 35.0.0.0/8\n"
-       "JavaScript Object Notation\n")
-{
-  int ret;
-  struct prefix_rd prd;
-
-  ret = str2prefix_rd (argv[0], &prd);
-  if (! ret)
-    {
-      vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
-      return CMD_WARNING;
-    }
-  return bgp_show_route (vty, NULL, argv[1], AFI_IP, SAFI_MPLS_VPN, &prd, 0, BGP_PATH_ALL, use_json(argc, argv));
-}
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (show_ip_bgp_view,
        show_ip_bgp_instance_cmd,
@@ -12248,33 +12166,6 @@ DEFUN (show_ip_bgp_ipv4_neighbor_prefix_counts,
   return bgp_peer_counts (vty, peer, AFI_IP, safi, uj);
 }
 
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-DEFUN (show_ip_bgp_vpnv4_neighbor_prefix_counts,
-       show_ip_bgp_vpnv4_neighbor_prefix_counts_cmd,
-       "show ip bgp vpnv4 all neighbors (A.B.C.D|X:X::X:X|WORD) prefix-counts {json}",
-       SHOW_STR
-       IP_STR
-       BGP_STR
-       "Address family\n"
-       BGP_SAFI_HELP_STR
-       "Detailed information on TCP and BGP neighbor connections\n"
-       "Neighbor to display information about\n"
-       "Neighbor to display information about\n"
-       "Neighbor on bgp configured interface\n"
-       "Display detailed prefix count information\n"
-       "JavaScript Object Notation\n")
-{
-  struct peer *peer;
-  u_char uj = use_json(argc, argv);
-
-  peer = peer_lookup_in_view (vty, NULL, argv[0], uj);
-  if (! peer)
-    return CMD_WARNING;
-  
-  return bgp_peer_counts (vty, peer, AFI_IP, SAFI_MPLS_VPN, uj);
-}
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
-
 static void
 show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
                 int in, const char *rmap_name, u_char use_json, json_object *json)
@@ -14784,10 +14675,6 @@ bgp_route_init (void)
   install_element (VIEW_NODE, &show_bgp_ipv4_safi_route_pathtype_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_ipv4_route_cmd);
   install_element (VIEW_NODE, &show_bgp_ipv4_safi_route_cmd);
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-  install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_route_cmd);
-  install_element (VIEW_NODE, &show_ip_bgp_vpnv4_rd_route_cmd);
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
   install_element (VIEW_NODE, &show_ip_bgp_prefix_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_instance_prefix_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_ipv4_prefix_cmd);
@@ -14796,10 +14683,6 @@ bgp_route_init (void)
   install_element (VIEW_NODE, &show_bgp_ipv4_safi_prefix_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_prefix_pathtype_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_instance_prefix_pathtype_cmd);
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-  install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_prefix_cmd);
-  install_element (VIEW_NODE, &show_ip_bgp_vpnv4_rd_prefix_cmd);
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
   install_element (VIEW_NODE, &show_ip_bgp_regexp_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_ipv4_regexp_cmd);
@@ -14904,9 +14787,6 @@ bgp_route_init (void)
   install_element (ENABLE_NODE, &show_ip_bgp_neighbor_prefix_counts_cmd);
   install_element (ENABLE_NODE, &show_ip_bgp_instance_neighbor_prefix_counts_cmd);
   install_element (ENABLE_NODE, &show_ip_bgp_ipv4_neighbor_prefix_counts_cmd);
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-  install_element (ENABLE_NODE, &show_ip_bgp_vpnv4_neighbor_prefix_counts_cmd);
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 #ifdef HAVE_IPV6
   install_element (ENABLE_NODE, &show_bgp_ipv6_neighbor_prefix_counts_cmd);
   install_element (ENABLE_NODE, &show_bgp_instance_ipv6_neighbor_prefix_counts_cmd);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8297,6 +8297,7 @@ ALIAS (show_ip_bgp_ipv4_route,
        "Network in the BGP routing table to display\n"
        "JavaScript Object Notation\n")
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (show_ip_bgp_vpnv4_all_route,
        show_ip_bgp_vpnv4_all_route_cmd,
        "show ip bgp vpnv4 all A.B.C.D {json}",
@@ -8310,6 +8311,7 @@ DEFUN (show_ip_bgp_vpnv4_all_route,
 {
   return bgp_show_route (vty, NULL, argv[0], AFI_IP, SAFI_MPLS_VPN, NULL, 0, BGP_PATH_ALL, use_json(argc, argv));
 }
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (show_bgp_ipv4_safi_rd_route,
        show_bgp_ipv4_safi_rd_route_cmd,
@@ -8430,6 +8432,7 @@ DEFUN (show_bgp_ipv6_safi_rd_prefix,
   return bgp_show_route (vty, NULL, argv[2], AFI_IP6, safi, &prd, 1, BGP_PATH_ALL, use_json (argc, argv));
 }
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (show_ip_bgp_vpnv4_rd_route,
        show_ip_bgp_vpnv4_rd_route_cmd,
        "show ip bgp vpnv4 rd ASN:nn_or_IP-address:nn A.B.C.D {json}",
@@ -8454,6 +8457,7 @@ DEFUN (show_ip_bgp_vpnv4_rd_route,
     }
   return bgp_show_route (vty, NULL, argv[1], AFI_IP, SAFI_MPLS_VPN, &prd, 0, BGP_PATH_ALL, uj);
 }
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (show_ip_bgp_prefix,
        show_ip_bgp_prefix_cmd,
@@ -8546,6 +8550,7 @@ ALIAS (show_ip_bgp_ipv4_prefix_pathtype,
        "Display only multipaths\n"
        "JavaScript Object Notation\n")
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (show_ip_bgp_vpnv4_all_prefix,
        show_ip_bgp_vpnv4_all_prefix_cmd,
        "show ip bgp vpnv4 all A.B.C.D/M {json}",
@@ -8583,6 +8588,7 @@ DEFUN (show_ip_bgp_vpnv4_rd_prefix,
     }
   return bgp_show_route (vty, NULL, argv[1], AFI_IP, SAFI_MPLS_VPN, &prd, 0, BGP_PATH_ALL, use_json(argc, argv));
 }
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (show_ip_bgp_view,
        show_ip_bgp_instance_cmd,
@@ -12242,6 +12248,7 @@ DEFUN (show_ip_bgp_ipv4_neighbor_prefix_counts,
   return bgp_peer_counts (vty, peer, AFI_IP, safi, uj);
 }
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (show_ip_bgp_vpnv4_neighbor_prefix_counts,
        show_ip_bgp_vpnv4_neighbor_prefix_counts_cmd,
        "show ip bgp vpnv4 all neighbors (A.B.C.D|X:X::X:X|WORD) prefix-counts {json}",
@@ -12266,6 +12273,7 @@ DEFUN (show_ip_bgp_vpnv4_neighbor_prefix_counts,
   
   return bgp_peer_counts (vty, peer, AFI_IP, SAFI_MPLS_VPN, uj);
 }
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 static void
 show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
@@ -14776,8 +14784,10 @@ bgp_route_init (void)
   install_element (VIEW_NODE, &show_bgp_ipv4_safi_route_pathtype_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_ipv4_route_cmd);
   install_element (VIEW_NODE, &show_bgp_ipv4_safi_route_cmd);
+#ifdef KEEP_OLD_VPNV4_COMMANDS
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_route_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_rd_route_cmd);
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
   install_element (VIEW_NODE, &show_ip_bgp_prefix_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_instance_prefix_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_ipv4_prefix_cmd);
@@ -14786,8 +14796,10 @@ bgp_route_init (void)
   install_element (VIEW_NODE, &show_bgp_ipv4_safi_prefix_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_prefix_pathtype_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_instance_prefix_pathtype_cmd);
+#ifdef KEEP_OLD_VPNV4_COMMANDS
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_prefix_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_rd_prefix_cmd);
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
   install_element (VIEW_NODE, &show_ip_bgp_regexp_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_ipv4_regexp_cmd);
@@ -14892,7 +14904,9 @@ bgp_route_init (void)
   install_element (ENABLE_NODE, &show_ip_bgp_neighbor_prefix_counts_cmd);
   install_element (ENABLE_NODE, &show_ip_bgp_instance_neighbor_prefix_counts_cmd);
   install_element (ENABLE_NODE, &show_ip_bgp_ipv4_neighbor_prefix_counts_cmd);
+#ifdef KEEP_OLD_VPNV4_COMMANDS
   install_element (ENABLE_NODE, &show_ip_bgp_vpnv4_neighbor_prefix_counts_cmd);
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 #ifdef HAVE_IPV6
   install_element (ENABLE_NODE, &show_bgp_ipv6_neighbor_prefix_counts_cmd);
   install_element (ENABLE_NODE, &show_bgp_instance_ipv6_neighbor_prefix_counts_cmd);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6416,7 +6416,8 @@ route_vty_out_tmp (struct vty *vty, struct prefix *p, struct attr *attr, safi_t 
                safi == SAFI_ENCAP ||
                !BGP_ATTR_NEXTHOP_AFI_IP6(attr)))
             {
-              if (safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP)
+              if (attr->extra && 
+                  (safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP))
                 vty_out (vty, "%-16s",
                          inet_ntoa (attr->extra->mp_nexthop_global_in));
               else
@@ -6427,13 +6428,15 @@ route_vty_out_tmp (struct vty *vty, struct prefix *p, struct attr *attr, safi_t 
             {
               int len;
               char buf[BUFSIZ];
-
-              assert (attr->extra);
-
-              len = vty_out (vty, "%s",
-                             inet_ntop (AF_INET6, &attr->extra->mp_nexthop_global,
-                             buf, BUFSIZ));
-              len = 16 - len;
+              if (attr->extra)
+                {
+                  len = vty_out (vty, "%s",
+                                 inet_ntop (AF_INET6, &attr->extra->mp_nexthop_global,
+                                            buf, BUFSIZ));
+                  len = 16 - len;
+                }
+              else
+                len = 0;
               if (len < 1)
                 vty_out (vty, "%s%*s", VTY_NEWLINE, 36, " ");
               else

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2342,64 +2342,6 @@ struct route_map_rule_cmd route_set_ipv6_nexthop_peer_cmd =
 
 #endif /* HAVE_IPV6 */
 
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-/* `set ip vpn nexthop A.B.C.D' */
-static route_map_result_t
-route_set_vpnv4_nexthop (void *rule, struct prefix *prefix, 
-			 route_map_object_t type, void *object)
-{
-  struct in_addr *address;
-  struct bgp_info *bgp_info;
-
-  if (type == RMAP_BGP)
-    {
-      /* Fetch routemap's rule information. */
-      address = rule;
-      bgp_info = object;
-    
-      /* Set next hop value. */ 
-      (bgp_attr_extra_get (bgp_info->attr))->mp_nexthop_global_in = *address;
-      (bgp_attr_extra_get (bgp_info->attr))->mp_nexthop_len = 4;
-    }
-
-  return RMAP_OKAY;
-}
-
-static void *
-route_set_vpnv4_nexthop_compile (const char *arg)
-{
-  int ret;
-  struct in_addr *address;
-
-  address = XMALLOC (MTYPE_ROUTE_MAP_COMPILED, sizeof (struct in_addr));
-
-  ret = inet_aton (arg, address);
-
-  if (ret == 0)
-    {
-      XFREE (MTYPE_ROUTE_MAP_COMPILED, address);
-      return NULL;
-    }
-
-  return address;
-}
-
-static void
-route_set_vpnv4_nexthop_free (void *rule)
-{
-  XFREE (MTYPE_ROUTE_MAP_COMPILED, rule);
-}
-
-/* Route map commands for ip nexthop set. */
-struct route_map_rule_cmd route_set_vpnv4_nexthop_cmd =
-{
-  "ip vpn next-hop",
-  route_set_vpnv4_nexthop,
-  route_set_vpnv4_nexthop_compile,
-  route_set_vpnv4_nexthop_free
-};
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
-
 /* `set originator-id' */
 
 /* For origin set. */
@@ -4501,42 +4443,6 @@ ALIAS (no_set_ipv6_nexthop_local,
        "IPv6 address of next hop\n")
 #endif /* HAVE_IPV6 */
 
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-DEFUN (set_vpnv4_nexthop,
-       set_vpnv4_nexthop_cmd,
-       "set ip vpn next-hop A.B.C.D",
-       SET_STR
-       "IP VPN information\n"
-       "IP VPN next-hop address\n"
-       "IP address of next hop\n")
-{
-  return bgp_route_set_add (vty, vty->index, "ip vpn next-hop", argv[0]);
-}
-
-DEFUN (no_set_vpnv4_nexthop,
-       no_set_vpnv4_nexthop_cmd,
-       "no set ip vpn next-hop",
-       NO_STR
-       SET_STR
-       "IP VPN information\n"
-       "IP VPN next-hop address\n")
-{
-  if (argc == 0)
-    return bgp_route_set_delete (vty, vty->index, "ip vpn next-hop", NULL);
-
-  return bgp_route_set_delete (vty, vty->index, "ip vpn next-hop", argv[0]);
-}
-
-ALIAS (no_set_vpnv4_nexthop,
-       no_set_vpnv4_nexthop_val_cmd,
-       "no set ip vpn next-hop A.B.C.D",
-       NO_STR
-       SET_STR
-       "IP VPN information\n"
-       "IP VPN next-hop address\n"
-       "IP address of next hop\n")
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
-
 DEFUN (set_originator_id,
        set_originator_id_cmd,
        "set originator-id A.B.C.D",
@@ -4607,9 +4513,6 @@ bgp_route_map_init (void)
   route_map_install_set (&route_set_aggregator_as_cmd);
   route_map_install_set (&route_set_community_cmd);
   route_map_install_set (&route_set_community_delete_cmd);
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-  route_map_install_set (&route_set_vpnv4_nexthop_cmd);
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
   route_map_install_set (&route_set_originator_id_cmd);
   route_map_install_set (&route_set_ecommunity_rt_cmd);
   route_map_install_set (&route_set_ecommunity_soo_cmd);
@@ -4715,11 +4618,6 @@ bgp_route_map_init (void)
   install_element (RMAP_NODE, &set_ecommunity_soo_cmd);
   install_element (RMAP_NODE, &no_set_ecommunity_soo_cmd);
   install_element (RMAP_NODE, &no_set_ecommunity_soo_val_cmd);
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-  install_element (RMAP_NODE, &set_vpnv4_nexthop_cmd);
-  install_element (RMAP_NODE, &no_set_vpnv4_nexthop_cmd);
-  install_element (RMAP_NODE, &no_set_vpnv4_nexthop_val_cmd);
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
   install_element (RMAP_NODE, &set_originator_id_cmd);
   install_element (RMAP_NODE, &no_set_originator_id_cmd);
   install_element (RMAP_NODE, &no_set_originator_id_val_cmd);

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -2342,8 +2342,8 @@ struct route_map_rule_cmd route_set_ipv6_nexthop_peer_cmd =
 
 #endif /* HAVE_IPV6 */
 
-/* `set vpnv4 nexthop A.B.C.D' */
-
+#ifdef KEEP_OLD_VPNV4_COMMANDS
+/* `set ip vpn nexthop A.B.C.D' */
 static route_map_result_t
 route_set_vpnv4_nexthop (void *rule, struct prefix *prefix, 
 			 route_map_object_t type, void *object)
@@ -2393,11 +2393,12 @@ route_set_vpnv4_nexthop_free (void *rule)
 /* Route map commands for ip nexthop set. */
 struct route_map_rule_cmd route_set_vpnv4_nexthop_cmd =
 {
-  "vpnv4 next-hop",
+  "ip vpn next-hop",
   route_set_vpnv4_nexthop,
   route_set_vpnv4_nexthop_compile,
   route_set_vpnv4_nexthop_free
 };
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 /* `set originator-id' */
 
@@ -4500,39 +4501,41 @@ ALIAS (no_set_ipv6_nexthop_local,
        "IPv6 address of next hop\n")
 #endif /* HAVE_IPV6 */
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (set_vpnv4_nexthop,
        set_vpnv4_nexthop_cmd,
-       "set vpnv4 next-hop A.B.C.D",
+       "set ip vpn next-hop A.B.C.D",
        SET_STR
-       "VPNv4 information\n"
-       "VPNv4 next-hop address\n"
+       "IP VPN information\n"
+       "IP VPN next-hop address\n"
        "IP address of next hop\n")
 {
-  return bgp_route_set_add (vty, vty->index, "vpnv4 next-hop", argv[0]);
+  return bgp_route_set_add (vty, vty->index, "ip vpn next-hop", argv[0]);
 }
 
 DEFUN (no_set_vpnv4_nexthop,
        no_set_vpnv4_nexthop_cmd,
-       "no set vpnv4 next-hop",
+       "no set ip vpn next-hop",
        NO_STR
        SET_STR
-       "VPNv4 information\n"
-       "VPNv4 next-hop address\n")
+       "IP VPN information\n"
+       "IP VPN next-hop address\n")
 {
   if (argc == 0)
-    return bgp_route_set_delete (vty, vty->index, "vpnv4 next-hop", NULL);
+    return bgp_route_set_delete (vty, vty->index, "ip vpn next-hop", NULL);
 
-  return bgp_route_set_delete (vty, vty->index, "vpnv4 next-hop", argv[0]);
+  return bgp_route_set_delete (vty, vty->index, "ip vpn next-hop", argv[0]);
 }
 
 ALIAS (no_set_vpnv4_nexthop,
        no_set_vpnv4_nexthop_val_cmd,
-       "no set vpnv4 next-hop A.B.C.D",
+       "no set ip vpn next-hop A.B.C.D",
        NO_STR
        SET_STR
-       "VPNv4 information\n"
-       "VPNv4 next-hop address\n"
+       "IP VPN information\n"
+       "IP VPN next-hop address\n"
        "IP address of next hop\n")
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (set_originator_id,
        set_originator_id_cmd,
@@ -4604,7 +4607,9 @@ bgp_route_map_init (void)
   route_map_install_set (&route_set_aggregator_as_cmd);
   route_map_install_set (&route_set_community_cmd);
   route_map_install_set (&route_set_community_delete_cmd);
+#ifdef KEEP_OLD_VPNV4_COMMANDS
   route_map_install_set (&route_set_vpnv4_nexthop_cmd);
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
   route_map_install_set (&route_set_originator_id_cmd);
   route_map_install_set (&route_set_ecommunity_rt_cmd);
   route_map_install_set (&route_set_ecommunity_soo_cmd);
@@ -4710,9 +4715,11 @@ bgp_route_map_init (void)
   install_element (RMAP_NODE, &set_ecommunity_soo_cmd);
   install_element (RMAP_NODE, &no_set_ecommunity_soo_cmd);
   install_element (RMAP_NODE, &no_set_ecommunity_soo_val_cmd);
+#ifdef KEEP_OLD_VPNV4_COMMANDS
   install_element (RMAP_NODE, &set_vpnv4_nexthop_cmd);
   install_element (RMAP_NODE, &no_set_vpnv4_nexthop_cmd);
   install_element (RMAP_NODE, &no_set_vpnv4_nexthop_val_cmd);
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
   install_element (RMAP_NODE, &set_originator_id_cmd);
   install_element (RMAP_NODE, &no_set_originator_id_cmd);
   install_element (RMAP_NODE, &no_set_originator_id_val_cmd);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6139,15 +6139,6 @@ DEFUN (address_family_vpnv4,
   return CMD_SUCCESS;
 }
 
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-ALIAS (address_family_vpnv4,
-       address_family_vpnv4_unicast_cmd,
-       "address-family vpnv4 unicast",
-       "Enter Address Family command mode\n"
-       "Address family\n"
-       "Address Family Modifier\n")
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
-
 DEFUN (address_family_vpnv6,
        address_family_vpnv6_cmd,
        "address-family vpnv6",
@@ -6157,15 +6148,6 @@ DEFUN (address_family_vpnv6,
   vty->node = BGP_VPNV6_NODE;
   return CMD_SUCCESS;
 }
-
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-ALIAS (address_family_vpnv6,
-       address_family_vpnv6_unicast_cmd,
-       "address-family vpnv6 unicast",
-       "Enter Address Family command mode\n"
-       "Address family\n"
-       "Address Family Modifier\n")
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (address_family_encap,
        address_family_encap_cmd,
@@ -6734,62 +6716,6 @@ ALIAS (clear_ip_bgp_instance_all_ipv4_soft_out,
        BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-DEFUN (clear_ip_bgp_all_vpnv4_soft_out,
-       clear_ip_bgp_all_vpnv4_soft_out_cmd,
-       "clear ip bgp * vpnv4 unicast soft out",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear all peers\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       BGP_SOFT_STR
-       BGP_SOFT_OUT_STR)
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MPLS_VPN, clear_all,
-			BGP_CLEAR_SOFT_OUT, NULL);
-}
-
-ALIAS (clear_ip_bgp_all_vpnv4_soft_out,
-       clear_ip_bgp_all_vpnv4_out_cmd,
-       "clear ip bgp * vpnv4 unicast out",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear all peers\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       BGP_SOFT_OUT_STR)
-
-DEFUN (clear_ip_bgp_all_encap_soft_out,
-       clear_ip_bgp_all_encap_soft_out_cmd,
-       "clear ip bgp * encap unicast soft out",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear all peers\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       "Soft reconfig\n"
-       "Soft reconfig outbound update\n")
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_ENCAP, clear_all,
-			BGP_CLEAR_SOFT_OUT, NULL);
-}
-
-ALIAS (clear_ip_bgp_all_encap_soft_out,
-       clear_ip_bgp_all_encap_out_cmd,
-       "clear ip bgp * encap unicast out",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear all peers\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       "Soft reconfig outbound update\n")
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
-
 DEFUN (clear_bgp_all_soft_out,
        clear_bgp_all_soft_out_cmd,
        "clear bgp * soft out",
@@ -7020,65 +6946,6 @@ ALIAS (clear_ip_bgp_instance_peer_ipv4_soft_out,
        "Address family\n"
        BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
-
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-/* NOTE: WORD peers have not been tested for vpnv4 */
-DEFUN (clear_ip_bgp_peer_vpnv4_soft_out,
-       clear_ip_bgp_peer_vpnv4_soft_out_cmd,
-       "clear ip bgp (A.B.C.D|WORD) vpnv4 unicast soft out",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "BGP neighbor address to clear\n"
-       "BGP neighbor on interface to clear\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       BGP_SOFT_STR
-       BGP_SOFT_OUT_STR)
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MPLS_VPN, clear_peer,
-			BGP_CLEAR_SOFT_OUT, argv[0]);
-}
-
-ALIAS (clear_ip_bgp_peer_vpnv4_soft_out,
-       clear_ip_bgp_peer_vpnv4_out_cmd,
-       "clear ip bgp (A.B.C.D|WORD) vpnv4 unicast out",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "BGP neighbor address to clear\n"
-       "BGP neighbor on interface to clear\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       BGP_SOFT_OUT_STR)
-
-DEFUN (clear_ip_bgp_peer_encap_soft_out,
-       clear_ip_bgp_peer_encap_soft_out_cmd,
-       "clear ip bgp A.B.C.D encap unicast soft out",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "BGP neighbor address to clear\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       "Soft reconfig\n"
-       "Soft reconfig outbound update\n")
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_ENCAP, clear_peer,
-			BGP_CLEAR_SOFT_OUT, argv[0]);
-}
-
-ALIAS (clear_ip_bgp_peer_encap_soft_out,
-       clear_ip_bgp_peer_encap_out_cmd,
-       "clear ip bgp A.B.C.D encap unicast out",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "BGP neighbor address to clear\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       "Soft reconfig outbound update\n")
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (clear_bgp_peer_soft_out,
        clear_bgp_peer_soft_out_cmd,
@@ -7688,62 +7555,6 @@ ALIAS (clear_ip_bgp_instance_as_ipv4_soft_out,
        BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-DEFUN (clear_ip_bgp_as_vpnv4_soft_out,
-       clear_ip_bgp_as_vpnv4_soft_out_cmd,
-       "clear ip bgp " CMD_AS_RANGE " vpnv4 unicast soft out",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear peers with the AS number\n"
-       "Address family\n"
-       "Address Family modifier\n"
-       BGP_SOFT_STR
-       BGP_SOFT_OUT_STR)
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MPLS_VPN, clear_as,
-			BGP_CLEAR_SOFT_OUT, argv[0]);
-}
-
-ALIAS (clear_ip_bgp_as_vpnv4_soft_out,
-       clear_ip_bgp_as_vpnv4_out_cmd,
-       "clear ip bgp " CMD_AS_RANGE " vpnv4 unicast out",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear peers with the AS number\n"
-       "Address family\n"
-       "Address Family modifier\n"
-       BGP_SOFT_OUT_STR)
-
-DEFUN (clear_ip_bgp_as_encap_soft_out,
-       clear_ip_bgp_as_encap_soft_out_cmd,
-       "clear ip bgp " CMD_AS_RANGE " encap unicast soft out",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear peers with the AS number\n"
-       "Address family\n"
-       "Address Family modifier\n"
-       "Soft reconfig\n"
-       "Soft reconfig outbound update\n")
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_ENCAP, clear_as,
-			BGP_CLEAR_SOFT_OUT, argv[0]);
-}
-
-ALIAS (clear_ip_bgp_as_encap_soft_out,
-       clear_ip_bgp_as_encap_out_cmd,
-       "clear ip bgp " CMD_AS_RANGE " encap unicast out",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear peers with the AS number\n"
-       "Address family\n"
-       "Address Family modifier\n"
-       "Soft reconfig outbound update\n")
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
-
 DEFUN (clear_bgp_as_soft_out,
        clear_bgp_as_soft_out_cmd,
        "clear bgp " CMD_AS_RANGE " soft out",
@@ -7972,62 +7783,6 @@ DEFUN (clear_ip_bgp_all_ipv4_in_prefix_filter,
   return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_all,
                         BGP_CLEAR_SOFT_IN_ORF_PREFIX, NULL);
 }
-
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-DEFUN (clear_ip_bgp_all_vpnv4_soft_in,
-       clear_ip_bgp_all_vpnv4_soft_in_cmd,
-       "clear ip bgp * vpnv4 unicast soft in",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear all peers\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       BGP_SOFT_STR
-       BGP_SOFT_IN_STR)
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MPLS_VPN, clear_all,
-			BGP_CLEAR_SOFT_IN, NULL);
-}
-
-ALIAS (clear_ip_bgp_all_vpnv4_soft_in,
-       clear_ip_bgp_all_vpnv4_in_cmd,
-       "clear ip bgp * vpnv4 unicast in",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear all peers\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       BGP_SOFT_IN_STR)
-
-DEFUN (clear_ip_bgp_all_encap_soft_in,
-       clear_ip_bgp_all_encap_soft_in_cmd,
-       "clear ip bgp * encap unicast soft in",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear all peers\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       "Soft reconfig\n"
-       "Soft reconfig inbound update\n")
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_ENCAP, clear_all,
-			BGP_CLEAR_SOFT_IN, NULL);
-}
-
-ALIAS (clear_ip_bgp_all_encap_soft_in,
-       clear_ip_bgp_all_encap_in_cmd,
-       "clear ip bgp * encap unicast in",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear all peers\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       "Soft reconfig inbound update\n")
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (clear_bgp_all_soft_in,
        clear_bgp_all_soft_in_cmd,
@@ -8285,64 +8040,6 @@ DEFUN (clear_ip_bgp_peer_ipv4_in_prefix_filter,
   return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_peer,
                         BGP_CLEAR_SOFT_IN_ORF_PREFIX, argv[0]);
 }
-
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-DEFUN (clear_ip_bgp_peer_vpnv4_soft_in,
-       clear_ip_bgp_peer_vpnv4_soft_in_cmd,
-       "clear ip bgp (A.B.C.D|WORD) vpnv4 unicast soft in",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "BGP neighbor address to clear\n"
-       "BGP neighbor on interface to clear\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       BGP_SOFT_STR
-       BGP_SOFT_IN_STR)
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MPLS_VPN, clear_peer,
-			BGP_CLEAR_SOFT_IN, argv[0]);
-}
-
-ALIAS (clear_ip_bgp_peer_vpnv4_soft_in,
-       clear_ip_bgp_peer_vpnv4_in_cmd,
-       "clear ip bgp (A.B.C.D|WORD) vpnv4 unicast in",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "BGP neighbor address to clear\n"
-       "BGP neighbor on interface to clear\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       BGP_SOFT_IN_STR)
-
-DEFUN (clear_ip_bgp_peer_encap_soft_in,
-       clear_ip_bgp_peer_encap_soft_in_cmd,
-       "clear ip bgp A.B.C.D encap unicast soft in",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "BGP neighbor address to clear\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       "Soft reconfig\n"
-       "Soft reconfig inbound update\n")
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_ENCAP, clear_peer,
-			BGP_CLEAR_SOFT_IN, argv[0]);
-}
-
-ALIAS (clear_ip_bgp_peer_encap_soft_in,
-       clear_ip_bgp_peer_encap_in_cmd,
-       "clear ip bgp A.B.C.D encap unicast in",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "BGP neighbor address to clear\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       "Soft reconfig inbound update\n")
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (clear_bgp_peer_soft_in,
        clear_bgp_peer_soft_in_cmd,
@@ -9125,62 +8822,6 @@ DEFUN (clear_ip_bgp_as_ipv4_in_prefix_filter,
                         BGP_CLEAR_SOFT_IN_ORF_PREFIX, argv[0]);
 }
 
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-DEFUN (clear_ip_bgp_as_vpnv4_soft_in,
-       clear_ip_bgp_as_vpnv4_soft_in_cmd,
-       "clear ip bgp " CMD_AS_RANGE " vpnv4 unicast soft in",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear peers with the AS number\n"
-       "Address family\n"
-       "Address Family modifier\n"
-       BGP_SOFT_STR
-       BGP_SOFT_IN_STR)
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MPLS_VPN, clear_as,
-			BGP_CLEAR_SOFT_IN, argv[0]);
-}
-
-ALIAS (clear_ip_bgp_as_vpnv4_soft_in,
-       clear_ip_bgp_as_vpnv4_in_cmd,
-       "clear ip bgp " CMD_AS_RANGE " vpnv4 unicast in",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear peers with the AS number\n"
-       "Address family\n"
-       "Address Family modifier\n"
-       BGP_SOFT_IN_STR)
-
-DEFUN (clear_ip_bgp_as_encap_soft_in,
-       clear_ip_bgp_as_encap_soft_in_cmd,
-       "clear ip bgp " CMD_AS_RANGE " encap unicast soft in",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear peers with the AS number\n"
-       "Address family\n"
-       "Address Family modifier\n"
-       "Soft reconfig\n"
-       "Soft reconfig inbound update\n")
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_ENCAP, clear_as,
-			BGP_CLEAR_SOFT_IN, argv[0]);
-}
-
-ALIAS (clear_ip_bgp_as_encap_soft_in,
-       clear_ip_bgp_as_encap_in_cmd,
-       "clear ip bgp " CMD_AS_RANGE " encap unicast in",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear peers with the AS number\n"
-       "Address family\n"
-       "Address Family modifier\n"
-       "Soft reconfig inbound update\n")
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
-
 DEFUN (clear_bgp_as_soft_in,
        clear_bgp_as_soft_in_cmd,
        "clear bgp " CMD_AS_RANGE " soft in",
@@ -9354,38 +8995,6 @@ DEFUN (clear_ip_bgp_instance_all_ipv4_soft,
                         BGP_CLEAR_SOFT_BOTH, NULL);
 }
 
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-DEFUN (clear_ip_bgp_all_vpnv4_soft,
-       clear_ip_bgp_all_vpnv4_soft_cmd,
-       "clear ip bgp * vpnv4 unicast soft",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear all peers\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       BGP_SOFT_STR)
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MPLS_VPN, clear_all,
-			BGP_CLEAR_SOFT_BOTH, argv[0]);
-}
-
-DEFUN (clear_ip_bgp_all_encap_soft,
-       clear_ip_bgp_all_encap_soft_cmd,
-       "clear ip bgp * encap unicast soft",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear all peers\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       "Soft reconfig\n")
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_ENCAP, clear_all,
-			BGP_CLEAR_SOFT_BOTH, argv[0]);
-}
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
-
 DEFUN (clear_bgp_all_soft,
        clear_bgp_all_soft_cmd,
        "clear bgp * soft",
@@ -9497,39 +9106,6 @@ DEFUN (clear_ip_bgp_instance_peer_ipv4_soft,
   return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_peer,
                         BGP_CLEAR_SOFT_BOTH, argv[2]);
 }
-
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-DEFUN (clear_ip_bgp_peer_vpnv4_soft,
-       clear_ip_bgp_peer_vpnv4_soft_cmd,
-       "clear ip bgp (A.B.C.D|WORD) vpnv4 unicast soft",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "BGP neighbor address to clear\n"
-       "BGP neighbor on interface to clear\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       BGP_SOFT_STR)
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MPLS_VPN, clear_peer,
-			BGP_CLEAR_SOFT_BOTH, argv[0]);
-}
-
-DEFUN (clear_ip_bgp_peer_encap_soft,
-       clear_ip_bgp_peer_encap_soft_cmd,
-       "clear ip bgp A.B.C.D encap unicast soft",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "BGP neighbor address to clear\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       "Soft reconfig\n")
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_ENCAP, clear_peer,
-			BGP_CLEAR_SOFT_BOTH, argv[0]);
-}
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (clear_bgp_peer_soft,
        clear_bgp_peer_soft_cmd,
@@ -9866,38 +9442,6 @@ DEFUN (clear_ip_bgp_instance_as_ipv4_soft,
   return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_as,
                         BGP_CLEAR_SOFT_BOTH, argv[2]);
 }
-
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-DEFUN (clear_ip_bgp_as_vpnv4_soft,
-       clear_ip_bgp_as_vpnv4_soft_cmd,
-       "clear ip bgp " CMD_AS_RANGE " vpnv4 unicast soft",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear peers with the AS number\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       BGP_SOFT_STR)
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MPLS_VPN, clear_as,
-			BGP_CLEAR_SOFT_BOTH, argv[0]);
-}
-
-DEFUN (clear_ip_bgp_as_encap_soft,
-       clear_ip_bgp_as_encap_soft_cmd,
-       "clear ip bgp " CMD_AS_RANGE " encap unicast soft",
-       CLEAR_STR
-       IP_STR
-       BGP_STR
-       "Clear peers with the AS number\n"
-       "Address family\n"
-       "Address Family Modifier\n"
-       "Soft reconfig\n")
-{
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_ENCAP, clear_as,
-			BGP_CLEAR_SOFT_BOTH, argv[0]);
-}
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (clear_bgp_as_soft,
        clear_bgp_as_soft_cmd,
@@ -10804,49 +10348,6 @@ ALIAS (show_ip_bgp_instance_ipv4_summary,
        "View name\n"
        BGP_AFI_SAFI_HELP_STR
        "Summary of BGP neighbor status\n")
-
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-DEFUN (show_ip_bgp_vpnv4_all_summary,
-       show_ip_bgp_vpnv4_all_summary_cmd,
-       "show ip bgp vpnv4 all summary {json}",
-       SHOW_STR
-       IP_STR
-       BGP_STR
-       "Display VPNv4 NLRI specific information\n"
-       "Display information about all VPNv4 NLRIs\n"
-       "Summary of BGP neighbor status\n"
-       "JavaScript Object Notation\n")
-{
-  u_char uj = use_json(argc, argv);
-  return bgp_show_summary_vty (vty, NULL, AFI_IP, SAFI_MPLS_VPN, uj);
-}
-
-DEFUN (show_ip_bgp_vpnv4_rd_summary,
-       show_ip_bgp_vpnv4_rd_summary_cmd,
-       "show ip bgp vpnv4 rd ASN:nn_or_IP-address:nn summary {json}",
-       SHOW_STR
-       IP_STR
-       BGP_STR
-       "Display VPNv4 NLRI specific information\n"
-       "Display information for a route distinguisher\n"
-       "VPN Route Distinguisher\n"
-       "Summary of BGP neighbor status\n"
-       "JavaScript Object Notation\n")
-{
-  int ret;
-  struct prefix_rd prd;
-  u_char uj = use_json(argc, argv);
-
-  ret = str2prefix_rd (argv[0], &prd);
-  if (! ret)
-    {
-      vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
-      return CMD_WARNING;
-    }
-
-  return bgp_show_summary_vty (vty, NULL, AFI_IP, SAFI_MPLS_VPN, uj);
-}
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 #ifdef HAVE_IPV6
 DEFUN (show_bgp_summary,
@@ -12845,31 +12346,6 @@ ALIAS (show_ip_bgp_neighbors,
        "Detailed information on TCP and BGP neighbor connections\n"
        "JavaScript Object Notation\n")
 
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-ALIAS (show_ip_bgp_neighbors,
-       show_ip_bgp_vpnv4_all_neighbors_cmd,
-       "show ip bgp vpnv4 all neighbors {json}",
-       SHOW_STR
-       IP_STR
-       BGP_STR
-       "Display VPNv4 NLRI specific information\n"
-       "Display information about all VPNv4 NLRIs\n"
-       "Detailed information on TCP and BGP neighbor connections\n"
-       "JavaScript Object Notation\n")
-
-ALIAS (show_ip_bgp_neighbors,
-       show_ip_bgp_vpnv4_rd_neighbors_cmd,
-       "show ip bgp vpnv4 rd ASN:nn_or_IP-address:nn neighbors {json}",
-       SHOW_STR
-       IP_STR
-       BGP_STR
-       "Display VPNv4 NLRI specific information\n"
-       "Display information for a route distinguisher\n"
-       "VPN Route Distinguisher\n"
-       "Detailed information on TCP and BGP neighbor connections\n"
-       "JavaScript Object Notation\n")
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
-
 ALIAS (show_ip_bgp_neighbors,
        show_bgp_neighbors_cmd,
        "show bgp neighbors {json}",
@@ -12917,32 +12393,6 @@ ALIAS (show_ip_bgp_neighbors_peer,
        "Neighbor to display information about\n"
        "Neighbor on bgp configured interface\n"
        "JavaScript Object Notation\n")
-
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-ALIAS (show_ip_bgp_neighbors_peer,
-       show_ip_bgp_vpnv4_all_neighbors_peer_cmd,
-       "show ip bgp vpnv4 all neighbors A.B.C.D {json}",
-       SHOW_STR
-       IP_STR
-       BGP_STR
-       "Display VPNv4 NLRI specific information\n"
-       "Display information about all VPNv4 NLRIs\n"
-       "Detailed information on TCP and BGP neighbor connections\n"
-       "Neighbor to display information about\n"
-       "JavaScript Object Notation\n")
-
-ALIAS (show_ip_bgp_neighbors_peer,
-       show_ip_bgp_vpnv4_rd_neighbors_peer_cmd,
-       "show ip bgp vpnv4 rd ASN:nn_or_IP-address:nn neighbors A.B.C.D {json}",
-       SHOW_STR
-       IP_STR
-       BGP_STR
-       "Display VPNv4 NLRI specific information\n"
-       "Display information about all VPNv4 NLRIs\n"
-       "Detailed information on TCP and BGP neighbor connections\n"
-       "Neighbor to display information about\n"
-       "JavaScript Object Notation\n")
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 ALIAS (show_ip_bgp_neighbors_peer,
        show_bgp_neighbors_peer_cmd,
@@ -15645,15 +15095,7 @@ bgp_vty_init (void)
   install_element (BGP_NODE, &address_family_ipv6_safi_cmd);
 #endif /* HAVE_IPV6 */
   install_element (BGP_NODE, &address_family_vpnv4_cmd);
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-  install_element (BGP_NODE, &address_family_vpnv4_unicast_cmd);
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
-
   install_element (BGP_NODE, &address_family_vpnv6_cmd);
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-  install_element (BGP_NODE, &address_family_vpnv6_unicast_cmd);
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
-
   install_element (BGP_NODE, &address_family_encap_cmd);
   install_element (BGP_NODE, &address_family_encapv4_cmd);
 #ifdef HAVE_IPV6
@@ -15754,20 +15196,6 @@ bgp_vty_init (void)
   install_element (ENABLE_NODE, &clear_ip_bgp_as_ipv4_in_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_instance_as_ipv4_in_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_as_ipv4_in_prefix_filter_cmd);
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-  install_element (ENABLE_NODE, &clear_ip_bgp_all_vpnv4_soft_in_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_all_vpnv4_in_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_peer_vpnv4_soft_in_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_peer_vpnv4_in_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_as_vpnv4_soft_in_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_as_vpnv4_in_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_all_encap_soft_in_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_all_encap_in_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_peer_encap_soft_in_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_peer_encap_in_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_as_encap_soft_in_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_as_encap_in_cmd);
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
   install_element (ENABLE_NODE, &clear_bgp_all_soft_in_cmd);
   install_element (ENABLE_NODE, &clear_bgp_instance_all_soft_in_cmd);
   install_element (ENABLE_NODE, &clear_bgp_all_in_cmd);
@@ -15866,20 +15294,6 @@ bgp_vty_init (void)
   install_element (ENABLE_NODE, &clear_ip_bgp_instance_as_ipv4_soft_out_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_as_ipv4_out_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_instance_as_ipv4_out_cmd);
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-  install_element (ENABLE_NODE, &clear_ip_bgp_all_vpnv4_soft_out_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_all_vpnv4_out_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_peer_vpnv4_soft_out_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_peer_vpnv4_out_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_as_vpnv4_soft_out_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_as_vpnv4_out_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_all_encap_soft_out_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_all_encap_out_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_peer_encap_soft_out_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_peer_encap_out_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_as_encap_soft_out_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_as_encap_out_cmd);
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
   install_element (ENABLE_NODE, &clear_bgp_all_soft_out_cmd);
   install_element (ENABLE_NODE, &clear_bgp_instance_all_soft_out_cmd);
   install_element (ENABLE_NODE, &clear_bgp_all_out_cmd);
@@ -15942,14 +15356,6 @@ bgp_vty_init (void)
   install_element (ENABLE_NODE, &clear_ip_bgp_instance_external_ipv4_soft_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_as_ipv4_soft_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_instance_as_ipv4_soft_cmd);
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-  install_element (ENABLE_NODE, &clear_ip_bgp_all_vpnv4_soft_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_peer_vpnv4_soft_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_as_vpnv4_soft_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_all_encap_soft_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_peer_encap_soft_cmd);
-  install_element (ENABLE_NODE, &clear_ip_bgp_as_encap_soft_cmd);
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
   install_element (ENABLE_NODE, &clear_bgp_all_soft_cmd);
   install_element (ENABLE_NODE, &clear_bgp_instance_all_soft_cmd);
   install_element (ENABLE_NODE, &clear_bgp_peer_soft_cmd);
@@ -16001,10 +15407,6 @@ bgp_vty_init (void)
   install_element (VIEW_NODE, &show_bgp_ipv4_safi_summary_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_instance_ipv4_summary_cmd);
   install_element (VIEW_NODE, &show_bgp_instance_ipv4_safi_summary_cmd);
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-  install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_summary_cmd);
-  install_element (VIEW_NODE, &show_ip_bgp_vpnv4_rd_summary_cmd);
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 #ifdef HAVE_IPV6
   install_element (VIEW_NODE, &show_bgp_summary_cmd);
   install_element (VIEW_NODE, &show_bgp_instance_summary_cmd);
@@ -16020,12 +15422,6 @@ bgp_vty_init (void)
   install_element (VIEW_NODE, &show_ip_bgp_ipv4_neighbors_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_neighbors_peer_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_ipv4_neighbors_peer_cmd);
-#ifdef KEEP_OLD_VPNV4_COMMANDS
-  install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_neighbors_cmd);
-  install_element (VIEW_NODE, &show_ip_bgp_vpnv4_rd_neighbors_cmd);
-  install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_neighbors_peer_cmd);
-  install_element (VIEW_NODE, &show_ip_bgp_vpnv4_rd_neighbors_peer_cmd);
-#endif  /* KEEP_OLD_VPNV4_COMMANDS */
   install_element (VIEW_NODE, &show_ip_bgp_instance_neighbors_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_instance_all_neighbors_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_instance_neighbors_peer_cmd);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -107,21 +107,32 @@ bgp_node_safi (struct vty *vty)
   return safi;
 }
 
+/* supports (ipv4|ipv6) */
+afi_t
+bgp_vty_afi_from_arg(const char *afi_str)
+{
+  afi_t afi = AFI_MAX;       /* unknown */
+  if (!strcmp(afi_str, "ipv4")) {
+    afi = AFI_IP;
+    }
+#ifdef HAVE_IPV6
+  else if (!strcmp(afi_str, "ipv6")) {
+    afi = AFI_IP6;
+  }
+#endif /* HAVE_IPV6 */
+  return afi;
+}
+
 int
 bgp_parse_afi(const char *str, afi_t *afi)
 {
-    if (!strcmp(str, "ipv4")) {
-	*afi = AFI_IP;
-	return 0;
-    }
-#ifdef HAVE_IPV6
-    if (!strcmp(str, "ipv6")) {
-	*afi = AFI_IP6;
-	return 0;
-    }
-#endif /* HAVE_IPV6 */
+  *afi = bgp_vty_afi_from_arg(str);
+  if (*afi != AFI_MAX)
+    return 0;
+  else
     return -1;
 }
+
 
 /* supports (unicast|multicast|vpn|encap) */
 safi_t
@@ -135,7 +146,7 @@ bgp_vty_safi_from_arg(const char *safi_str)
   else if (strncmp (safi_str, "e", 1) == 0)
     safi = SAFI_ENCAP;
   else if (strncmp (safi_str, "v", 1) == 0)
-   safi = SAFI_MPLS_VPN;
+    safi = SAFI_MPLS_VPN;
   return safi;
 }
 
@@ -359,10 +370,8 @@ bgp_clear_vty_error (struct vty *vty, struct peer *peer, afi_t afi,
     {
     case BGP_ERR_AF_UNCONFIGURED:
       vty_out (vty,
-	       "%%BGP: Enable %s %s address family for the neighbor %s%s",
-	       afi == AFI_IP6 ? "IPv6" : safi == SAFI_MPLS_VPN ? "VPNv4" : "IPv4",
-	       safi == SAFI_MULTICAST ? "Multicast" : "Unicast",
-	       peer->host, VTY_NEWLINE);
+	       "%%BGP: Enable %s address family for the neighbor %s%s",
+	       afi_safi_print(afi, safi), peer->host, VTY_NEWLINE);
       break;
     case BGP_ERR_SOFT_RECONFIG_UNCONFIGURED:
       vty_out (vty, "%%BGP: Inbound soft reconfig for %s not possible as it%s      has neither refresh capability, nor inbound soft reconfig%s", peer->host, VTY_NEWLINE, VTY_NEWLINE);
@@ -6057,9 +6066,10 @@ DEFUN (address_family_ipv4,
 
 DEFUN (address_family_ipv4_safi,
        address_family_ipv4_safi_cmd,
-       "address-family ipv4 (unicast|multicast)",
+       "address-family ipv4 "BGP_SAFI_CMD_STR,
        "Enter Address Family command mode\n"
-       AFI_SAFI_STR)
+       "Address Family\n"
+       BGP_SAFI_HELP_STR)
 {
   switch (bgp_vty_safi_from_arg(argv[0]))
     {
@@ -6093,16 +6103,28 @@ DEFUN (address_family_ipv6,
 
 DEFUN (address_family_ipv6_safi,
        address_family_ipv6_safi_cmd,
-       "address-family ipv6 (unicast|multicast)",
+       "address-family ipv6 "BGP_SAFI_CMD_STR,
        "Enter Address Family command mode\n"
-       "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n")
+       "Address Family\n"
+       BGP_SAFI_HELP_STR)
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    vty->node = BGP_IPV6M_NODE;
-  else
-    vty->node = BGP_IPV6_NODE;
+  int idx_safi = 0;
+  switch (bgp_vty_safi_from_arg(argv[idx_safi]))
+    {
+    case SAFI_MULTICAST:
+      vty->node = BGP_IPV6M_NODE;
+      break;
+    case SAFI_ENCAP:
+      vty->node = BGP_ENCAPV6_NODE;
+      break;
+    case SAFI_MPLS_VPN:
+      vty->node = BGP_VPNV6_NODE;
+      break;
+    case SAFI_UNICAST:
+    default:
+      vty->node = BGP_IPV6_NODE;
+      break;
+    }
 
   return CMD_SUCCESS;
 }
@@ -6651,69 +6673,61 @@ ALIAS (clear_ip_bgp_all_soft_out,
 
 DEFUN (clear_ip_bgp_all_ipv4_soft_out,
        clear_ip_bgp_all_ipv4_soft_out_cmd,
-       "clear ip bgp * ipv4 (unicast|multicast) soft out",
+       "clear ip bgp * ipv4 "BGP_SAFI_CMD_STR" soft out",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_OUT_STR)
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_all,
-			  BGP_CLEAR_SOFT_OUT, NULL);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_all,
-			BGP_CLEAR_SOFT_OUT, NULL);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_all,
+                        BGP_CLEAR_SOFT_OUT, NULL);
 }
 
 DEFUN (clear_ip_bgp_instance_all_ipv4_soft_out,
        clear_ip_bgp_instance_all_ipv4_soft_out_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " * ipv4 (unicast|multicast) soft out",
+       "clear ip bgp " BGP_INSTANCE_CMD " * ipv4 "BGP_SAFI_CMD_STR" soft out",
        CLEAR_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        "Clear all peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 {
-  if (strncmp (argv[2], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_all,
-                          BGP_CLEAR_SOFT_OUT, NULL);
-
-  return bgp_clear_vty (vty, argv[0], AFI_IP, SAFI_UNICAST, clear_all,
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[2]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_all,
                         BGP_CLEAR_SOFT_OUT, NULL);
 }
 
 ALIAS (clear_ip_bgp_all_ipv4_soft_out,
        clear_ip_bgp_all_ipv4_out_cmd,
-       "clear ip bgp * ipv4 (unicast|multicast) out",
+       "clear ip bgp * ipv4 "BGP_SAFI_CMD_STR" out",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
 ALIAS (clear_ip_bgp_instance_all_ipv4_soft_out,
        clear_ip_bgp_instance_all_ipv4_out_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " * ipv4 (unicast|multicast) out",
+       "clear ip bgp " BGP_INSTANCE_CMD " * ipv4 "BGP_SAFI_CMD_STR" out",
        CLEAR_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        "Clear all peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
 DEFUN (clear_ip_bgp_all_vpnv4_soft_out,
@@ -6856,7 +6870,7 @@ ALIAS (clear_bgp_all_soft_out,
 
 DEFUN (clear_bgp_ipv6_safi_prefix,
        clear_bgp_ipv6_safi_prefix_cmd,
-       "clear bgp ipv6 (unicast|multicast) prefix X:X::X:X/M",
+       "clear bgp ipv6 "BGP_SAFI_CMD_STR" prefix X:X::X:X/M",
        CLEAR_STR
        BGP_STR
        "Address family\n"
@@ -6864,15 +6878,14 @@ DEFUN (clear_bgp_ipv6_safi_prefix,
        "Clear bestpath and re-advertise\n"
        "IPv6 prefix <network>/<length>,  e.g.,  3ffe::/16\n")
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_clear_prefix (vty, NULL, argv[1], AFI_IP6, SAFI_MULTICAST, NULL);
-  else
-    return bgp_clear_prefix (vty, NULL, argv[1], AFI_IP6, SAFI_UNICAST, NULL);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_clear_prefix (vty, NULL, argv[1], AFI_IP6, safi, NULL);
 }
 
 DEFUN (clear_bgp_instance_ipv6_safi_prefix,
        clear_bgp_instance_ipv6_safi_prefix_cmd,
-       "clear bgp " BGP_INSTANCE_CMD " ipv6 (unicast|multicast) prefix X:X::X:X/M",
+       "clear bgp " BGP_INSTANCE_CMD " ipv6 "BGP_SAFI_CMD_STR" prefix X:X::X:X/M",
        CLEAR_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
@@ -6881,10 +6894,9 @@ DEFUN (clear_bgp_instance_ipv6_safi_prefix,
        "Clear bestpath and re-advertise\n"
        "IPv6 prefix <network>/<length>,  e.g.,  3ffe::/16\n")
 {
-  if (strncmp (argv[2], "m", 1) == 0)
-    return bgp_clear_prefix (vty, argv[1], argv[3], AFI_IP6, SAFI_MULTICAST, NULL);
-  else
-    return bgp_clear_prefix (vty, argv[1], argv[3], AFI_IP6, SAFI_UNICAST, NULL);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[2]);
+  return bgp_clear_prefix (vty, argv[1], argv[3], AFI_IP6, safi, NULL);
 }
 
 DEFUN (clear_ip_bgp_peer_soft_out,
@@ -6941,29 +6953,26 @@ ALIAS (clear_ip_bgp_peer_soft_out,
 
 DEFUN (clear_ip_bgp_peer_ipv4_soft_out,
        clear_ip_bgp_peer_ipv4_soft_out_cmd,
-       "clear ip bgp (A.B.C.D|WORD) ipv4 (unicast|multicast) soft out",
+       "clear ip bgp (A.B.C.D|WORD) ipv4 "BGP_SAFI_CMD_STR" soft out",
        CLEAR_STR
        IP_STR
        BGP_STR
        "BGP neighbor address to clear\n"
        "BGP neighbor on interface to clear\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_OUT_STR)
 {
-  if (strncmp (argv[1], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_peer,
-			  BGP_CLEAR_SOFT_OUT, argv[0]);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_peer,
-			BGP_CLEAR_SOFT_OUT, argv[0]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[1]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_peer,
+                        BGP_CLEAR_SOFT_OUT, argv[0]);
 }
 
 DEFUN (clear_ip_bgp_instance_peer_ipv4_soft_out,
        clear_ip_bgp_instance_peer_ipv4_soft_out_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " (A.B.C.D|WORD) ipv4 (unicast|multicast) soft out",
+       "clear ip bgp " BGP_INSTANCE_CMD " (A.B.C.D|WORD) ipv4 "BGP_SAFI_CMD_STR" soft out",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -6971,35 +6980,31 @@ DEFUN (clear_ip_bgp_instance_peer_ipv4_soft_out,
        "BGP neighbor address to clear\n"
        "BGP neighbor on interface to clear\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_OUT_STR)
 {
-  if (strncmp (argv[3], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_peer,
-			  BGP_CLEAR_SOFT_OUT, argv[2]);
-
-  return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_UNICAST, clear_peer,
-			BGP_CLEAR_SOFT_OUT, argv[2]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[3]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_peer,
+                        BGP_CLEAR_SOFT_OUT, argv[2]);
 }
 
 ALIAS (clear_ip_bgp_peer_ipv4_soft_out,
        clear_ip_bgp_peer_ipv4_out_cmd,
-       "clear ip bgp (A.B.C.D|WORD) ipv4 (unicast|multicast) out",
+       "clear ip bgp (A.B.C.D|WORD) ipv4 "BGP_SAFI_CMD_STR" out",
        CLEAR_STR
        IP_STR
        BGP_STR
        "BGP neighbor address to clear\n"
        "BGP neighbor on interface to clear\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
 ALIAS (clear_ip_bgp_instance_peer_ipv4_soft_out,
        clear_ip_bgp_instance_peer_ipv4_out_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " (A.B.C.D|WORD) ipv4 (unicast|multicast) out",
+       "clear ip bgp " BGP_INSTANCE_CMD " (A.B.C.D|WORD) ipv4 "BGP_SAFI_CMD_STR" out",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -7007,8 +7012,7 @@ ALIAS (clear_ip_bgp_instance_peer_ipv4_soft_out,
        "BGP neighbor address to clear\n"
        "BGP neighbor on interface to clear\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
 /* NOTE: WORD peers have not been tested for vpnv4 */
@@ -7222,29 +7226,26 @@ ALIAS (clear_ip_bgp_peer_group_soft_out,
 
 DEFUN (clear_ip_bgp_peer_group_ipv4_soft_out,
        clear_ip_bgp_peer_group_ipv4_soft_out_cmd,
-       "clear ip bgp peer-group WORD ipv4 (unicast|multicast) soft out",
+       "clear ip bgp peer-group WORD ipv4 "BGP_SAFI_CMD_STR" soft out",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all members of peer-group\n"
        "BGP peer-group name\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_OUT_STR)
 {
-  if (strncmp (argv[1], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_group,
-			  BGP_CLEAR_SOFT_OUT, argv[0]);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_group,
-			BGP_CLEAR_SOFT_OUT, argv[0]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[1]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_group,
+                        BGP_CLEAR_SOFT_OUT, argv[0]);
 }
 
 DEFUN (clear_ip_bgp_instance_peer_group_ipv4_soft_out,
        clear_ip_bgp_instance_peer_group_ipv4_soft_out_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " peer-group WORD ipv4 (unicast|multicast) soft out",
+       "clear ip bgp " BGP_INSTANCE_CMD " peer-group WORD ipv4 "BGP_SAFI_CMD_STR" soft out",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -7252,35 +7253,31 @@ DEFUN (clear_ip_bgp_instance_peer_group_ipv4_soft_out,
        "Clear all members of peer-group\n"
        "BGP peer-group name\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_OUT_STR)
 {
-  if (strncmp (argv[3], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_group,
-			  BGP_CLEAR_SOFT_OUT, argv[2]);
-
-  return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_UNICAST, clear_group,
-			BGP_CLEAR_SOFT_OUT, argv[2]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[3]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_group,
+                        BGP_CLEAR_SOFT_OUT, argv[2]);
 }
 
 ALIAS (clear_ip_bgp_peer_group_ipv4_soft_out,
        clear_ip_bgp_peer_group_ipv4_out_cmd,
-       "clear ip bgp peer-group WORD ipv4 (unicast|multicast) out",
+       "clear ip bgp peer-group WORD ipv4 "BGP_SAFI_CMD_STR" out",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all members of peer-group\n"
        "BGP peer-group name\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
 ALIAS (clear_ip_bgp_instance_peer_group_ipv4_soft_out,
        clear_ip_bgp_instance_peer_group_ipv4_out_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " peer-group WORD ipv4 (unicast|multicast) out",
+       "clear ip bgp " BGP_INSTANCE_CMD " peer-group WORD ipv4 "BGP_SAFI_CMD_STR" out",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -7288,8 +7285,7 @@ ALIAS (clear_ip_bgp_instance_peer_group_ipv4_soft_out,
        "Clear all members of peer-group\n"
        "BGP peer-group name\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
 DEFUN (clear_bgp_peer_group_soft_out,
@@ -7434,70 +7430,62 @@ ALIAS (clear_ip_bgp_external_soft_out,
 
 DEFUN (clear_ip_bgp_external_ipv4_soft_out,
        clear_ip_bgp_external_ipv4_soft_out_cmd,
-       "clear ip bgp external ipv4 (unicast|multicast) soft out",
+       "clear ip bgp external ipv4 "BGP_SAFI_CMD_STR" soft out",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all external peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_OUT_STR)
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_external,
-			  BGP_CLEAR_SOFT_OUT, NULL);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_external,
-			BGP_CLEAR_SOFT_OUT, NULL);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_external,
+                        BGP_CLEAR_SOFT_OUT, NULL);
 }
 
 DEFUN (clear_ip_bgp_instance_external_ipv4_soft_out,
        clear_ip_bgp_instance_external_ipv4_soft_out_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " external ipv4 (unicast|multicast) soft out",
+       "clear ip bgp " BGP_INSTANCE_CMD " external ipv4 "BGP_SAFI_CMD_STR" soft out",
        CLEAR_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        "Clear all external peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_OUT_STR)
 {
-  if (strncmp (argv[2], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_external,
-			  BGP_CLEAR_SOFT_OUT, NULL);
-
-  return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_UNICAST, clear_external,
-			BGP_CLEAR_SOFT_OUT, NULL);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[2]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_external,
+                        BGP_CLEAR_SOFT_OUT, NULL);
 }
 
 ALIAS (clear_ip_bgp_external_ipv4_soft_out,
        clear_ip_bgp_external_ipv4_out_cmd,
-       "clear ip bgp external ipv4 (unicast|multicast) out",
+       "clear ip bgp external ipv4 "BGP_SAFI_CMD_STR" out",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all external peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
 ALIAS (clear_ip_bgp_instance_external_ipv4_soft_out,
        clear_ip_bgp_instance_external_ipv4_out_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " external ipv4 (unicast|multicast) out",
+       "clear ip bgp " BGP_INSTANCE_CMD " external ipv4 "BGP_SAFI_CMD_STR" out",
        CLEAR_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        "Clear all external peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
 DEFUN (clear_bgp_external_soft_out,
@@ -7634,70 +7622,62 @@ ALIAS (clear_ip_bgp_as_soft_out,
 
 DEFUN (clear_ip_bgp_as_ipv4_soft_out,
        clear_ip_bgp_as_ipv4_soft_out_cmd,
-       "clear ip bgp " CMD_AS_RANGE " ipv4 (unicast|multicast) soft out",
+       "clear ip bgp " CMD_AS_RANGE " ipv4 "BGP_SAFI_CMD_STR" soft out",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear peers with the AS number\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_OUT_STR)
 {
-  if (strncmp (argv[1], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_as,
-			  BGP_CLEAR_SOFT_OUT, argv[0]);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_as,
-			BGP_CLEAR_SOFT_OUT, argv[0]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[1]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_as,
+                        BGP_CLEAR_SOFT_OUT, argv[0]);
 }
 
 DEFUN (clear_ip_bgp_instance_as_ipv4_soft_out,
        clear_ip_bgp_instance_as_ipv4_soft_out_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " " CMD_AS_RANGE " ipv4 (unicast|multicast) soft out",
+       "clear ip bgp " BGP_INSTANCE_CMD " " CMD_AS_RANGE " ipv4 "BGP_SAFI_CMD_STR" soft out",
        CLEAR_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        "Clear peers with the AS number\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_OUT_STR)
 {
-  if (strncmp (argv[3], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_as,
-			  BGP_CLEAR_SOFT_OUT, argv[2]);
-
-  return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_UNICAST, clear_as,
-			BGP_CLEAR_SOFT_OUT, argv[2]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[3]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_as,
+                        BGP_CLEAR_SOFT_OUT, argv[2]);
 }
 
 ALIAS (clear_ip_bgp_as_ipv4_soft_out,
        clear_ip_bgp_as_ipv4_out_cmd,
-       "clear ip bgp " CMD_AS_RANGE " ipv4 (unicast|multicast) out",
+       "clear ip bgp " CMD_AS_RANGE " ipv4 "BGP_SAFI_CMD_STR" out",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear peers with the AS number\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
 ALIAS (clear_ip_bgp_instance_as_ipv4_soft_out,
        clear_ip_bgp_instance_as_ipv4_out_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " " CMD_AS_RANGE " ipv4 (unicast|multicast) out",
+       "clear ip bgp " BGP_INSTANCE_CMD " " CMD_AS_RANGE " ipv4 "BGP_SAFI_CMD_STR" out",
        CLEAR_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        "Clear peers with the AS number\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
 DEFUN (clear_ip_bgp_as_vpnv4_soft_out,
@@ -7907,91 +7887,80 @@ DEFUN (clear_ip_bgp_all_in_prefix_filter,
 
 DEFUN (clear_ip_bgp_all_ipv4_soft_in,
        clear_ip_bgp_all_ipv4_soft_in_cmd,
-       "clear ip bgp * ipv4 (unicast|multicast) soft in",
+       "clear ip bgp * ipv4 "BGP_SAFI_CMD_STR" soft in",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_IN_STR)
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_all,
-			  BGP_CLEAR_SOFT_IN, NULL);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_all,
-			BGP_CLEAR_SOFT_IN, NULL);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_all,
+                        BGP_CLEAR_SOFT_IN, NULL);
 }
 
 DEFUN (clear_ip_bgp_instance_all_ipv4_soft_in,
        clear_ip_bgp_instance_all_ipv4_soft_in_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " * ipv4 (unicast|multicast) soft in",
+       "clear ip bgp " BGP_INSTANCE_CMD " * ipv4 "BGP_SAFI_CMD_STR" soft in",
        CLEAR_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        "Clear all peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_IN_STR)
 {
-  if (strncmp (argv[2], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_all,
-                          BGP_CLEAR_SOFT_IN, NULL);
-
-  return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_UNICAST, clear_all,
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[2]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_all,
                         BGP_CLEAR_SOFT_IN, NULL);
 }
 
 ALIAS (clear_ip_bgp_all_ipv4_soft_in,
        clear_ip_bgp_all_ipv4_in_cmd,
-       "clear ip bgp * ipv4 (unicast|multicast) in",
+       "clear ip bgp * ipv4 "BGP_SAFI_CMD_STR" in",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR)
 
 ALIAS (clear_ip_bgp_instance_all_ipv4_soft_in,
        clear_ip_bgp_instance_all_ipv4_in_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " * ipv4 (unicast|multicast) in",
+       "clear ip bgp " BGP_INSTANCE_CMD " * ipv4 "BGP_SAFI_CMD_STR" in",
        CLEAR_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        "Clear all peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR)
 
 DEFUN (clear_ip_bgp_all_ipv4_in_prefix_filter,
        clear_ip_bgp_all_ipv4_in_prefix_filter_cmd,
-       "clear ip bgp * ipv4 (unicast|multicast) in prefix-filter",
+       "clear ip bgp * ipv4 "BGP_SAFI_CMD_STR" in prefix-filter",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR
        "Push out prefix-list ORF and do inbound soft reconfig\n")
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_all,
-			  BGP_CLEAR_SOFT_IN_ORF_PREFIX, NULL);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_all,
-			BGP_CLEAR_SOFT_IN_ORF_PREFIX, NULL);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_all,
+                        BGP_CLEAR_SOFT_IN_ORF_PREFIX, NULL);
 }
 
 DEFUN (clear_ip_bgp_all_vpnv4_soft_in,
@@ -8224,29 +8193,26 @@ DEFUN (clear_ip_bgp_peer_in_prefix_filter,
 
 DEFUN (clear_ip_bgp_peer_ipv4_soft_in,
        clear_ip_bgp_peer_ipv4_soft_in_cmd,
-       "clear ip bgp (A.B.C.D|WORD) ipv4 (unicast|multicast) soft in",
+       "clear ip bgp (A.B.C.D|WORD) ipv4 "BGP_SAFI_CMD_STR" soft in",
        CLEAR_STR
        IP_STR
        BGP_STR
        "BGP neighbor address to clear\n"
        "BGP neighbor on interface to clear\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_IN_STR)
 {
-  if (strncmp (argv[1], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_peer,
-			  BGP_CLEAR_SOFT_IN, argv[0]);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_peer,
-			BGP_CLEAR_SOFT_IN, argv[0]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[1]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_peer,
+                        BGP_CLEAR_SOFT_IN, argv[0]);
 }
 
 DEFUN (clear_ip_bgp_instance_peer_ipv4_soft_in,
        clear_ip_bgp_instance_peer_ipv4_soft_in_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " (A.B.C.D|WORD) ipv4 (unicast|multicast) soft in",
+       "clear ip bgp " BGP_INSTANCE_CMD " (A.B.C.D|WORD) ipv4 "BGP_SAFI_CMD_STR" soft in",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -8254,35 +8220,31 @@ DEFUN (clear_ip_bgp_instance_peer_ipv4_soft_in,
        "BGP neighbor address to clear\n"
        "BGP neighbor on interface to clear\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_IN_STR)
 {
-  if (strncmp (argv[3], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_peer,
-			  BGP_CLEAR_SOFT_IN, argv[2]);
-
-  return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_UNICAST, clear_peer,
-			BGP_CLEAR_SOFT_IN, argv[2]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[3]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_peer,
+                        BGP_CLEAR_SOFT_IN, argv[2]);
 }
 
 ALIAS (clear_ip_bgp_peer_ipv4_soft_in,
        clear_ip_bgp_peer_ipv4_in_cmd,
-       "clear ip bgp (A.B.C.D|WORD) ipv4 (unicast|multicast) in",
+       "clear ip bgp (A.B.C.D|WORD) ipv4 "BGP_SAFI_CMD_STR" in",
        CLEAR_STR
        IP_STR
        BGP_STR
        "BGP neighbor address to clear\n"
        "BGP neighbor on interface to clear\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR)
 
 ALIAS (clear_ip_bgp_instance_peer_ipv4_soft_in,
        clear_ip_bgp_instance_peer_ipv4_in_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " (A.B.C.D|WORD) ipv4 (unicast|multicast) in",
+       "clear ip bgp " BGP_INSTANCE_CMD " (A.B.C.D|WORD) ipv4 "BGP_SAFI_CMD_STR" in",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -8290,30 +8252,26 @@ ALIAS (clear_ip_bgp_instance_peer_ipv4_soft_in,
        "BGP neighbor address to clear\n"
        "BGP neighbor on interface to clear\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR)
 
 DEFUN (clear_ip_bgp_peer_ipv4_in_prefix_filter,
        clear_ip_bgp_peer_ipv4_in_prefix_filter_cmd,
-       "clear ip bgp (A.B.C.D|WORD) ipv4 (unicast|multicast) in prefix-filter",
+       "clear ip bgp (A.B.C.D|WORD) ipv4 "BGP_SAFI_CMD_STR" in prefix-filter",
        CLEAR_STR
        IP_STR
        BGP_STR
        "BGP neighbor address to clear\n"
        "BGP neighbor on interface to clear\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR
        "Push out the existing ORF prefix-list\n")
 {
-  if (strncmp (argv[1], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_peer,
-			  BGP_CLEAR_SOFT_IN_ORF_PREFIX, argv[0]);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_peer,
-			BGP_CLEAR_SOFT_IN_ORF_PREFIX, argv[0]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[1]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_peer,
+                        BGP_CLEAR_SOFT_IN_ORF_PREFIX, argv[0]);
 }
 
 DEFUN (clear_ip_bgp_peer_vpnv4_soft_in,
@@ -8568,29 +8526,26 @@ DEFUN (clear_ip_bgp_peer_group_in_prefix_filter,
 
 DEFUN (clear_ip_bgp_peer_group_ipv4_soft_in,
        clear_ip_bgp_peer_group_ipv4_soft_in_cmd,
-       "clear ip bgp peer-group WORD ipv4 (unicast|multicast) soft in",
+       "clear ip bgp peer-group WORD ipv4 "BGP_SAFI_CMD_STR" soft in",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all members of peer-group\n"
        "BGP peer-group name\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_IN_STR)
 {
-  if (strncmp (argv[1], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_group,
-			  BGP_CLEAR_SOFT_IN, argv[0]);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_group,
-			BGP_CLEAR_SOFT_IN, argv[0]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[1]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_group,
+                        BGP_CLEAR_SOFT_IN, argv[0]);
 }
 
 DEFUN (clear_ip_bgp_instance_peer_group_ipv4_soft_in,
        clear_ip_bgp_instance_peer_group_ipv4_soft_in_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " peer-group WORD ipv4 (unicast|multicast) soft in",
+       "clear ip bgp " BGP_INSTANCE_CMD " peer-group WORD ipv4 "BGP_SAFI_CMD_STR" soft in",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -8598,35 +8553,31 @@ DEFUN (clear_ip_bgp_instance_peer_group_ipv4_soft_in,
        "Clear all members of peer-group\n"
        "BGP peer-group name\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_IN_STR)
 {
-  if (strncmp (argv[3], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_group,
-			  BGP_CLEAR_SOFT_IN, argv[2]);
-
-  return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_UNICAST, clear_group,
-			BGP_CLEAR_SOFT_IN, argv[2]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[3]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_group,
+                        BGP_CLEAR_SOFT_IN, argv[2]);
 }
 
 ALIAS (clear_ip_bgp_peer_group_ipv4_soft_in,
        clear_ip_bgp_peer_group_ipv4_in_cmd,
-       "clear ip bgp peer-group WORD ipv4 (unicast|multicast) in",
+       "clear ip bgp peer-group WORD ipv4 "BGP_SAFI_CMD_STR" in",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all members of peer-group\n"
        "BGP peer-group name\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR)
 
 ALIAS (clear_ip_bgp_instance_peer_group_ipv4_soft_in,
        clear_ip_bgp_instance_peer_group_ipv4_in_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " peer-group WORD ipv4 (unicast|multicast) in",
+       "clear ip bgp " BGP_INSTANCE_CMD " peer-group WORD ipv4 "BGP_SAFI_CMD_STR" in",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -8634,30 +8585,26 @@ ALIAS (clear_ip_bgp_instance_peer_group_ipv4_soft_in,
        "Clear all members of peer-group\n"
        "BGP peer-group name\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR)
 
 DEFUN (clear_ip_bgp_peer_group_ipv4_in_prefix_filter,
        clear_ip_bgp_peer_group_ipv4_in_prefix_filter_cmd,
-       "clear ip bgp peer-group WORD ipv4 (unicast|multicast) in prefix-filter",
+       "clear ip bgp peer-group WORD ipv4 "BGP_SAFI_CMD_STR" in prefix-filter",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all members of peer-group\n"
        "BGP peer-group name\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR
        "Push out prefix-list ORF and do inbound soft reconfig\n")
 {
-  if (strncmp (argv[1], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_group,
-			  BGP_CLEAR_SOFT_IN_ORF_PREFIX, argv[0]);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_group,
-			BGP_CLEAR_SOFT_IN_ORF_PREFIX, argv[0]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[1]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_group,
+                        BGP_CLEAR_SOFT_IN_ORF_PREFIX, argv[0]);
 }
 
 DEFUN (clear_bgp_peer_group_soft_in,
@@ -8841,91 +8788,80 @@ DEFUN (clear_ip_bgp_external_in_prefix_filter,
 
 DEFUN (clear_ip_bgp_external_ipv4_soft_in,
        clear_ip_bgp_external_ipv4_soft_in_cmd,
-       "clear ip bgp external ipv4 (unicast|multicast) soft in",
+       "clear ip bgp external ipv4 "BGP_SAFI_CMD_STR" soft in",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all external peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_IN_STR)
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_external,
-			  BGP_CLEAR_SOFT_IN, NULL);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_external,
-			BGP_CLEAR_SOFT_IN, NULL);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_external,
+                        BGP_CLEAR_SOFT_IN, NULL);
 }
 
 DEFUN (clear_ip_bgp_instance_external_ipv4_soft_in,
        clear_ip_bgp_instance_external_ipv4_soft_in_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " external ipv4 (unicast|multicast) soft in",
+       "clear ip bgp " BGP_INSTANCE_CMD " external ipv4 "BGP_SAFI_CMD_STR" soft in",
        CLEAR_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        "Clear all external peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_IN_STR)
 {
-  if (strncmp (argv[2], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_external,
-			  BGP_CLEAR_SOFT_IN, NULL);
-
-  return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_UNICAST, clear_external,
-			BGP_CLEAR_SOFT_IN, NULL);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[2]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_external,
+                        BGP_CLEAR_SOFT_IN, NULL);
 }
 
 ALIAS (clear_ip_bgp_external_ipv4_soft_in,
        clear_ip_bgp_external_ipv4_in_cmd,
-       "clear ip bgp external ipv4 (unicast|multicast) in",
+       "clear ip bgp external ipv4 "BGP_SAFI_CMD_STR" in",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all external peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR)
 
 ALIAS (clear_ip_bgp_instance_external_ipv4_soft_in,
        clear_ip_bgp_instance_external_ipv4_in_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " external ipv4 (unicast|multicast) in",
+       "clear ip bgp " BGP_INSTANCE_CMD " external ipv4 "BGP_SAFI_CMD_STR" in",
        CLEAR_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        "Clear all external peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR)
 
 DEFUN (clear_ip_bgp_external_ipv4_in_prefix_filter,
        clear_ip_bgp_external_ipv4_in_prefix_filter_cmd,
-       "clear ip bgp external ipv4 (unicast|multicast) in prefix-filter",
+       "clear ip bgp external ipv4 "BGP_SAFI_CMD_STR" in prefix-filter",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all external peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR
        "Push out prefix-list ORF and do inbound soft reconfig\n")
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_external,
-			  BGP_CLEAR_SOFT_IN_ORF_PREFIX, NULL);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_external,
-			BGP_CLEAR_SOFT_IN_ORF_PREFIX, NULL);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_external,
+                        BGP_CLEAR_SOFT_IN_ORF_PREFIX, NULL);
 }
 
 DEFUN (clear_bgp_external_soft_in,
@@ -9099,91 +9035,80 @@ DEFUN (clear_ip_bgp_as_in_prefix_filter,
 
 DEFUN (clear_ip_bgp_as_ipv4_soft_in,
        clear_ip_bgp_as_ipv4_soft_in_cmd,
-       "clear ip bgp " CMD_AS_RANGE " ipv4 (unicast|multicast) soft in",
+       "clear ip bgp " CMD_AS_RANGE " ipv4 "BGP_SAFI_CMD_STR" soft in",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear peers with the AS number\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_IN_STR)
 {
-  if (strncmp (argv[1], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_as,
-			  BGP_CLEAR_SOFT_IN, argv[0]);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_as,
-			BGP_CLEAR_SOFT_IN, argv[0]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[1]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_as,
+                        BGP_CLEAR_SOFT_IN, argv[0]);
 }
 
 DEFUN (clear_ip_bgp_instance_as_ipv4_soft_in,
        clear_ip_bgp_instance_as_ipv4_soft_in_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " " CMD_AS_RANGE " ipv4 (unicast|multicast) soft in",
+       "clear ip bgp " BGP_INSTANCE_CMD " " CMD_AS_RANGE " ipv4 "BGP_SAFI_CMD_STR" soft in",
        CLEAR_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        "Clear peers with the AS number\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR
        BGP_SOFT_IN_STR)
 {
-  if (strncmp (argv[3], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_as,
-			  BGP_CLEAR_SOFT_IN, argv[2]);
-
-  return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_UNICAST, clear_as,
-			BGP_CLEAR_SOFT_IN, argv[2]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[3]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_as,
+                        BGP_CLEAR_SOFT_IN, argv[2]);
 }
 
 ALIAS (clear_ip_bgp_as_ipv4_soft_in,
        clear_ip_bgp_as_ipv4_in_cmd,
-       "clear ip bgp " CMD_AS_RANGE " ipv4 (unicast|multicast) in",
+       "clear ip bgp " CMD_AS_RANGE " ipv4 "BGP_SAFI_CMD_STR" in",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear peers with the AS number\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR)
 
 ALIAS (clear_ip_bgp_instance_as_ipv4_soft_in,
        clear_ip_bgp_instance_as_ipv4_in_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " " CMD_AS_RANGE " ipv4 (unicast|multicast) in",
+       "clear ip bgp " BGP_INSTANCE_CMD " " CMD_AS_RANGE " ipv4 "BGP_SAFI_CMD_STR" in",
        CLEAR_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        "Clear peers with the AS number\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR)
 
 DEFUN (clear_ip_bgp_as_ipv4_in_prefix_filter,
        clear_ip_bgp_as_ipv4_in_prefix_filter_cmd,
-       "clear ip bgp " CMD_AS_RANGE " ipv4 (unicast|multicast) in prefix-filter",
+       "clear ip bgp " CMD_AS_RANGE " ipv4 "BGP_SAFI_CMD_STR" in prefix-filter",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear peers with the AS number\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_IN_STR
        "Push out prefix-list ORF and do inbound soft reconfig\n")
 {
-  if (strncmp (argv[1], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_as,
-			  BGP_CLEAR_SOFT_IN_ORF_PREFIX, argv[0]);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_as,
-			BGP_CLEAR_SOFT_IN_ORF_PREFIX, argv[0]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[1]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_as,
+                        BGP_CLEAR_SOFT_IN_ORF_PREFIX, argv[0]);
 }
 
 DEFUN (clear_ip_bgp_as_vpnv4_soft_in,
@@ -9378,7 +9303,7 @@ ALIAS (clear_ip_bgp_all_soft,
 
 DEFUN (clear_ip_bgp_all_ipv4_soft,
        clear_ip_bgp_all_ipv4_soft_cmd,
-       "clear ip bgp * ipv4 (unicast|multicast) soft",
+       "clear ip bgp * ipv4 "BGP_SAFI_CMD_STR" soft",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -9388,17 +9313,15 @@ DEFUN (clear_ip_bgp_all_ipv4_soft,
        "Address Family Modifier\n"
        BGP_SOFT_STR)
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_all,
-			  BGP_CLEAR_SOFT_BOTH, NULL);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_all,
-			BGP_CLEAR_SOFT_BOTH, NULL);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_all,
+                        BGP_CLEAR_SOFT_BOTH, NULL);
 }
 
 DEFUN (clear_ip_bgp_instance_all_ipv4_soft,
        clear_ip_bgp_instance_all_ipv4_soft_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " * ipv4 (unicast|multicast) soft",
+       "clear ip bgp " BGP_INSTANCE_CMD " * ipv4 "BGP_SAFI_CMD_STR" soft",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -9409,11 +9332,9 @@ DEFUN (clear_ip_bgp_instance_all_ipv4_soft,
        "Address Family Modifier\n"
        BGP_SOFT_STR)
 {
-  if (strncmp (argv[2], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_all,
-                          BGP_CLEAR_SOFT_BOTH, NULL);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_all,
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[2]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_all,
                         BGP_CLEAR_SOFT_BOTH, NULL);
 }
 
@@ -9522,7 +9443,7 @@ ALIAS (clear_ip_bgp_peer_soft,
 
 DEFUN (clear_ip_bgp_peer_ipv4_soft,
        clear_ip_bgp_peer_ipv4_soft_cmd,
-       "clear ip bgp (A.B.C.D|WORD) ipv4 (unicast|multicast) soft",
+       "clear ip bgp (A.B.C.D|WORD) ipv4 "BGP_SAFI_CMD_STR" soft",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -9533,17 +9454,15 @@ DEFUN (clear_ip_bgp_peer_ipv4_soft,
        "Address Family Modifier\n"
        BGP_SOFT_STR)
 {
-  if (strncmp (argv[1], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_peer,
-			  BGP_CLEAR_SOFT_BOTH, argv[0]);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_peer,
-			BGP_CLEAR_SOFT_BOTH, argv[0]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[1]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_peer,
+                        BGP_CLEAR_SOFT_BOTH, argv[0]);
 }
 
 DEFUN (clear_ip_bgp_instance_peer_ipv4_soft,
        clear_ip_bgp_instance_peer_ipv4_soft_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " (A.B.C.D|WORD) ipv4 (unicast|multicast) soft",
+       "clear ip bgp " BGP_INSTANCE_CMD " (A.B.C.D|WORD) ipv4 "BGP_SAFI_CMD_STR" soft",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -9555,12 +9474,10 @@ DEFUN (clear_ip_bgp_instance_peer_ipv4_soft,
        "Address Family Modifier\n"
        BGP_SOFT_STR)
 {
-  if (strncmp (argv[3], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_peer,
-			  BGP_CLEAR_SOFT_BOTH, argv[2]);
-
-  return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_UNICAST, clear_peer,
-			BGP_CLEAR_SOFT_BOTH, argv[2]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[3]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_peer,
+                        BGP_CLEAR_SOFT_BOTH, argv[2]);
 }
 
 DEFUN (clear_ip_bgp_peer_vpnv4_soft,
@@ -9677,28 +9594,25 @@ ALIAS (clear_ip_bgp_peer_group_soft,
 
 DEFUN (clear_ip_bgp_peer_group_ipv4_soft,
        clear_ip_bgp_peer_group_ipv4_soft_cmd,
-       "clear ip bgp peer-group WORD ipv4 (unicast|multicast) soft",
+       "clear ip bgp peer-group WORD ipv4 "BGP_SAFI_CMD_STR" soft",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all members of peer-group\n"
        "BGP peer-group name\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR)
 {
-  if (strncmp (argv[1], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_group,
-			  BGP_CLEAR_SOFT_BOTH, argv[0]);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_group,
-			BGP_CLEAR_SOFT_BOTH, argv[0]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[1]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_group,
+                        BGP_CLEAR_SOFT_BOTH, argv[0]);
 }
 
 DEFUN (clear_ip_bgp_instance_peer_group_ipv4_soft,
        clear_ip_bgp_instance_peer_group_ipv4_soft_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " peer-group WORD ipv4 (unicast|multicast) soft",
+       "clear ip bgp " BGP_INSTANCE_CMD " peer-group WORD ipv4 "BGP_SAFI_CMD_STR" soft",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -9706,16 +9620,13 @@ DEFUN (clear_ip_bgp_instance_peer_group_ipv4_soft,
        "Clear all members of peer-group\n"
        "BGP peer-group name\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR)
 {
-  if (strncmp (argv[3], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_group,
-			  BGP_CLEAR_SOFT_BOTH, argv[2]);
-
-  return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_UNICAST, clear_group,
-			BGP_CLEAR_SOFT_BOTH, argv[2]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[3]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_group,
+                        BGP_CLEAR_SOFT_BOTH, argv[2]);
 }
 
 DEFUN (clear_bgp_peer_group_soft,
@@ -9795,43 +9706,37 @@ ALIAS (clear_ip_bgp_external_soft,
 
 DEFUN (clear_ip_bgp_external_ipv4_soft,
        clear_ip_bgp_external_ipv4_soft_cmd,
-       "clear ip bgp external ipv4 (unicast|multicast) soft",
+       "clear ip bgp external ipv4 "BGP_SAFI_CMD_STR" soft",
        CLEAR_STR
        IP_STR
        BGP_STR
        "Clear all external peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR)
 {
-  if (strncmp (argv[0], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_external,
-			  BGP_CLEAR_SOFT_BOTH, NULL);
-
-  return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_UNICAST, clear_external,
-			BGP_CLEAR_SOFT_BOTH, NULL);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[0]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_external,
+                        BGP_CLEAR_SOFT_BOTH, NULL);
 }
 
 DEFUN (clear_ip_bgp_instance_external_ipv4_soft,
        clear_ip_bgp_instance_external_ipv4_soft_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " external ipv4 (unicast|multicast) soft",
+       "clear ip bgp " BGP_INSTANCE_CMD " external ipv4 "BGP_SAFI_CMD_STR" soft",
        CLEAR_STR
        IP_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
        "Clear all external peers\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        BGP_SOFT_STR)
 {
-  if (strncmp (argv[2], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_external,
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[2]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_external,
 			  BGP_CLEAR_SOFT_BOTH, NULL);
-
-  return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_UNICAST, clear_external,
-			BGP_CLEAR_SOFT_BOTH, NULL);
 }
 
 DEFUN (clear_bgp_external_soft,
@@ -9907,7 +9812,7 @@ ALIAS (clear_ip_bgp_as_soft,
 
 DEFUN (clear_ip_bgp_as_ipv4_soft,
        clear_ip_bgp_as_ipv4_soft_cmd,
-       "clear ip bgp " CMD_AS_RANGE " ipv4 (unicast|multicast) soft",
+       "clear ip bgp " CMD_AS_RANGE " ipv4 "BGP_SAFI_CMD_STR" soft",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -9917,17 +9822,15 @@ DEFUN (clear_ip_bgp_as_ipv4_soft,
        "Address Family Modifier\n"
        BGP_SOFT_STR)
 {
-  if (strncmp (argv[1], "m", 1) == 0)
-    return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_MULTICAST, clear_as,
-			  BGP_CLEAR_SOFT_BOTH, argv[0]);
-
-  return bgp_clear_vty (vty, NULL,AFI_IP, SAFI_UNICAST, clear_as,
-			BGP_CLEAR_SOFT_BOTH, argv[0]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[1]);
+  return bgp_clear_vty (vty, NULL, AFI_IP, safi, clear_as,
+                        BGP_CLEAR_SOFT_BOTH, argv[0]);
 }
 
 DEFUN (clear_ip_bgp_instance_as_ipv4_soft,
        clear_ip_bgp_instance_as_ipv4_soft_cmd,
-       "clear ip bgp " BGP_INSTANCE_CMD " " CMD_AS_RANGE " ipv4 (unicast|multicast) soft",
+       "clear ip bgp " BGP_INSTANCE_CMD " " CMD_AS_RANGE " ipv4 "BGP_SAFI_CMD_STR" soft",
        CLEAR_STR
        IP_STR
        BGP_STR
@@ -9938,12 +9841,10 @@ DEFUN (clear_ip_bgp_instance_as_ipv4_soft,
        "Address Family Modifier\n"
        BGP_SOFT_STR)
 {
-  if (strncmp (argv[3], "m", 1) == 0)
-    return bgp_clear_vty (vty, argv[1], AFI_IP, SAFI_MULTICAST, clear_as,
-			  BGP_CLEAR_SOFT_BOTH, argv[2]);
-
-  return bgp_clear_vty (vty, argv[1],AFI_IP, SAFI_UNICAST, clear_as,
-			BGP_CLEAR_SOFT_BOTH, argv[2]);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[3]);
+  return bgp_clear_vty (vty, argv[1], AFI_IP, safi, clear_as,
+                        BGP_CLEAR_SOFT_BOTH, argv[2]);
 }
 
 DEFUN (clear_ip_bgp_as_vpnv4_soft,
@@ -10634,10 +10535,10 @@ bgp_show_summary (struct vty *vty, struct bgp *bgp, int afi, int safi,
         {
           if (use_json)
             vty_out(vty, "{\"error\": {\"message\": \"No %s neighbor configured\"}}%s",
-                    afi == AFI_IP ? "IPv4" : "IPv6", VTY_NEWLINE);
+                    afi_safi_print(afi, safi), VTY_NEWLINE);
           else
             vty_out (vty, "No %s neighbor is configured%s",
-                     afi == AFI_IP ? "IPv4" : "IPv6", VTY_NEWLINE);
+                     afi_safi_print(afi, safi), VTY_NEWLINE);
         }
 
       if (dn_count && ! use_json)
@@ -10778,7 +10679,7 @@ DEFUN (show_ip_bgp_ipv4_summary,
        SHOW_STR
        IP_STR
        BGP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "Summary of BGP neighbor status\n"
        "JavaScript Object Notation\n")
 {
@@ -10792,38 +10693,36 @@ ALIAS (show_ip_bgp_ipv4_summary,
        "show bgp ipv4 (unicast|multicast|vpn|encap) summary {json}",
        SHOW_STR
        BGP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "Summary of BGP neighbor status\n")
 
 DEFUN (show_ip_bgp_instance_ipv4_summary,
        show_ip_bgp_instance_ipv4_summary_cmd,
-       "show ip bgp view WORD ipv4 (unicast|multicast) summary {json}",
+       "show ip bgp view WORD ipv4 "BGP_SAFI_CMD_STR" summary {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "BGP view\n"
        "View name\n"
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Summary of BGP neighbor status\n"
        "JavaScript Object Notation\n")
 {
   u_char uj = use_json(argc, argv);
-  if (strncmp (argv[1], "m", 1) == 0)
-    return bgp_show_summary_vty (vty, argv[0], AFI_IP, SAFI_MULTICAST, uj);
-  else
-    return bgp_show_summary_vty (vty, argv[0], AFI_IP, SAFI_UNICAST, uj);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[1]);
+  return bgp_show_summary_vty (vty, argv[0], AFI_IP, safi, uj);
 }
 
 ALIAS (show_ip_bgp_instance_ipv4_summary,
        show_bgp_instance_ipv4_safi_summary_cmd,
-       "show bgp view WORD ipv4 (unicast|multicast) summary {json}",
+       "show bgp view WORD ipv4 "BGP_SAFI_CMD_STR" summary {json}",
        SHOW_STR
        BGP_STR
        "BGP view\n"
        "View name\n"
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "Summary of BGP neighbor status\n")
 
 DEFUN (show_ip_bgp_vpnv4_all_summary,
@@ -10928,7 +10827,7 @@ DEFUN (show_bgp_ipv6_safi_summary,
        "show bgp ipv6 (unicast|multicast|vpn|encap) summary {json}",
        SHOW_STR
        BGP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "Summary of BGP neighbor status\n"
        "JavaScript Object Notation\n")
 {
@@ -10939,19 +10838,18 @@ DEFUN (show_bgp_ipv6_safi_summary,
 
 DEFUN (show_bgp_instance_ipv6_safi_summary,
        show_bgp_instance_ipv6_safi_summary_cmd,
-       "show bgp " BGP_INSTANCE_CMD " ipv6 (unicast|multicast) summary {json}",
+       "show bgp " BGP_INSTANCE_CMD " ipv6 "BGP_SAFI_CMD_STR" summary {json}",
        SHOW_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "Summary of BGP neighbor status\n"
        "JavaScript Object Notation\n")
 {
   u_char uj = use_json(argc, argv);
-  if (strncmp (argv[2], "m", 1) == 0)
-    return bgp_show_summary_vty (vty, argv[1], AFI_IP6, SAFI_MULTICAST, uj);
-
-  return bgp_show_summary_vty (vty, argv[1], AFI_IP6, SAFI_UNICAST, uj);
+  safi_t safi;
+  safi = bgp_vty_safi_from_arg(argv[2]);
+  return bgp_show_summary_vty (vty, argv[1], AFI_IP6, safi, uj);
 }
 
 /* old command */
@@ -10991,17 +10889,17 @@ afi_safi_print (afi_t afi, safi_t safi)
   else if (afi == AFI_IP && safi == SAFI_MULTICAST)
     return "IPv4 Multicast";
   else if (afi == AFI_IP && safi == SAFI_MPLS_VPN)
-    return "VPN-IPv4 Unicast";
+    return "IPv4 VPN";
   else if (afi == AFI_IP && safi == SAFI_ENCAP)
-    return "ENCAP-IPv4 Unicast";
+    return "IPv4 Encap";
   else if (afi == AFI_IP6 && safi == SAFI_UNICAST)
     return "IPv6 Unicast";
   else if (afi == AFI_IP6 && safi == SAFI_MULTICAST)
     return "IPv6 Multicast";
   else if (afi == AFI_IP6 && safi == SAFI_MPLS_VPN)
-    return "VPN-IPv6 Unicast";
+    return "IPv6 VPN";
   else if (afi == AFI_IP6 && safi == SAFI_ENCAP)
-    return "ENCAP-IPv6 Unicast";
+    return "IPv6 Encap";
   else
     return "Unknown";
 }
@@ -12826,13 +12724,12 @@ DEFUN (show_ip_bgp_neighbors,
 
 ALIAS (show_ip_bgp_neighbors,
        show_ip_bgp_ipv4_neighbors_cmd,
-       "show ip bgp ipv4 (unicast|multicast) neighbors {json}",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Detailed information on TCP and BGP neighbor connections\n"
        "JavaScript Object Notation\n")
 
@@ -12895,13 +12792,12 @@ DEFUN (show_ip_bgp_neighbors_peer,
 
 ALIAS (show_ip_bgp_neighbors_peer,
        show_ip_bgp_ipv4_neighbors_peer_cmd,
-       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) {json}",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -13066,13 +12962,12 @@ DEFUN (show_ip_bgp_paths,
 
 DEFUN (show_ip_bgp_ipv4_paths, 
        show_ip_bgp_ipv4_paths_cmd,
-       "show ip bgp ipv4 (unicast|multicast) paths",
+       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" paths",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_SAFI_HELP_STR
        "Path information\n")
 {
   vty_out (vty, "Address Refcnt Path\r\n");
@@ -13227,19 +13122,16 @@ DEFUN (show_bgp_instance_all_ipv6_updgrps,
 
 DEFUN (show_bgp_updgrps,
        show_bgp_updgrps_cmd,
-       "show bgp (ipv4|ipv6) (unicast|multicast|vpn|encap) update-groups",
+       "show bgp "BGP_AFI_SAFI_CMD_STR" update-groups",
        SHOW_STR
        BGP_STR
-       "Address family\n"
-       "Address family\n"
-       "Address Family modifier\n"
-       "Address Family modifier\n"
+       BGP_AFI_SAFI_HELP_STR
        "Detailed info about dynamic update groups\n")
 {
   afi_t afi;
   safi_t safi;
 
-  afi = (strcmp(argv[0], "ipv4") == 0) ? AFI_IP : AFI_IP6;
+  afi = bgp_vty_safi_from_arg(argv[0]);
   safi = bgp_vty_safi_from_arg(argv[1]);
   return (bgp_show_update_groups(vty, NULL, afi, safi, 0));
 }
@@ -13305,11 +13197,11 @@ DEFUN (show_bgp_instance_ipv6_updgrps_s,
 
 DEFUN (show_bgp_updgrps_s,
        show_bgp_updgrps_s_cmd,
-       "show bgp (ipv4|ipv6) (unicast|multicast|vpn|encap) update-groups SUBGROUP-ID",
+       "show bgp "BGP_AFI_SAFI_CMD_STR" update-groups SUBGROUP-ID",
        SHOW_STR
        BGP_STR
        "Address family\n"
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "Detailed info about v6 dynamic update groups\n"
        "Specific subgroup to display detailed info for")
 {
@@ -13317,7 +13209,7 @@ DEFUN (show_bgp_updgrps_s,
   safi_t safi;
   uint64_t subgrp_id;
 
-  afi = (strcmp(argv[0], "ipv4") == 0) ? AFI_IP : AFI_IP6;
+  afi = bgp_vty_safi_from_arg(argv[0]);
   safi = bgp_vty_safi_from_arg(argv[1]);
   VTY_GET_ULL("subgroup-id", subgrp_id, argv[2]);
   return(bgp_show_update_groups(vty, NULL, afi, safi, subgrp_id));
@@ -13416,11 +13308,10 @@ DEFUN (show_ip_bgp_instance_updgrps_adj,
 
 DEFUN (show_bgp_updgrps_afi_adj,
        show_bgp_updgrps_afi_adj_cmd,
-       "show bgp (ipv4|ipv6) (unicast|multicast|vpn|encap) update-groups (advertise-queue|advertised-routes|packet-queue)",
+       "show bgp "BGP_AFI_SAFI_CMD_STR" update-groups (advertise-queue|advertised-routes|packet-queue)",
        SHOW_STR
        BGP_STR
-       "Address family\n"
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "BGP update groups\n"
        "Advertisement queue\n"
        "Announced routes\n"
@@ -13430,7 +13321,7 @@ DEFUN (show_bgp_updgrps_afi_adj,
   afi_t afi;
   safi_t safi;
 
-  afi = (strcmp(argv[0], "ipv4") == 0) ? AFI_IP : AFI_IP6;
+  afi = bgp_vty_safi_from_arg(argv[0]);
   safi = bgp_vty_safi_from_arg(argv[1]);
   show_bgp_updgrps_adj_info_aux(vty, NULL, afi, safi, argv[2], 0);
   return CMD_SUCCESS;
@@ -13510,11 +13401,10 @@ DEFUN (show_ip_bgp_instance_updgrps_adj_s,
 
 DEFUN (show_bgp_updgrps_afi_adj_s,
        show_bgp_updgrps_afi_adj_s_cmd,
-       "show bgp (ipv4|ipv6) (unicast|multicast|vpn|encap) update-groups SUBGROUP-ID (advertise-queue|advertised-routes|packet-queue)",
+       "show bgp "BGP_AFI_SAFI_CMD_STR" update-groups SUBGROUP-ID (advertise-queue|advertised-routes|packet-queue)",
        SHOW_STR
        BGP_STR
-       "Address family\n"
-       AFI_SAFI_STR
+       BGP_AFI_SAFI_HELP_STR
        "BGP update groups\n"
        "Specific subgroup to display info for\n"
        "Advertisement queue\n"
@@ -13526,7 +13416,7 @@ DEFUN (show_bgp_updgrps_afi_adj_s,
   safi_t safi;
   uint64_t subgrp_id;
 
-  afi = (strcmp(argv[0], "ipv4") == 0) ? AFI_IP : AFI_IP6;
+  afi = bgp_vty_safi_from_arg(argv[0]);
   safi = bgp_vty_safi_from_arg(argv[1]);
   VTY_GET_ULL("subgroup-id", subgrp_id, argv[2]);
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6139,12 +6139,14 @@ DEFUN (address_family_vpnv4,
   return CMD_SUCCESS;
 }
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 ALIAS (address_family_vpnv4,
        address_family_vpnv4_unicast_cmd,
        "address-family vpnv4 unicast",
        "Enter Address Family command mode\n"
        "Address family\n"
        "Address Family Modifier\n")
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (address_family_vpnv6,
        address_family_vpnv6_cmd,
@@ -6156,12 +6158,14 @@ DEFUN (address_family_vpnv6,
   return CMD_SUCCESS;
 }
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 ALIAS (address_family_vpnv6,
        address_family_vpnv6_unicast_cmd,
        "address-family vpnv6 unicast",
        "Enter Address Family command mode\n"
        "Address family\n"
        "Address Family Modifier\n")
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (address_family_encap,
        address_family_encap_cmd,
@@ -6730,6 +6734,7 @@ ALIAS (clear_ip_bgp_instance_all_ipv4_soft_out,
        BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (clear_ip_bgp_all_vpnv4_soft_out,
        clear_ip_bgp_all_vpnv4_soft_out_cmd,
        "clear ip bgp * vpnv4 unicast soft out",
@@ -6783,6 +6788,7 @@ ALIAS (clear_ip_bgp_all_encap_soft_out,
        "Address family\n"
        "Address Family Modifier\n"
        "Soft reconfig outbound update\n")
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (clear_bgp_all_soft_out,
        clear_bgp_all_soft_out_cmd,
@@ -7015,6 +7021,7 @@ ALIAS (clear_ip_bgp_instance_peer_ipv4_soft_out,
        BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 /* NOTE: WORD peers have not been tested for vpnv4 */
 DEFUN (clear_ip_bgp_peer_vpnv4_soft_out,
        clear_ip_bgp_peer_vpnv4_soft_out_cmd,
@@ -7071,6 +7078,7 @@ ALIAS (clear_ip_bgp_peer_encap_soft_out,
        "Address family\n"
        "Address Family Modifier\n"
        "Soft reconfig outbound update\n")
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (clear_bgp_peer_soft_out,
        clear_bgp_peer_soft_out_cmd,
@@ -7680,6 +7688,7 @@ ALIAS (clear_ip_bgp_instance_as_ipv4_soft_out,
        BGP_SAFI_HELP_STR
        BGP_SOFT_OUT_STR)
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (clear_ip_bgp_as_vpnv4_soft_out,
        clear_ip_bgp_as_vpnv4_soft_out_cmd,
        "clear ip bgp " CMD_AS_RANGE " vpnv4 unicast soft out",
@@ -7733,6 +7742,7 @@ ALIAS (clear_ip_bgp_as_encap_soft_out,
        "Address family\n"
        "Address Family modifier\n"
        "Soft reconfig outbound update\n")
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (clear_bgp_as_soft_out,
        clear_bgp_as_soft_out_cmd,
@@ -7963,6 +7973,7 @@ DEFUN (clear_ip_bgp_all_ipv4_in_prefix_filter,
                         BGP_CLEAR_SOFT_IN_ORF_PREFIX, NULL);
 }
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (clear_ip_bgp_all_vpnv4_soft_in,
        clear_ip_bgp_all_vpnv4_soft_in_cmd,
        "clear ip bgp * vpnv4 unicast soft in",
@@ -8016,6 +8027,7 @@ ALIAS (clear_ip_bgp_all_encap_soft_in,
        "Address family\n"
        "Address Family Modifier\n"
        "Soft reconfig inbound update\n")
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (clear_bgp_all_soft_in,
        clear_bgp_all_soft_in_cmd,
@@ -8274,6 +8286,7 @@ DEFUN (clear_ip_bgp_peer_ipv4_in_prefix_filter,
                         BGP_CLEAR_SOFT_IN_ORF_PREFIX, argv[0]);
 }
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (clear_ip_bgp_peer_vpnv4_soft_in,
        clear_ip_bgp_peer_vpnv4_soft_in_cmd,
        "clear ip bgp (A.B.C.D|WORD) vpnv4 unicast soft in",
@@ -8329,6 +8342,7 @@ ALIAS (clear_ip_bgp_peer_encap_soft_in,
        "Address family\n"
        "Address Family Modifier\n"
        "Soft reconfig inbound update\n")
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (clear_bgp_peer_soft_in,
        clear_bgp_peer_soft_in_cmd,
@@ -9111,6 +9125,7 @@ DEFUN (clear_ip_bgp_as_ipv4_in_prefix_filter,
                         BGP_CLEAR_SOFT_IN_ORF_PREFIX, argv[0]);
 }
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (clear_ip_bgp_as_vpnv4_soft_in,
        clear_ip_bgp_as_vpnv4_soft_in_cmd,
        "clear ip bgp " CMD_AS_RANGE " vpnv4 unicast soft in",
@@ -9164,6 +9179,7 @@ ALIAS (clear_ip_bgp_as_encap_soft_in,
        "Address family\n"
        "Address Family modifier\n"
        "Soft reconfig inbound update\n")
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (clear_bgp_as_soft_in,
        clear_bgp_as_soft_in_cmd,
@@ -9338,6 +9354,7 @@ DEFUN (clear_ip_bgp_instance_all_ipv4_soft,
                         BGP_CLEAR_SOFT_BOTH, NULL);
 }
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (clear_ip_bgp_all_vpnv4_soft,
        clear_ip_bgp_all_vpnv4_soft_cmd,
        "clear ip bgp * vpnv4 unicast soft",
@@ -9367,6 +9384,7 @@ DEFUN (clear_ip_bgp_all_encap_soft,
   return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_ENCAP, clear_all,
 			BGP_CLEAR_SOFT_BOTH, argv[0]);
 }
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (clear_bgp_all_soft,
        clear_bgp_all_soft_cmd,
@@ -9480,6 +9498,7 @@ DEFUN (clear_ip_bgp_instance_peer_ipv4_soft,
                         BGP_CLEAR_SOFT_BOTH, argv[2]);
 }
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (clear_ip_bgp_peer_vpnv4_soft,
        clear_ip_bgp_peer_vpnv4_soft_cmd,
        "clear ip bgp (A.B.C.D|WORD) vpnv4 unicast soft",
@@ -9510,6 +9529,7 @@ DEFUN (clear_ip_bgp_peer_encap_soft,
   return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_ENCAP, clear_peer,
 			BGP_CLEAR_SOFT_BOTH, argv[0]);
 }
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (clear_bgp_peer_soft,
        clear_bgp_peer_soft_cmd,
@@ -9847,6 +9867,7 @@ DEFUN (clear_ip_bgp_instance_as_ipv4_soft,
                         BGP_CLEAR_SOFT_BOTH, argv[2]);
 }
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (clear_ip_bgp_as_vpnv4_soft,
        clear_ip_bgp_as_vpnv4_soft_cmd,
        "clear ip bgp " CMD_AS_RANGE " vpnv4 unicast soft",
@@ -9876,6 +9897,7 @@ DEFUN (clear_ip_bgp_as_encap_soft,
   return bgp_clear_vty (vty, NULL, AFI_IP, SAFI_ENCAP, clear_as,
 			BGP_CLEAR_SOFT_BOTH, argv[0]);
 }
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 DEFUN (clear_bgp_as_soft,
        clear_bgp_as_soft_cmd,
@@ -10783,6 +10805,7 @@ ALIAS (show_ip_bgp_instance_ipv4_summary,
        BGP_AFI_SAFI_HELP_STR
        "Summary of BGP neighbor status\n")
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 DEFUN (show_ip_bgp_vpnv4_all_summary,
        show_ip_bgp_vpnv4_all_summary_cmd,
        "show ip bgp vpnv4 all summary {json}",
@@ -10823,6 +10846,7 @@ DEFUN (show_ip_bgp_vpnv4_rd_summary,
 
   return bgp_show_summary_vty (vty, NULL, AFI_IP, SAFI_MPLS_VPN, uj);
 }
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 #ifdef HAVE_IPV6
 DEFUN (show_bgp_summary,
@@ -12821,6 +12845,7 @@ ALIAS (show_ip_bgp_neighbors,
        "Detailed information on TCP and BGP neighbor connections\n"
        "JavaScript Object Notation\n")
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 ALIAS (show_ip_bgp_neighbors,
        show_ip_bgp_vpnv4_all_neighbors_cmd,
        "show ip bgp vpnv4 all neighbors {json}",
@@ -12843,6 +12868,7 @@ ALIAS (show_ip_bgp_neighbors,
        "VPN Route Distinguisher\n"
        "Detailed information on TCP and BGP neighbor connections\n"
        "JavaScript Object Notation\n")
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 ALIAS (show_ip_bgp_neighbors,
        show_bgp_neighbors_cmd,
@@ -12892,6 +12918,7 @@ ALIAS (show_ip_bgp_neighbors_peer,
        "Neighbor on bgp configured interface\n"
        "JavaScript Object Notation\n")
 
+#ifdef KEEP_OLD_VPNV4_COMMANDS
 ALIAS (show_ip_bgp_neighbors_peer,
        show_ip_bgp_vpnv4_all_neighbors_peer_cmd,
        "show ip bgp vpnv4 all neighbors A.B.C.D {json}",
@@ -12915,6 +12942,7 @@ ALIAS (show_ip_bgp_neighbors_peer,
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "JavaScript Object Notation\n")
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
 ALIAS (show_ip_bgp_neighbors_peer,
        show_bgp_neighbors_peer_cmd,
@@ -15617,10 +15645,14 @@ bgp_vty_init (void)
   install_element (BGP_NODE, &address_family_ipv6_safi_cmd);
 #endif /* HAVE_IPV6 */
   install_element (BGP_NODE, &address_family_vpnv4_cmd);
+#ifdef KEEP_OLD_VPNV4_COMMANDS
   install_element (BGP_NODE, &address_family_vpnv4_unicast_cmd);
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
   install_element (BGP_NODE, &address_family_vpnv6_cmd);
+#ifdef KEEP_OLD_VPNV4_COMMANDS
   install_element (BGP_NODE, &address_family_vpnv6_unicast_cmd);
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 
   install_element (BGP_NODE, &address_family_encap_cmd);
   install_element (BGP_NODE, &address_family_encapv4_cmd);
@@ -15722,6 +15754,7 @@ bgp_vty_init (void)
   install_element (ENABLE_NODE, &clear_ip_bgp_as_ipv4_in_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_instance_as_ipv4_in_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_as_ipv4_in_prefix_filter_cmd);
+#ifdef KEEP_OLD_VPNV4_COMMANDS
   install_element (ENABLE_NODE, &clear_ip_bgp_all_vpnv4_soft_in_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_all_vpnv4_in_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_peer_vpnv4_soft_in_cmd);
@@ -15734,6 +15767,7 @@ bgp_vty_init (void)
   install_element (ENABLE_NODE, &clear_ip_bgp_peer_encap_in_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_as_encap_soft_in_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_as_encap_in_cmd);
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
   install_element (ENABLE_NODE, &clear_bgp_all_soft_in_cmd);
   install_element (ENABLE_NODE, &clear_bgp_instance_all_soft_in_cmd);
   install_element (ENABLE_NODE, &clear_bgp_all_in_cmd);
@@ -15832,6 +15866,7 @@ bgp_vty_init (void)
   install_element (ENABLE_NODE, &clear_ip_bgp_instance_as_ipv4_soft_out_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_as_ipv4_out_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_instance_as_ipv4_out_cmd);
+#ifdef KEEP_OLD_VPNV4_COMMANDS
   install_element (ENABLE_NODE, &clear_ip_bgp_all_vpnv4_soft_out_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_all_vpnv4_out_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_peer_vpnv4_soft_out_cmd);
@@ -15844,6 +15879,7 @@ bgp_vty_init (void)
   install_element (ENABLE_NODE, &clear_ip_bgp_peer_encap_out_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_as_encap_soft_out_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_as_encap_out_cmd);
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
   install_element (ENABLE_NODE, &clear_bgp_all_soft_out_cmd);
   install_element (ENABLE_NODE, &clear_bgp_instance_all_soft_out_cmd);
   install_element (ENABLE_NODE, &clear_bgp_all_out_cmd);
@@ -15906,12 +15942,14 @@ bgp_vty_init (void)
   install_element (ENABLE_NODE, &clear_ip_bgp_instance_external_ipv4_soft_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_as_ipv4_soft_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_instance_as_ipv4_soft_cmd);
+#ifdef KEEP_OLD_VPNV4_COMMANDS
   install_element (ENABLE_NODE, &clear_ip_bgp_all_vpnv4_soft_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_peer_vpnv4_soft_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_as_vpnv4_soft_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_all_encap_soft_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_peer_encap_soft_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_as_encap_soft_cmd);
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
   install_element (ENABLE_NODE, &clear_bgp_all_soft_cmd);
   install_element (ENABLE_NODE, &clear_bgp_instance_all_soft_cmd);
   install_element (ENABLE_NODE, &clear_bgp_peer_soft_cmd);
@@ -15963,8 +16001,10 @@ bgp_vty_init (void)
   install_element (VIEW_NODE, &show_bgp_ipv4_safi_summary_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_instance_ipv4_summary_cmd);
   install_element (VIEW_NODE, &show_bgp_instance_ipv4_safi_summary_cmd);
+#ifdef KEEP_OLD_VPNV4_COMMANDS
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_summary_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_rd_summary_cmd);
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
 #ifdef HAVE_IPV6
   install_element (VIEW_NODE, &show_bgp_summary_cmd);
   install_element (VIEW_NODE, &show_bgp_instance_summary_cmd);
@@ -15980,10 +16020,12 @@ bgp_vty_init (void)
   install_element (VIEW_NODE, &show_ip_bgp_ipv4_neighbors_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_neighbors_peer_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_ipv4_neighbors_peer_cmd);
+#ifdef KEEP_OLD_VPNV4_COMMANDS
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_neighbors_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_rd_neighbors_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_neighbors_peer_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_rd_neighbors_peer_cmd);
+#endif  /* KEEP_OLD_VPNV4_COMMANDS */
   install_element (VIEW_NODE, &show_ip_bgp_instance_neighbors_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_instance_all_neighbors_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_instance_neighbors_peer_cmd);

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -30,12 +30,16 @@ struct bgp;
 #define BGP_INSTANCE_ALL_CMD "(view|vrf) all"
 #define BGP_INSTANCE_ALL_HELP_STR "BGP view\nBGP VRF\nAll Views/VRFs\n"
 
-#define AFI_SAFI_STR \
-  "Address family\n" \
-  "Address Family modifier\n" \
-  "Address Family modifier\n" \
-  "Address Family modifier\n" \
+#define BGP_AFI_CMD_STR         "(ipv4|ipv6)"
+#define BGP_AFI_HELP_STR        "Address Family\nAddress Family\n"
+#define BGP_SAFI_CMD_STR        "(unicast|multicast|vpn|encap)"
+#define BGP_SAFI_HELP_STR       \
+  "Address Family modifier\n"   \
+  "Address Family modifier\n"   \
+  "Address Family modifier\n"   \
   "Address Family modifier\n"
+#define BGP_AFI_SAFI_CMD_STR    BGP_AFI_CMD_STR" "BGP_SAFI_CMD_STR
+#define BGP_AFI_SAFI_HELP_STR   BGP_AFI_HELP_STR BGP_SAFI_HELP_STR
 
 extern void bgp_vty_init (void);
 extern const char *afi_safi_print (afi_t, safi_t);
@@ -52,6 +56,9 @@ bgp_parse_afi(const char *str, afi_t *afi);
 
 extern int
 bgp_parse_safi(const char *str, safi_t *safi);
+
+extern afi_t
+bgp_vty_afi_from_arg(const char *afi_str);
 
 extern safi_t
 bgp_vty_safi_from_arg(const char *safi_str);

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -43,6 +43,7 @@ struct bgp;
 
 extern void bgp_vty_init (void);
 extern const char *afi_safi_print (afi_t, safi_t);
+extern const char *afi_safi_json (afi_t, safi_t);
 extern int bgp_config_write_update_delay (struct vty *, struct bgp *);
 extern int bgp_config_write_wpkt_quanta(struct vty *vty, struct bgp *bgp);
 extern int bgp_config_write_listen(struct vty *vty, struct bgp *bgp);


### PR DESCRIPTION
Replace https://github.com/freerangerouting/frr/pull/62
    bgpd: conditionally compile out old vpnv4 syntax (Issue #61)
          (under ifdef KEEP_OLD_VPNV4_COMMANDS)
    bgpd: restore wildcard handling in show summary (Issue#14)
          Includes more branch specific afi/safi changes
    bgpd: restore some missing afi/safi commands (Issue #14)
          Added defines and parse utility functions
          Fix vty code that treated vpn&encap as AFIs
          and some other related vty printing/handline issues
          Note: Includes branch specific changes (due to new parser)

Addresses comments and one cut and paste bug