### PR TITLE
VPNv6 Improvements ( version 2)

### DIFF
--- a/bgpd/bgp_mpath.c
+++ b/bgpd/bgp_mpath.c
@@ -113,7 +113,6 @@ bgp_info_nexthop_cmp (struct bgp_info *bi1, struct bgp_info *bi2)
   ae2 = bi2->attr->extra;
 
   compare = IPV4_ADDR_CMP (&bi1->attr->nexthop, &bi2->attr->nexthop);
-
   if (!compare && ae1 && ae2)
     {
       if (ae1->mp_nexthop_len == ae2->mp_nexthop_len)
@@ -127,6 +126,7 @@ bgp_info_nexthop_cmp (struct bgp_info *bi1, struct bgp_info *bi2)
               break;
 #ifdef HAVE_IPV6
             case BGP_ATTR_NHLEN_IPV6_GLOBAL:
+            case BGP_ATTR_NHLEN_VPNV6_GLOBAL:
               compare = IPV6_ADDR_CMP (&ae1->mp_nexthop_global,
                                        &ae2->mp_nexthop_global);
               break;

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -963,7 +963,7 @@ DEFUN (show_bgp_ip_vpn_rd,
        SHOW_STR
        IP_STR
        BGP_STR
-       "Address Family\n"
+       BGP_VPNVX_HELP_STR
        "Display VPN NLRI specific information\n"
        "Display information for a route distinguisher\n"
        "VPN Route Distinguisher\n"
@@ -1001,7 +1001,6 @@ DEFUN (show_ip_bgp_vpn_all,
        SHOW_STR
        IP_STR
        BGP_STR
-       "Address Family\n"
        BGP_VPNVX_HELP_STR)
 {
   afi_t afi;
@@ -1018,7 +1017,6 @@ DEFUN (show_ip_bgp_vpn_rd,
        SHOW_STR
        IP_STR
        BGP_STR
-       "Address Family\n"
        BGP_VPNVX_HELP_STR
        "Display information for a route distinguisher\n"
        "VPN Route Distinguisher\n")
@@ -1048,7 +1046,6 @@ DEFUN (show_ip_bgp_vpn_all_tags,
        SHOW_STR
        IP_STR
        BGP_STR
-       "Address Family\n"
        BGP_VPNVX_HELP_STR
        "Display information about all VPNv4/VPNV6 NLRIs\n"
        "Display BGP tags for prefixes\n")
@@ -1067,7 +1064,6 @@ DEFUN (show_ip_bgp_vpn_rd_tags,
        SHOW_STR
        IP_STR
        BGP_STR
-       "Address Family\n"
        BGP_VPNVX_HELP_STR
        "Display information for a route distinguisher\n"
        "VPN Route Distinguisher\n"
@@ -1098,7 +1094,6 @@ DEFUN (show_ip_bgp_vpn_all_neighbor_routes,
        SHOW_STR
        IP_STR
        BGP_STR
-       "Address Family\n"
        BGP_VPNVX_HELP_STR
        "Display information about all VPNv4/VPNv6 NLRIs\n"
        "Detailed information on TCP and BGP neighbor connections\n"
@@ -1159,7 +1154,6 @@ DEFUN (show_ip_bgp_vpn_rd_neighbor_routes,
        SHOW_STR
        IP_STR
        BGP_STR
-       "Address Family\n"
        BGP_VPNVX_HELP_STR
        "Display information for a route distinguisher\n"
        "VPN Route Distinguisher\n"
@@ -1239,7 +1233,6 @@ DEFUN (show_ip_bgp_vpn_all_neighbor_advertised_routes,
        SHOW_STR
        IP_STR
        BGP_STR
-       "Address Family\n"
        BGP_VPNVX_HELP_STR
        "Display information about all VPNv4/VPNv6 NLRIs\n"
        "Detailed information on TCP and BGP neighbor connections\n"
@@ -1299,7 +1292,6 @@ DEFUN (show_ip_bgp_vpn_rd_neighbor_advertised_routes,
        SHOW_STR
        IP_STR
        BGP_STR
-       "Address Family\n"
        BGP_VPNVX_HELP_STR
        "Display information for a route distinguisher\n"
        "VPN Route Distinguisher\n"

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -520,7 +520,7 @@ DEFUN (no_vpnv4_network,
 
 DEFUN (vpnv6_network,
        vpnv6_network_cmd,
-       "network X:X::X:X/M rd ASN:nn_or_IP-address:nn tag WORD",
+       "network X:X::X:X/M rd ASN:nn_or_IP-address:nn tag WORD [route-map WORD]",
        "Specify a network to announce via BGP\n"
        "IPv6 prefix <network>/<length>, e.g., 3ffe::/16\n"
        "Specify Route Distinguisher\n"
@@ -531,26 +531,11 @@ DEFUN (vpnv6_network,
   int idx_ipv6_prefix = 1;
   int idx_ext_community = 3;
   int idx_word = 5;
-  return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, NULL);
-}
-
-DEFUN (vpnv6_network_route_map,
-       vpnv6_network_route_map_cmd,
-       "network X:X::X:X/M rd ASN:nn_or_IP-address:nn tag WORD route-map WORD",
-       "Specify a network to announce via BGP\n"
-       "IPv6 prefix <network>/<length>, e.g., 3ffe::/16\n"
-       "Specify Route Distinguisher\n"
-       "VPN Route Distinguisher\n"
-       "BGP tag\n"
-       "tag value\n"
-       "route map\n"
-       "route map name\n")
-{
-  int idx_ipv6_prefix = 1;
-  int idx_ext_community = 3;
-  int idx_word = 5;
   int idx_word_2 = 7;
-  return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, argv[idx_word_2]->arg);
+  if (argv[idx_word_2])
+    return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, argv[idx_word_2]->arg);
+  else
+    return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, NULL);
 }
 
 /* For testing purpose, static route of MPLS-VPN. */
@@ -1395,7 +1380,6 @@ bgp_mplsvpn_init (void)
   install_element (BGP_VPNV4_NODE, &no_vpnv4_network_cmd);
 
   install_element (BGP_VPNV6_NODE, &vpnv6_network_cmd);
-  install_element (BGP_VPNV6_NODE, &vpnv6_network_route_map_cmd);
   install_element (BGP_VPNV6_NODE, &no_vpnv6_network_cmd);
 
   install_element (VIEW_NODE, &show_bgp_ip_vpn_rd_cmd);

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -494,6 +494,59 @@ DEFUN (no_vpnv4_network,
   return bgp_static_unset_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv4_prefixlen]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg);
 }
 
+DEFUN (vpnv6_network,
+       vpnv6_network_cmd,
+       "network X:X::X:X/M rd ASN:nn_or_IP-address:nn tag WORD",
+       "Specify a network to announce via BGP\n"
+       "IPv6 prefix <network>/<length>, e.g., 3ffe::/16\n"
+       "Specify Route Distinguisher\n"
+       "VPN Route Distinguisher\n"
+       "BGP tag\n"
+       "tag value\n")
+{
+  int idx_ipv6_prefix = 1;
+  int idx_ext_community = 3;
+  int idx_word = 5;
+  return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, NULL);
+}
+
+DEFUN (vpnv6_network_route_map,
+       vpnv6_network_route_map_cmd,
+       "network X:X::X:X/M rd ASN:nn_or_IP-address:nn tag WORD route-map WORD",
+       "Specify a network to announce via BGP\n"
+       "IPv6 prefix <network>/<length>, e.g., 3ffe::/16\n"
+       "Specify Route Distinguisher\n"
+       "VPN Route Distinguisher\n"
+       "BGP tag\n"
+       "tag value\n"
+       "route map\n"
+       "route map name\n")
+{
+  int idx_ipv6_prefix = 1;
+  int idx_ext_community = 3;
+  int idx_word = 5;
+  int idx_word_2 = 7;
+  return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, argv[idx_word_2]->arg);
+}
+
+/* For testing purpose, static route of MPLS-VPN. */
+DEFUN (no_vpnv6_network,
+       no_vpnv6_network_cmd,
+       "no network X:X::X:X/M rd ASN:nn_or_IP-address:nn tag WORD",
+       NO_STR
+       "Specify a network to announce via BGP\n"
+       "IPv6 prefix <network>/<length>, e.g., 3ffe::/16\n"
+       "Specify Route Distinguisher\n"
+       "VPN Route Distinguisher\n"
+       "BGP tag\n"
+       "tag value\n")
+{
+  int idx_ipv6_prefix = 2;
+  int idx_ext_community = 4;
+  int idx_word = 6;
+  return bgp_static_unset_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg);
+}
+
 static int
 show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd, u_char use_json)
 {
@@ -1305,6 +1358,11 @@ bgp_mplsvpn_init (void)
 
   install_element (VIEW_NODE, &show_bgp_ipv4_vpn_cmd);
   install_element (VIEW_NODE, &show_bgp_ipv4_vpn_rd_cmd);
+
+  install_element (BGP_VPNV6_NODE, &vpnv6_network_cmd);
+  install_element (BGP_VPNV6_NODE, &vpnv6_network_route_map_cmd);
+  install_element (BGP_VPNV6_NODE, &no_vpnv6_network_cmd);
+
   install_element (VIEW_NODE, &show_bgp_ipv6_vpn_cmd);
   install_element (VIEW_NODE, &show_bgp_ipv6_vpn_rd_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_cmd);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2323,6 +2323,7 @@ bgp_update_martian_nexthop (struct bgp *bgp, afi_t afi, safi_t safi, struct attr
 #ifdef HAVE_IPV6
         case BGP_ATTR_NHLEN_IPV6_GLOBAL:
         case BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL:
+        case BGP_ATTR_NHLEN_VPNV6_GLOBAL:
           ret = (IN6_IS_ADDR_UNSPECIFIED(&attre->mp_nexthop_global) ||
                  IN6_IS_ADDR_LOOPBACK(&attre->mp_nexthop_global)    ||
                  IN6_IS_ADDR_MULTICAST(&attre->mp_nexthop_global));

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4313,6 +4313,7 @@ bgp_static_set_safi (safi_t safi, struct vty *vty, const char *ip_str,
   struct bgp_table *table;
   struct bgp_static *bgp_static;
   u_char tag[3];
+  afi_t afi;
 
   ret = str2prefix (ip_str, &p);
   if (! ret)
@@ -4335,11 +4336,19 @@ bgp_static_set_safi (safi_t safi, struct vty *vty, const char *ip_str,
       vty_out (vty, "%% Malformed tag%s", VTY_NEWLINE);
       return CMD_WARNING;
     }
-
-  prn = bgp_node_get (bgp->route[AFI_IP][safi],
+  if (p.family == AF_INET)
+    afi = AFI_IP;
+  else if (p.family == AF_INET6)
+    afi = AFI_IP6;
+  else
+    {
+      vty_out (vty, "%% Non Supported prefix%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  prn = bgp_node_get (bgp->route[afi][safi],
 			(struct prefix *)&prd);
   if (prn->info == NULL)
-    prn->info = bgp_table_init (AFI_IP, safi);
+    prn->info = bgp_table_init (afi, safi);
   else
     bgp_unlock_node (prn);
   table = prn->info;
@@ -4372,7 +4381,7 @@ bgp_static_set_safi (safi_t safi, struct vty *vty, const char *ip_str,
       rn->info = bgp_static;
 
       bgp_static->valid = 1;
-      bgp_static_update_safi (bgp, &p, bgp_static, AFI_IP, safi);
+      bgp_static_update_safi (bgp, &p, bgp_static, afi, safi);
     }
 
   return CMD_SUCCESS;
@@ -10303,7 +10312,7 @@ DEFUN (clear_ip_bgp_dampening_address_mask,
 
 /* also used for encap safi */
 static int
-bgp_config_write_network_vpnv4 (struct vty *vty, struct bgp *bgp,
+bgp_config_write_network_vpn (struct vty *vty, struct bgp *bgp,
 				afi_t afi, safi_t safi, int *write)
 {
   struct bgp_node *prn;
@@ -10353,8 +10362,8 @@ bgp_config_write_network (struct vty *vty, struct bgp *bgp,
   struct bgp_aggregate *bgp_aggregate;
   char buf[SU_ADDRSTRLEN];
   
-  if (afi == AFI_IP && ((safi == SAFI_MPLS_VPN) || (safi == SAFI_ENCAP)))
-    return bgp_config_write_network_vpnv4 (vty, bgp, afi, safi, write);
+  if ((safi == SAFI_MPLS_VPN) || (safi == SAFI_ENCAP))
+    return bgp_config_write_network_vpn (vty, bgp, afi, safi, write);
 
   /* Network configuration. */
   for (rn = bgp_table_top (bgp->route[afi][safi]); rn; rn = bgp_route_next (rn)) 


### PR DESCRIPTION
Hi all,

This series of 5 commits is fixing an issue related to VPNv6 ECMP feature.
It also changes the vty regarding network configuration command under bgp vpnv6 address family subnode.
It adds also some show ip bgp vpnv6 commands, in the same manner it has been done for 'show ip bgp vpnv4 commands'. By the way, for the last commit, unless for backward compatibility reasons, I am not sure about the need for keeping this show ip bgp vpnv4 subnode ( may confused), and also vpnv6 subnode.
It fixes the issue related to the number of help handlers.

Thanks,

Philippe