### PR TITLE
Fix a number of VPN SAFI related issues, add vrf flavor of vnc commands

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2643,6 +2643,8 @@ bgp_packet_mpattr_start (struct stream *s, afi_t afi, safi_t safi, afi_t nh_afi,
   stream_putw (s, afi);
   stream_putc (s, (safi == SAFI_MPLS_VPN) ? SAFI_MPLS_LABELED_VPN : safi);
 
+  if (nh_afi == AFI_MAX)
+    nh_afi = (attr->extra->mp_nexthop_len == 16 ? AFI_IP6 : AFI_IP);
   /* Nexthop */
   switch (nh_afi)
     {
@@ -2894,7 +2896,8 @@ bgp_packet_attribute (struct bgp *bgp, struct peer *peer,
       size_t mpattrlen_pos = 0;
 
       mpattrlen_pos = bgp_packet_mpattr_start(s, afi, safi,
-                                    (peer_cap_enhe(peer) ? AFI_IP6 : afi),
+                                    (peer_cap_enhe(peer) ? AFI_IP6 :
+                                     AFI_MAX), /* get from NH */
                                     vecarr, attr);
       bgp_packet_mpattr_prefix(s, afi, safi, p, prd, tag,
                                addpath_encode, addpath_tx_id);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8160,12 +8160,13 @@ DEFUN (show_ip_bgp,
 
 DEFUN (show_ip_bgp_ipv4,
        show_ip_bgp_ipv4_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" {json}",
+       "show ip bgp ipv4 (unicast|multicast) {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "JavaScript Object Notation\n")
 {
   u_char uj = use_json(argc, argv);
@@ -8177,11 +8178,12 @@ DEFUN (show_ip_bgp_ipv4,
 
 ALIAS (show_ip_bgp_ipv4,
        show_bgp_ipv4_safi_cmd,
-       "show bgp ipv4 "BGP_SAFI_CMD_STR" {json}",
+       "show bgp ipv4 (unicast|multicast) {json}",
        SHOW_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "JavaScript Object Notation\n")
 
 DEFUN (show_ip_bgp_route,
@@ -8635,11 +8637,12 @@ ALIAS (show_bgp,
 
 DEFUN (show_bgp_ipv6_safi,
        show_bgp_ipv6_safi_cmd,
-       "show bgp ipv6 "BGP_SAFI_CMD_STR" {json}",
+       "show bgp ipv6 (unicast|multicast) {json}",
        SHOW_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "JavaScript Object Notation\n")
 {
   u_char uj = use_json(argc, argv);
@@ -9245,12 +9248,13 @@ ALIAS (show_ip_bgp_flap_regexp,
 
 DEFUN (show_ip_bgp_ipv4_regexp, 
        show_ip_bgp_ipv4_regexp_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" regexp .LINE",
+       "show ip bgp ipv4 (unicast|multicast) regexp .LINE",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes matching the AS path regular expression\n"
        "A regular-expression to match the BGP AS paths\n")
 {
@@ -9392,12 +9396,13 @@ ALIAS (show_ip_bgp_flap_prefix_list,
 
 DEFUN (show_ip_bgp_ipv4_prefix_list, 
        show_ip_bgp_ipv4_prefix_list_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" prefix-list WORD",
+       "show ip bgp ipv4 (unicast|multicast) prefix-list WORD",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes conforming to the prefix-list\n"
        "IP prefix-list name\n")
 {
@@ -9538,12 +9543,13 @@ ALIAS (show_ip_bgp_flap_filter_list,
 
 DEFUN (show_ip_bgp_ipv4_filter_list, 
        show_ip_bgp_ipv4_filter_list_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" filter-list WORD",
+       "show ip bgp ipv4 (unicast|multicast) filter-list WORD",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes conforming to the filter-list\n"
        "Regular expression access list name\n")
 {
@@ -9621,12 +9627,13 @@ DEFUN (show_ip_bgp_dampening_info,
 
 DEFUN (show_ip_bgp_ipv4_dampening_parameters,
        show_ip_bgp_ipv4_dampening_parameters_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" dampening parameters",
+       "show ip bgp ipv4 (unicast|multicast) dampening parameters",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display detailed information about dampening\n"
        "Display detail of configured dampening parameters\n")
 {
@@ -9638,12 +9645,13 @@ DEFUN (show_ip_bgp_ipv4_dampening_parameters,
 
 DEFUN (show_ip_bgp_ipv4_dampening_flap_stats,
        show_ip_bgp_ipv4_dampening_flap_stats_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" dampening flap-statistics",
+       "show ip bgp ipv4 (unicast|multicast) dampening flap-statistics",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display detailed information about dampening\n"
        "Display flap statistics of routes\n")
 {
@@ -9655,12 +9663,13 @@ DEFUN (show_ip_bgp_ipv4_dampening_flap_stats,
 
 DEFUN (show_ip_bgp_ipv4_dampening_dampd_paths,
        show_ip_bgp_ipv4_dampening_dampd_paths_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" dampening dampened-paths",
+       "show ip bgp ipv4 (unicast|multicast) dampening dampened-paths",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display detailed information about dampening\n"
        "Display paths suppressed due to dampening\n")
 {
@@ -9749,12 +9758,13 @@ ALIAS (show_ip_bgp_flap_route_map,
 
 DEFUN (show_ip_bgp_ipv4_route_map, 
        show_ip_bgp_ipv4_route_map_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" route-map WORD",
+       "show ip bgp ipv4 (unicast|multicast) route-map WORD",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes matching the route-map\n"
        "A route-map to match on\n")
 {
@@ -9822,12 +9832,13 @@ ALIAS (show_ip_bgp_flap_cidr_only,
 
 DEFUN (show_ip_bgp_ipv4_cidr_only,
        show_ip_bgp_ipv4_cidr_only_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" cidr-only",
+       "show ip bgp ipv4 (unicast|multicast) cidr-only",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display only routes with non-natural netmasks\n")
 {
   safi_t safi;
@@ -9850,12 +9861,13 @@ DEFUN (show_ip_bgp_community_all,
 
 DEFUN (show_ip_bgp_ipv4_community_all,
        show_ip_bgp_ipv4_community_all_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community",
+       "show ip bgp ipv4 (unicast|multicast) community",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes matching the communities\n")
 {
   safi_t safi;
@@ -10053,12 +10065,13 @@ ALIAS (show_ip_bgp_community,
 
 DEFUN (show_ip_bgp_ipv4_community,
        show_ip_bgp_ipv4_community_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export)",
+       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -10072,12 +10085,13 @@ DEFUN (show_ip_bgp_ipv4_community,
 
 ALIAS (show_ip_bgp_ipv4_community,
        show_ip_bgp_ipv4_community2_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
+       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -10090,12 +10104,13 @@ ALIAS (show_ip_bgp_ipv4_community,
 	
 ALIAS (show_ip_bgp_ipv4_community,
        show_ip_bgp_ipv4_community3_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
+       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -10112,12 +10127,13 @@ ALIAS (show_ip_bgp_ipv4_community,
 	
 ALIAS (show_ip_bgp_ipv4_community,
        show_ip_bgp_ipv4_community4_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
+       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -10138,11 +10154,14 @@ ALIAS (show_ip_bgp_ipv4_community,
 
 DEFUN (show_bgp_instance_afi_safi_community_all,
        show_bgp_instance_afi_safi_community_all_cmd,
-       "show bgp " BGP_INSTANCE_CMD " "BGP_AFI_SAFI_CMD_STR" community",
+       "show bgp " BGP_INSTANCE_CMD " (ipv4|ipv6) (unicast|multicast) community",
        SHOW_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
-       BGP_AFI_SAFI_HELP_STR
+       "Address family\n"
+       "Address family\n"
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes matching the communities\n")
 {
   int afi;
@@ -10164,7 +10183,7 @@ DEFUN (show_bgp_instance_afi_safi_community_all,
 
 DEFUN (show_bgp_instance_afi_safi_community,
        show_bgp_instance_afi_safi_community_cmd,
-       "show bgp " BGP_INSTANCE_CMD " "BGP_AFI_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export)",
+       "show bgp " BGP_INSTANCE_CMD " (ipv4|ipv6) (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
@@ -10188,7 +10207,7 @@ DEFUN (show_bgp_instance_afi_safi_community,
 
 ALIAS (show_bgp_instance_afi_safi_community,
        show_bgp_instance_afi_safi_community2_cmd,
-       "show bgp " BGP_INSTANCE_CMD " "BGP_AFI_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
+       "show bgp " BGP_INSTANCE_CMD " (ipv4|ipv6) (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
@@ -10208,7 +10227,7 @@ ALIAS (show_bgp_instance_afi_safi_community,
 
 ALIAS (show_bgp_instance_afi_safi_community,
        show_bgp_instance_afi_safi_community3_cmd,
-       "show bgp " BGP_INSTANCE_CMD " "BGP_AFI_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
+       "show bgp " BGP_INSTANCE_CMD " (ipv4|ipv6) (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
@@ -10232,7 +10251,7 @@ ALIAS (show_bgp_instance_afi_safi_community,
 
 ALIAS (show_bgp_instance_afi_safi_community,
        show_bgp_instance_afi_safi_community4_cmd,
-       "show bgp " BGP_INSTANCE_CMD " "BGP_AFI_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
+       "show bgp " BGP_INSTANCE_CMD " (ipv4|ipv6) (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export)",
        SHOW_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
@@ -10339,12 +10358,13 @@ ALIAS (show_ip_bgp_community_exact,
 
 DEFUN (show_ip_bgp_ipv4_community_exact,
        show_ip_bgp_ipv4_community_exact_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) exact-match",
+       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) exact-match",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -10359,12 +10379,13 @@ DEFUN (show_ip_bgp_ipv4_community_exact,
 
 ALIAS (show_ip_bgp_ipv4_community_exact,
        show_ip_bgp_ipv4_community2_exact_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) exact-match",
+       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) exact-match",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -10378,12 +10399,13 @@ ALIAS (show_ip_bgp_ipv4_community_exact,
 
 ALIAS (show_ip_bgp_ipv4_community_exact,
        show_ip_bgp_ipv4_community3_exact_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) exact-match",
+       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) exact-match",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -10401,12 +10423,13 @@ ALIAS (show_ip_bgp_ipv4_community_exact,
        
 ALIAS (show_ip_bgp_ipv4_community_exact,
        show_ip_bgp_ipv4_community4_exact_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) exact-match",
+       "show ip bgp ipv4 (unicast|multicast) community (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) (AA:NN|local-AS|no-advertise|no-export) exact-match",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes matching the communities\n"
        COMMUNITY_AANN_STR
        "Do not send outside local AS (well-known community)\n"
@@ -11106,12 +11129,13 @@ DEFUN (show_ip_bgp_instance_community_list,
 
 DEFUN (show_ip_bgp_ipv4_community_list,
        show_ip_bgp_ipv4_community_list_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community-list (<1-500>|WORD)",
+       "show ip bgp ipv4 (unicast|multicast) community-list (<1-500>|WORD)",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes matching the community-list\n"
        "community-list number\n"
        "community-list name\n")
@@ -11137,12 +11161,13 @@ DEFUN (show_ip_bgp_community_list_exact,
 
 DEFUN (show_ip_bgp_ipv4_community_list_exact,
        show_ip_bgp_ipv4_community_list_exact_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" community-list (<1-500>|WORD) exact-match",
+       "show ip bgp ipv4 (unicast|multicast) community-list (<1-500>|WORD) exact-match",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Display routes matching the community-list\n"
        "community-list number\n"
        "community-list name\n"
@@ -11342,12 +11367,13 @@ ALIAS (show_ip_bgp_flap_prefix_longer,
 
 DEFUN (show_ip_bgp_ipv4_prefix_longer,
        show_ip_bgp_ipv4_prefix_longer_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" A.B.C.D/M longer-prefixes",
+       "show ip bgp ipv4 (unicast|multicast) A.B.C.D/M longer-prefixes",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "IP prefix <network>/<length>, e.g., 35.0.0.0/8\n"
        "Display route and more specific routes\n")
 {
@@ -11839,7 +11865,7 @@ DEFUN (show_bgp_statistics,
        "show bgp "BGP_AFI_SAFI_CMD_STR" statistics",
        SHOW_STR
        BGP_STR
-       BGP_INSTANCE_HELP_STR
+       BGP_AFI_SAFI_HELP_STR
        "BGP RIB advertisement statistics\n")
 {
   return bgp_table_stats_vty (vty, NULL, argv[0], argv[1]);
@@ -12144,12 +12170,13 @@ DEFUN (show_bgp_instance_ipv6_neighbor_prefix_counts,
 
 DEFUN (show_ip_bgp_ipv4_neighbor_prefix_counts,
        show_ip_bgp_ipv4_neighbor_prefix_counts_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) prefix-counts {json}",
+       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) prefix-counts {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -12494,12 +12521,13 @@ ALIAS (show_ip_bgp_instance_neighbor_advertised_route,
        "JavaScript Object Notation\n")
 DEFUN (show_ip_bgp_ipv4_neighbor_advertised_route,
        show_ip_bgp_ipv4_neighbor_advertised_route_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) advertised-routes {json}",
+       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) advertised-routes {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -12526,12 +12554,13 @@ DEFUN (show_ip_bgp_ipv4_neighbor_advertised_route,
 
 ALIAS (show_ip_bgp_ipv4_neighbor_advertised_route,
        show_ip_bgp_ipv4_neighbor_advertised_route_rmap_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) advertised-routes route-map WORD {json}",
+       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) advertised-routes route-map WORD {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -12783,12 +12812,13 @@ ALIAS (show_ip_bgp_instance_neighbor_received_routes,
 
 DEFUN (show_ip_bgp_ipv4_neighbor_received_routes,
        show_ip_bgp_ipv4_neighbor_received_routes_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) received-routes {json}",
+       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) received-routes {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -12814,12 +12844,13 @@ DEFUN (show_ip_bgp_ipv4_neighbor_received_routes,
 
 ALIAS (show_ip_bgp_ipv4_neighbor_received_routes,
        show_ip_bgp_ipv4_neighbor_received_routes_rmap_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) received-routes route-map WORD {json}",
+       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) received-routes route-map WORD {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -12829,11 +12860,14 @@ ALIAS (show_ip_bgp_ipv4_neighbor_received_routes,
 
 DEFUN (show_bgp_instance_afi_safi_neighbor_adv_recd_routes,
        show_bgp_instance_afi_safi_neighbor_adv_recd_routes_cmd,
-       "show bgp " BGP_INSTANCE_CMD " "BGP_AFI_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) (advertised-routes|received-routes) {json}",
+       "show bgp " BGP_INSTANCE_CMD " (ipv4|ipv6) (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) (advertised-routes|received-routes) {json}",
        SHOW_STR
        BGP_STR
        BGP_INSTANCE_HELP_STR
-       BGP_AFI_SAFI_HELP_STR
+       "Address family\n"
+       "Address family\n"
+       "Address family modifier\n"
+       "Address family modifier\n"
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -12949,12 +12983,13 @@ DEFUN (show_ip_bgp_neighbor_received_prefix_filter,
 
 DEFUN (show_ip_bgp_ipv4_neighbor_received_prefix_filter,
        show_ip_bgp_ipv4_neighbor_received_prefix_filter_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) received prefix-filter {json}",
+       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) received prefix-filter {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"
@@ -13449,12 +13484,13 @@ DEFUN (show_ip_bgp_neighbor_damp,
 
 DEFUN (show_ip_bgp_ipv4_neighbor_routes,
        show_ip_bgp_ipv4_neighbor_routes_cmd,
-       "show ip bgp ipv4 "BGP_SAFI_CMD_STR" neighbors (A.B.C.D|X:X::X:X|WORD) routes {json}",
+       "show ip bgp ipv4 (unicast|multicast) neighbors (A.B.C.D|X:X::X:X|WORD) routes {json}",
        SHOW_STR
        IP_STR
        BGP_STR
        "Address family\n"
-       BGP_SAFI_HELP_STR
+       "Address Family modifier\n"
+       "Address Family modifier\n"
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
        "Neighbor to display information about\n"

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -1435,9 +1435,10 @@ subgroup_announce_check (struct bgp_info *ri, struct update_subgroup *subgrp,
 
 #ifdef HAVE_IPV6
 #define NEXTHOP_IS_V6 (\
-    (safi != SAFI_ENCAP && \
+    (safi != SAFI_ENCAP && safi != SAFI_MPLS_VPN &&\
      (p->family == AF_INET6 || peer_cap_enhe(peer))) || \
-    (safi == SAFI_ENCAP && attr->extra->mp_nexthop_len == 16))
+    ((safi == SAFI_ENCAP || safi != SAFI_MPLS_VPN) &&\
+     attr->extra->mp_nexthop_len == 16))
 
   /* IPv6/MP starts with 1 nexthop. The link-local address is passed only if
    * the peer (group) is configured to receive link-local nexthop unchanged

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -418,10 +418,21 @@ bpacket_reformat_for_peer (struct bpacket *pkt, struct peer_af *paf)
   if (CHECK_FLAG (vec->flags, BPKT_ATTRVEC_FLAGS_UPDATED))
     {
       u_int8_t nhlen;
+      afi_t    nhafi;           /* NH AFI is based on nhlen! */
       int route_map_sets_nh;
       nhlen = stream_getc_from (s, vec->offset);
+      if (paf->afi == AFI_IP || paf->afi == AFI_IP6)
+        {
+          if (nhlen < IPV6_MAX_BYTELEN && !peer_cap_enhe(peer))
+            nhafi = AFI_IP;
+          else
+            nhafi = AFI_IP6;
+          if (paf->safi == SAFI_MPLS_VPN &&     /* if VPN */
+              nhlen != 48)                      /* and ! GLOBAL_AND_LL */
+            nhafi = AFI_MAX;                    /* no change allowed */
+        }
 
-      if (paf->afi == AFI_IP && !peer_cap_enhe(peer))
+      if (nhafi == AFI_IP)
 	{
 	  struct in_addr v4nh, *mod_v4nh;
           int nh_modified = 0;
@@ -462,23 +473,24 @@ bpacket_reformat_for_peer (struct bpacket *pkt, struct peer_af *paf)
                    (bgp_multiaccess_check_v4 (v4nh, peer) == 0) &&
                    !CHECK_FLAG(vec->flags,
                                BPKT_ATTRVEC_FLAGS_RMAP_NH_UNCHANGED) &&
-                   !peer_af_flag_check (peer, paf->afi, paf->safi,
+                   !peer_af_flag_check (peer, nhafi, paf->safi,
                                          PEER_FLAG_NEXTHOP_UNCHANGED))
             {
+              /* NOTE: not handling case where NH has new AFI */
                mod_v4nh = &peer->nexthop.v4;
                nh_modified = 1;
             }
 
-          if (nh_modified)
-            stream_put_in_addr_at (s, vec->offset + 1, mod_v4nh);
+          if (nh_modified)      /* allow for VPN RD */
+            stream_put_in_addr_at (s, vec->offset + 1 + nhlen - 4, mod_v4nh);
 
           if (bgp_debug_update(peer, NULL, NULL, 0))
-            zlog_debug ("u%" PRIu64 ":s%" PRIu64 " %s send UPDATE w/ nexthop %s",
+            zlog_debug ("u%" PRIu64 ":s%" PRIu64 " %s send UPDATE w/ nexthop %s%s",
                     PAF_SUBGRP(paf)->update_group->id, PAF_SUBGRP(paf)->id,
-                    peer->host, inet_ntoa (*mod_v4nh));
-
+                        peer->host, inet_ntoa (*mod_v4nh),
+                        (nhlen == 12 ? " and RD" : ""));
 	}
-      else if (paf->afi == AFI_IP6 || peer_cap_enhe(peer))
+      else if (nhafi == AFI_IP6)
 	{
           struct in6_addr v6nhglobal, *mod_v6nhg;
           struct in6_addr v6nhlocal, *mod_v6nhl;
@@ -515,17 +527,18 @@ bpacket_reformat_for_peer (struct bpacket *pkt, struct peer_af *paf)
           else if (peer->sort == BGP_PEER_EBGP &&
                    !CHECK_FLAG(vec->flags,
                                BPKT_ATTRVEC_FLAGS_RMAP_NH_UNCHANGED) &&
-                   !peer_af_flag_check (peer, paf->afi, paf->safi,
+                   !peer_af_flag_check (peer, nhafi, paf->safi,
                                          PEER_FLAG_NEXTHOP_UNCHANGED))
             {
+              /* NOTE: not handling case where NH has new AFI */
                mod_v6nhg = &peer->nexthop.v6_global;
                gnh_modified = 1;
             }
 
 
-	  if (nhlen == 32)
+	  if (nhlen == 32 || nhlen == 48) /* 48 == VPN */
 	    {
-              stream_get_from (&v6nhlocal, s, vec->offset + 1 + 16, 16);
+              stream_get_from (&v6nhlocal, s, vec->offset + 1 + (nhlen-IPV6_MAX_BYTELEN), IPV6_MAX_BYTELEN);
               if (IN6_IS_ADDR_UNSPECIFIED (&v6nhlocal))
                 {
                    mod_v6nhl = &peer->nexthop.v6_local;
@@ -534,25 +547,27 @@ bpacket_reformat_for_peer (struct bpacket *pkt, struct peer_af *paf)
 	    }
 
           if (gnh_modified)
-            stream_put_in6_addr_at (s, vec->offset + 1, mod_v6nhg);
+            stream_put_in6_addr_at (s, vec->offset + 1 + (nhlen-IPV6_MAX_BYTELEN), mod_v6nhg);
           if (lnh_modified)
-            stream_put_in6_addr_at (s, vec->offset + 1 + 16, mod_v6nhl);
+            stream_put_in6_addr_at (s, vec->offset + 1 + (nhlen-IPV6_MAX_BYTELEN), mod_v6nhl);
 
           if (bgp_debug_update(peer, NULL, NULL, 0))
             {
-              if (nhlen == 32)
-                zlog_debug ("u%" PRIu64 ":s%" PRIu64 " %s send UPDATE w/ mp_nexthops %s, %s",
+              if (nhlen == 32 || nhlen == 48)
+                zlog_debug ("u%" PRIu64 ":s%" PRIu64 " %s send UPDATE w/ mp_nexthops %s, %s%s",
                             PAF_SUBGRP(paf)->update_group->id,
                             PAF_SUBGRP(paf)->id,
                             peer->host,
                             inet_ntop (AF_INET6, mod_v6nhg, buf, BUFSIZ),
-                            inet_ntop (AF_INET6, mod_v6nhl, buf2, BUFSIZ));
+                            inet_ntop (AF_INET6, mod_v6nhl, buf2, BUFSIZ),
+                            (nhlen == 48 ? " and RD" : ""));
               else
-                zlog_debug ("u%" PRIu64 ":s%" PRIu64 " %s send UPDATE w/ mp_nexthop %s",
+                zlog_debug ("u%" PRIu64 ":s%" PRIu64 " %s send UPDATE w/ mp_nexthop %s%s",
                             PAF_SUBGRP(paf)->update_group->id,
                             PAF_SUBGRP(paf)->id,
                             peer->host,
-                            inet_ntop (AF_INET6, mod_v6nhg, buf, BUFSIZ));
+                            inet_ntop (AF_INET6, mod_v6nhg, buf, BUFSIZ),
+                            (nhlen == 24 ? " and RD" : ""));
             }
 	}
     }

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -486,7 +486,7 @@ bpacket_reformat_for_peer (struct bpacket *pkt, struct peer_af *paf)
 
           if (bgp_debug_update(peer, NULL, NULL, 0))
             zlog_debug ("u%" PRIu64 ":s%" PRIu64 " %s send UPDATE w/ nexthop %s%s",
-                    PAF_SUBGRP(paf)->update_group->id, PAF_SUBGRP(paf)->id,
+                        PAF_SUBGRP(paf)->update_group->id, PAF_SUBGRP(paf)->id,
                         peer->host, inet_ntoa (*mod_v4nh),
                         (nhlen == 12 ? " and RD" : ""));
 	}

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -762,7 +762,8 @@ subgroup_update_packet (struct update_subgroup *subgrp)
 
 	  if (stream_empty (snlri))
 	    mpattrlen_pos = bgp_packet_mpattr_start (snlri, afi, safi,
-                                         (peer_cap_enhe(peer) ? AFI_IP6 : afi),
+                                         (peer_cap_enhe(peer) ? AFI_IP6 :
+                                          AFI_MAX), /* get from NH */
 				          &vecarr, adv->baa->attr);
           bgp_packet_mpattr_prefix (snlri, afi, safi, &rn->p, prd, tag,
                                     addpath_encode, addpath_tx_id);

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -2661,7 +2661,7 @@ DEFUN (vnc_nve_group,
           rfg->rt_import_list =
             ecommunity_dup (bgp->rfapi_cfg->default_rt_import_list);
           rfg->rfapi_import_table =
-            rfapiImportTableRefAdd (bgp, rfg->rt_import_list);
+            rfapiImportTableRefAdd (bgp, rfg->rt_import_list, rfg);
         }
 
       /*
@@ -3119,7 +3119,7 @@ DEFUN (vnc_nve_group_rt_import,
    */
   if (rfg->rfapi_import_table)
     rfapiImportTableRefDelByIt (bgp, rfg->rfapi_import_table);
-  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list);
+  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list, rfg);
 
   if (is_export_bgp)
     vnc_direct_bgp_add_group (bgp, rfg);
@@ -3238,7 +3238,7 @@ DEFUN (vnc_nve_group_rt_both,
    */
   if (rfg->rfapi_import_table)
     rfapiImportTableRefDelByIt (bgp, rfg->rfapi_import_table);
-  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list);
+  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list, rfg);
 
   if (is_export_bgp)
     vnc_direct_bgp_add_group (bgp, rfg);
@@ -3676,7 +3676,7 @@ DEFUN (vnc_vrf_policy_rt_import,
    */
   if (rfg->rfapi_import_table)
     rfapiImportTableRefDelByIt (bgp, rfg->rfapi_import_table);
-  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list);
+  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list, rfg);
 
   if (is_export_bgp)
     vnc_direct_bgp_add_group (bgp, rfg);
@@ -3795,7 +3795,7 @@ DEFUN (vnc_vrf_policy_rt_both,
    */
   if (rfg->rfapi_import_table)
     rfapiImportTableRefDelByIt (bgp, rfg->rfapi_import_table);
-  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list);
+  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list, rfg);
 
   if (is_export_bgp)
     vnc_direct_bgp_add_group (bgp, rfg);

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -606,8 +606,9 @@ DEFUN (vnc_defaults_responselifetime,
   return CMD_SUCCESS;
 }
 
-static struct rfapi_nve_group_cfg *
-rfapi_group_lookup_byname (struct bgp *bgp, const char *name)
+struct rfapi_nve_group_cfg *
+bgp_rfapi_cfg_match_byname (struct bgp *bgp, const char *name,
+                           rfapi_group_cfg_type_t type)  /* _MAX = any */
 {
   struct rfapi_nve_group_cfg *rfg;
   struct listnode *node, *nnode;
@@ -615,18 +616,28 @@ rfapi_group_lookup_byname (struct bgp *bgp, const char *name)
   for (ALL_LIST_ELEMENTS
        (bgp->rfapi_cfg->nve_groups_sequential, node, nnode, rfg))
     {
-      if (!strcmp (rfg->name, name))
+      if ((type == RFAPI_GROUP_CFG_MAX || type == rfg->type) &&
+          !strcmp (rfg->name, name))
         return rfg;
     }
   return NULL;
 }
 
 static struct rfapi_nve_group_cfg *
-rfapi_group_new ()
+rfapi_group_new (struct bgp *bgp,
+                 rfapi_group_cfg_type_t type,
+                 const char *name)
 {
   struct rfapi_nve_group_cfg *rfg;
 
   rfg = XCALLOC (MTYPE_RFAPI_GROUP_CFG, sizeof (struct rfapi_nve_group_cfg));
+  if (rfg) 
+    {
+      rfg->type = type;
+      rfg->name = strdup (name);
+      /* add to tail of list */
+      listnode_add (bgp->rfapi_cfg->nve_groups_sequential, rfg);
+    }
   QOBJ_REG (rfg, rfapi_nve_group_cfg);
 
   return rfg;
@@ -1109,7 +1120,8 @@ DEFUN (vnc_redistribute_nvegroup,
    * OK if nve group doesn't exist yet; we'll set the pointer
    * when the group is defined later
    */
-  bgp->rfapi_cfg->rfg_redist = rfapi_group_lookup_byname (bgp, argv[0]);
+  bgp->rfapi_cfg->rfg_redist = bgp_rfapi_cfg_match_byname (bgp, argv[0],
+                                                           RFAPI_GROUP_CFG_NVE);
   if (bgp->rfapi_cfg->rfg_redist_name)
     free (bgp->rfapi_cfg->rfg_redist_name);
   bgp->rfapi_cfg->rfg_redist_name = strdup (argv[0]);
@@ -1768,7 +1780,7 @@ DEFUN (vnc_export_nvegroup,
       return CMD_WARNING;
     }
 
-  rfg_new = rfapi_group_lookup_byname (bgp, argv[1]);
+  rfg_new = bgp_rfapi_cfg_match_byname (bgp, argv[1], RFAPI_GROUP_CFG_NVE);
 
   if (*argv[0] == 'b')
     {
@@ -2616,20 +2628,17 @@ DEFUN (vnc_nve_group,
     }
 
   /* Search for name */
-  rfg = rfapi_group_lookup_byname (bgp, argv[0]);
+  rfg = bgp_rfapi_cfg_match_byname (bgp, argv[0], RFAPI_GROUP_CFG_NVE);
 
   if (!rfg)
     {
-      rfg = rfapi_group_new ();
+      rfg = rfapi_group_new (bgp, RFAPI_GROUP_CFG_NVE, argv[0]);
       if (!rfg)
         {
           /* Error out of memory */
           vty_out (vty, "Can't allocate memory for NVE group%s", VTY_NEWLINE);
           return CMD_WARNING;
         }
-      rfg->name = strdup (argv[0]);
-      /* add to tail of list */
-      listnode_add (bgp->rfapi_cfg->nve_groups_sequential, rfg);
 
       /* Copy defaults from struct rfapi_cfg */
       rfg->rd = bgp->rfapi_cfg->default_rd;
@@ -2828,7 +2837,8 @@ static int
 bgp_rfapi_delete_named_nve_group (
   struct vty *vty,      /* NULL = no output */
   struct bgp *bgp,
-  const char *rfg_name)        /* NULL = any */
+  const char *rfg_name, /* NULL = any */
+  rfapi_group_cfg_type_t type)  /* _MAX = any */
 {
   struct rfapi_nve_group_cfg *rfg = NULL;
   struct listnode *node, *nnode;
@@ -2837,7 +2847,7 @@ bgp_rfapi_delete_named_nve_group (
   /* Search for name */
   if (rfg_name)
     {
-      rfg = rfapi_group_lookup_byname (bgp, rfg_name);
+      rfg = bgp_rfapi_cfg_match_byname (bgp, rfg_name, type);
       if (!rfg)
         {
           if (vty)
@@ -2864,7 +2874,8 @@ bgp_rfapi_delete_named_nve_group (
   for (ALL_LIST_ELEMENTS_RO (bgp->rfapi_cfg->rfg_export_direct_bgp_l,
                              node, rfgn))
     {
-      if (rfg_name == NULL || !strcmp (rfgn->name, rfg_name))
+      if (rfg_name == NULL ||
+          (type == RFAPI_GROUP_CFG_NVE && !strcmp (rfgn->name, rfg_name)))
         {
           rfgn->rfg = NULL;
           /* remove exported routes from this group */
@@ -2879,7 +2890,8 @@ bgp_rfapi_delete_named_nve_group (
   for (ALL_LIST_ELEMENTS_RO (bgp->rfapi_cfg->rfg_export_zebra_l, node, rfgn))
     {
 
-      if (rfg_name == NULL || !strcmp (rfgn->name, rfg_name))
+      if (rfg_name == NULL ||
+          (type == RFAPI_GROUP_CFG_NVE && !strcmp (rfgn->name, rfg_name)))
         {
           rfgn->rfg = NULL;
           /* remove exported routes from this group */
@@ -2911,7 +2923,7 @@ DEFUN (vnc_no_nve_group,
       vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
       return CMD_WARNING;
     }
-  return bgp_rfapi_delete_named_nve_group (vty, bgp, argv[0]);
+  return bgp_rfapi_delete_named_nve_group (vty, bgp, argv[0], RFAPI_GROUP_CFG_NVE);
 }
 
 DEFUN (vnc_nve_group_prefix,
@@ -3491,6 +3503,422 @@ static struct cmd_node bgp_vnc_nve_group_node = {
 };
 
 /*-------------------------------------------------------------------------
+ *			VNC nve-group
+ * Note there are two types of NVEs, one for VPNs one for RFP NVEs
+ *-----------------------------------------------------------------------*/
+
+DEFUN (vnc_vrf_policy,
+       vnc_vrf_policy_cmd,
+       "vrf-policy NAME",
+       "Configure a VRF policy group\n"
+       "VRF name\n")
+{
+  struct rfapi_nve_group_cfg *rfg;
+  struct bgp *bgp = vty->index;
+
+  if (!bgp)
+    {
+      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  /* Search for name */
+  rfg = bgp_rfapi_cfg_match_byname (bgp, argv[0], RFAPI_GROUP_CFG_VRF);
+
+  if (!rfg)
+    {
+      rfg = rfapi_group_new (bgp, RFAPI_GROUP_CFG_VRF, argv[0]);
+      if (!rfg)
+        {
+          /* Error out of memory */
+          vty_out (vty, "Can't allocate memory for NVE group%s", VTY_NEWLINE);
+          return CMD_WARNING;
+        }
+    }
+  /*
+   * XXX subsequent calls will need to make sure this item is still
+   * in the linked list and has the same name
+   */
+  VTY_PUSH_CONTEXT_SUB (BGP_VRF_POLICY_NODE, rfg);
+
+  return CMD_SUCCESS;
+}
+
+DEFUN (vnc_no_vrf_policy,
+       vnc_no_vrf_policy_cmd,
+       "no vrf-policy NAME",
+       NO_STR
+       "Remove a VRF policy group\n"
+       "VRF name\n")
+{
+  struct bgp *bgp = vty->index;
+
+  if (!bgp)
+    {
+      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  return bgp_rfapi_delete_named_nve_group (vty, bgp, argv[0], RFAPI_GROUP_CFG_VRF);
+}
+
+DEFUN (vnc_vrf_policy_nexthop,
+       vnc_vrf_policy_nexthop_cmd,
+       "nexthop (A.B.C.D|X:X::X:X|self)",
+       "Specify next hop to use for VRF advertised prefixes\n"
+       "IPv4 prefix\n"
+       "IPv6 prefix\n"
+       "Use configured router-id (default)")
+{
+  VTY_DECLVAR_CONTEXT_SUB(rfapi_nve_group_cfg, rfg);
+  struct prefix p;
+
+  struct bgp *bgp = vty->index;
+
+  if (!bgp)
+    {
+      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  /* make sure it's still in list */
+  if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
+    {
+      /* Not in list anymore */
+      vty_out (vty, "Current VRF no longer exists%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  if (!str2prefix (argv[0], &p) && p.family)
+    {
+      //vty_out (vty, "Nexthop set to self%s", VTY_NEWLINE);
+      SET_FLAG (rfg->flags, RFAPI_RFG_VPN_NH_SELF);
+      memset(&rfg->vn_prefix, 0, sizeof(struct prefix));
+    }
+  else
+    {
+      UNSET_FLAG (rfg->flags, RFAPI_RFG_VPN_NH_SELF);
+      rfg->vn_prefix = p;
+    }
+
+  /* TBD handle router-id/ nexthop changes when have advertised prefixes */
+
+  if (bgp->rfapi_cfg->rfg_redist == rfg)
+    {
+      vnc_redistribute_postchange (bgp);
+    }
+
+  return CMD_SUCCESS;
+}
+
+/* The RT code should be refactored/simplified with above... */
+DEFUN (vnc_vrf_policy_rt_import,
+       vnc_vrf_policy_rt_import_cmd,
+       "rt import .RTLIST",
+       "Specify route targets\n"
+       "Import filter\n"
+       "Space separated route target list (A.B.C.D:MN|EF:OPQR|GHJK:MN)\n")
+{
+  VTY_DECLVAR_CONTEXT_SUB(rfapi_nve_group_cfg, rfg);
+  struct bgp *bgp = vty->index;
+  int rc;
+  struct listnode *node;
+  struct rfapi_rfg_name *rfgn;
+  int is_export_bgp = 0;
+  int is_export_zebra = 0;
+
+  if (!bgp)
+    {
+      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  /* make sure it's still in list */
+  if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
+    {
+      /* Not in list anymore */
+      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  rc = set_ecom_list (vty, argc, argv, &rfg->rt_import_list);
+  if (rc != CMD_SUCCESS)
+    return rc;
+
+  for (ALL_LIST_ELEMENTS_RO (bgp->rfapi_cfg->rfg_export_direct_bgp_l,
+                             node, rfgn))
+    {
+
+      if (rfgn->rfg == rfg)
+        {
+          is_export_bgp = 1;
+          break;
+        }
+    }
+
+  if (is_export_bgp)
+    vnc_direct_bgp_del_group (bgp, rfg);
+
+  for (ALL_LIST_ELEMENTS_RO (bgp->rfapi_cfg->rfg_export_zebra_l, node, rfgn))
+    {
+
+      if (rfgn->rfg == rfg)
+        {
+          is_export_zebra = 1;
+          break;
+        }
+    }
+
+  if (is_export_zebra)
+    vnc_zebra_del_group (bgp, rfg);
+
+  /*
+   * stop referencing old import table, now reference new one
+   */
+  if (rfg->rfapi_import_table)
+    rfapiImportTableRefDelByIt (bgp, rfg->rfapi_import_table);
+  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list);
+
+  if (is_export_bgp)
+    vnc_direct_bgp_add_group (bgp, rfg);
+
+  if (is_export_zebra)
+    vnc_zebra_add_group (bgp, rfg);
+
+  return CMD_SUCCESS;
+}
+
+DEFUN (vnc_vrf_policy_rt_export,
+       vnc_vrf_policy_rt_export_cmd,
+       "rt export .RTLIST",
+       "Specify route targets\n"
+       "Export filter\n"
+       "Space separated route target list (A.B.C.D:MN|EF:OPQR|GHJK:MN)\n")
+{
+  VTY_DECLVAR_CONTEXT_SUB(rfapi_nve_group_cfg, rfg);
+  struct bgp *bgp = vty->index;
+  int rc;
+
+  if (!bgp)
+    {
+      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  /* make sure it's still in list */
+  if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
+    {
+      /* Not in list anymore */
+      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  if (bgp->rfapi_cfg->rfg_redist == rfg)
+    {
+      vnc_redistribute_prechange (bgp);
+    }
+
+  rc = set_ecom_list (vty, argc, argv, &rfg->rt_export_list);
+
+  if (bgp->rfapi_cfg->rfg_redist == rfg)
+    {
+      vnc_redistribute_postchange (bgp);
+    }
+
+  return rc;
+}
+
+DEFUN (vnc_vrf_policy_rt_both,
+       vnc_vrf_policy_rt_both_cmd,
+       "rt both .RTLIST",
+       "Specify route targets\n"
+       "Export+import filters\n"
+       "Space separated route target list (A.B.C.D:MN|EF:OPQR|GHJK:MN)\n")
+{
+  VTY_DECLVAR_CONTEXT_SUB(rfapi_nve_group_cfg, rfg);
+  struct bgp *bgp = vty->index;
+  int rc;
+  int is_export_bgp = 0;
+  int is_export_zebra = 0;
+  struct listnode *node;
+  struct rfapi_rfg_name *rfgn;
+
+  if (!bgp)
+    {
+      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  /* make sure it's still in list */
+  if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
+    {
+      /* Not in list anymore */
+      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  rc = set_ecom_list (vty, argc, argv, &rfg->rt_import_list);
+  if (rc != CMD_SUCCESS)
+    return rc;
+
+  for (ALL_LIST_ELEMENTS_RO (bgp->rfapi_cfg->rfg_export_direct_bgp_l,
+                             node, rfgn))
+    {
+
+      if (rfgn->rfg == rfg)
+        {
+          is_export_bgp = 1;
+          break;
+        }
+    }
+
+  if (is_export_bgp)
+    vnc_direct_bgp_del_group (bgp, rfg);
+
+  for (ALL_LIST_ELEMENTS_RO (bgp->rfapi_cfg->rfg_export_zebra_l, node, rfgn))
+    {
+
+      if (rfgn->rfg == rfg)
+        {
+          is_export_zebra = 1;
+          break;
+        }
+    }
+
+  if (is_export_zebra)
+    {
+      vnc_zlog_debug_verbose ("%s: is_export_zebra", __func__);
+      vnc_zebra_del_group (bgp, rfg);
+    }
+
+  /*
+   * stop referencing old import table, now reference new one
+   */
+  if (rfg->rfapi_import_table)
+    rfapiImportTableRefDelByIt (bgp, rfg->rfapi_import_table);
+  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list);
+
+  if (is_export_bgp)
+    vnc_direct_bgp_add_group (bgp, rfg);
+
+  if (is_export_zebra)
+    vnc_zebra_add_group (bgp, rfg);
+
+  if (bgp->rfapi_cfg->rfg_redist == rfg)
+    {
+      vnc_redistribute_prechange (bgp);
+    }
+
+  rc = set_ecom_list (vty, argc, argv, &rfg->rt_export_list);
+
+  if (bgp->rfapi_cfg->rfg_redist == rfg)
+    {
+      vnc_redistribute_postchange (bgp);
+    }
+
+  return rc;
+
+}
+
+DEFUN (vnc_vrf_policy_rd,
+       vnc_vrf_policy_rd_cmd,
+       "rd ASN:nn_or_IP-address:nn",
+       "Specify default VRF route distinguisher\n"
+       "Route Distinguisher (<as-number>:<number> | <ip-address>:<number> | auto:nh:<number> )\n")
+{
+  int ret;
+  struct prefix_rd prd;
+  VTY_DECLVAR_CONTEXT_SUB(rfapi_nve_group_cfg, rfg);
+  struct bgp *bgp = vty->index;
+
+  if (!bgp)
+    {
+      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  /* make sure it's still in list */
+  if (!listnode_lookup (bgp->rfapi_cfg->nve_groups_sequential, rfg))
+    {
+      /* Not in list anymore */
+      vty_out (vty, "Current NVE group no longer exists%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  if (!strncmp (argv[0], "auto:nh:", 8))
+    {
+      /*
+       * use AF_UNIX to designate automatically-assigned RD
+       * auto:vn:nn where nn is a 2-octet quantity
+       */
+      char *end = NULL;
+      uint32_t value32 = strtoul (argv[0] + 8, &end, 10);
+      uint16_t value = value32 & 0xffff;
+
+      if (!*(argv[0] + 5) || *end)
+        {
+          vty_out (vty, "%% Malformed rd%s", VTY_NEWLINE);
+          return CMD_WARNING;
+        }
+      if (value32 > 0xffff)
+        {
+          vty_out (vty, "%% Malformed rd (must be less than %u%s",
+                   0x0ffff, VTY_NEWLINE);
+          return CMD_WARNING;
+        }
+
+      memset (&prd, 0, sizeof (prd));
+      prd.family = AF_UNIX;
+      prd.prefixlen = 64;
+      prd.val[0] = (RD_TYPE_IP >> 8) & 0x0ff;
+      prd.val[1] = RD_TYPE_IP & 0x0ff;
+      prd.val[6] = (value >> 8) & 0x0ff;
+      prd.val[7] = value & 0x0ff;
+
+    }
+  else
+    {
+
+      ret = str2prefix_rd (argv[0], &prd);
+      if (!ret)
+        {
+          vty_out (vty, "%% Malformed rd%s", VTY_NEWLINE);
+          return CMD_WARNING;
+        }
+    }
+
+  if (bgp->rfapi_cfg->rfg_redist == rfg)
+    {
+      vnc_redistribute_prechange (bgp);
+    }
+
+  rfg->rd = prd;
+
+  if (bgp->rfapi_cfg->rfg_redist == rfg)
+    {
+      vnc_redistribute_postchange (bgp);
+    }
+  return CMD_SUCCESS;
+}
+
+DEFUN (exit_vrf_policy,
+       exit_vrf_policy_cmd,
+       "exit-vrf-policy",
+       "Exit VRF policy configuration mode\n")
+{
+  if (vty->node == BGP_VRF_POLICY_NODE)
+    {
+      vty->node = BGP_NODE;
+    }
+  return CMD_SUCCESS;
+}
+
+static struct cmd_node bgp_vrf_policy_node = {
+  BGP_VRF_POLICY_NODE,
+  "%s(config-router-vrf-policy)# ",
+  1
+};
+
+/*-------------------------------------------------------------------------
  *			vnc-l2-group
  *-----------------------------------------------------------------------*/
 
@@ -3850,7 +4278,9 @@ bgp_rfapi_cfg_init (void)
 
   install_node (&bgp_vnc_defaults_node, NULL);
   install_node (&bgp_vnc_nve_group_node, NULL);
+  install_node (&bgp_vrf_policy_node, NULL);
   install_node (&bgp_vnc_l2_group_node, NULL);
+  install_default (BGP_VRF_POLICY_NODE);
   install_default (BGP_VNC_DEFAULTS_NODE);
   install_default (BGP_VNC_NVE_GROUP_NODE);
   install_default (BGP_VNC_L2_GROUP_NODE);
@@ -3861,6 +4291,8 @@ bgp_rfapi_cfg_init (void)
   install_element (BGP_NODE, &vnc_defaults_cmd);
   install_element (BGP_NODE, &vnc_nve_group_cmd);
   install_element (BGP_NODE, &vnc_no_nve_group_cmd);
+  install_element (BGP_NODE, &vnc_vrf_policy_cmd);
+  install_element (BGP_NODE, &vnc_no_vrf_policy_cmd);
   install_element (BGP_NODE, &vnc_l2_group_cmd);
   install_element (BGP_NODE, &vnc_no_l2_group_cmd);
   install_element (BGP_NODE, &vnc_advertise_un_method_cmd);
@@ -3923,6 +4355,13 @@ bgp_rfapi_cfg_init (void)
   install_element (BGP_VNC_NVE_GROUP_NODE,
                    &vnc_nve_group_export_no_routemap_cmd);
   install_element (BGP_VNC_NVE_GROUP_NODE, &exit_vnc_cmd);
+
+  install_element (BGP_VRF_POLICY_NODE, &vnc_vrf_policy_nexthop_cmd);
+  install_element (BGP_VRF_POLICY_NODE, &vnc_vrf_policy_rt_import_cmd);
+  install_element (BGP_VRF_POLICY_NODE, &vnc_vrf_policy_rt_export_cmd);
+  install_element (BGP_VRF_POLICY_NODE, &vnc_vrf_policy_rt_both_cmd);
+  install_element (BGP_VRF_POLICY_NODE, &vnc_vrf_policy_rd_cmd);
+  install_element (BGP_VRF_POLICY_NODE, &exit_vrf_policy_cmd);
 
   install_element (BGP_VNC_L2_GROUP_NODE, &vnc_l2_group_lni_cmd);
   install_element (BGP_VNC_L2_GROUP_NODE, &vnc_l2_group_labels_cmd);
@@ -3992,7 +4431,7 @@ bgp_rfapi_cfg_destroy (struct bgp *bgp, struct rfapi_cfg *h)
   if (h == NULL)
     return;
 
-  bgp_rfapi_delete_named_nve_group (NULL, bgp, NULL);
+  bgp_rfapi_delete_named_nve_group (NULL, bgp, NULL, RFAPI_GROUP_CFG_MAX);
   bgp_rfapi_delete_named_l2_group (NULL, bgp, NULL);
   if (h->l2_groups != NULL)
     list_delete (h->l2_groups);
@@ -4020,6 +4459,161 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
   afi_t afi;
   int type;
 
+  vty_out (vty, "!%s", VTY_NEWLINE);
+  for (ALL_LIST_ELEMENTS (hc->nve_groups_sequential, node, nnode, rfg))
+    if (rfg->type == RFAPI_GROUP_CFG_VRF)
+      {
+        ++write;
+        vty_out (vty, " vrf-policy %s%s", rfg->name, VTY_NEWLINE);
+        if (CHECK_FLAG (rfg->flags, RFAPI_RFG_VPN_NH_SELF))
+          {
+            vty_out (vty, "  nexthop self%s", VTY_NEWLINE);
+
+          }
+        else 
+          {
+            if (rfg->vn_prefix.family)
+              {
+                char buf[BUFSIZ];
+                buf[0] = buf[BUFSIZ - 1] = 0;
+                inet_ntop(rfg->vn_prefix.family, &rfg->vn_prefix.u.prefix, buf, sizeof(buf));
+                if (!buf[0] || buf[BUFSIZ - 1])
+                  {
+                    //vty_out (vty, "nexthop self%s", VTY_NEWLINE);
+                  }
+                else
+                  {
+                    vty_out (vty, "  nexthop %s%s", buf, VTY_NEWLINE);
+                  }
+              }
+          }
+
+        if (rfg->rd.prefixlen)
+          {
+            char buf[BUFSIZ];
+            buf[0] = buf[BUFSIZ - 1] = 0;
+
+            if (AF_UNIX == rfg->rd.family)
+              {
+
+                uint16_t value = 0;
+
+                value = ((rfg->rd.val[6] << 8) & 0x0ff00) |
+                  (rfg->rd.val[7] & 0x0ff);
+
+                vty_out (vty, "  rd auto:nh:%d%s", value, VTY_NEWLINE);
+
+              }
+            else
+              {
+
+                if (!prefix_rd2str (&rfg->rd, buf, BUFSIZ) ||
+                    !buf[0] || buf[BUFSIZ - 1])
+                  {
+
+                    vty_out (vty, "!Error: Can't convert rd%s", VTY_NEWLINE);
+                  }
+                else
+                  {
+                    vty_out (vty, "  rd %s%s", buf, VTY_NEWLINE);
+                  }
+              }
+          }
+
+        if (rfg->rt_import_list && rfg->rt_export_list &&
+            ecommunity_cmp (rfg->rt_import_list, rfg->rt_export_list))
+          {
+            char *b = ecommunity_ecom2str (rfg->rt_import_list,
+                                           ECOMMUNITY_FORMAT_ROUTE_MAP);
+            vty_out (vty, "  rt both %s%s", b, VTY_NEWLINE);
+            XFREE (MTYPE_ECOMMUNITY_STR, b);
+          }
+        else
+          {
+            if (rfg->rt_import_list)
+              {
+                char *b = ecommunity_ecom2str (rfg->rt_import_list,
+                                               ECOMMUNITY_FORMAT_ROUTE_MAP);
+                vty_out (vty, "  rt import %s%s", b, VTY_NEWLINE);
+                XFREE (MTYPE_ECOMMUNITY_STR, b);
+              }
+            if (rfg->rt_export_list)
+              {
+                char *b = ecommunity_ecom2str (rfg->rt_export_list,
+                                               ECOMMUNITY_FORMAT_ROUTE_MAP);
+                vty_out (vty, "  rt export %s%s", b, VTY_NEWLINE);
+                XFREE (MTYPE_ECOMMUNITY_STR, b);
+              }
+          }
+
+        /*
+         * route filtering: prefix-lists and route-maps
+         */
+        for (afi = AFI_IP; afi < AFI_MAX; ++afi)
+          {
+
+            const char *afistr = (afi == AFI_IP) ? "ipv4" : "ipv6";
+
+            if (rfg->plist_export_bgp_name[afi])
+              {
+                vty_out (vty, "  export bgp %s prefix-list %s%s",
+                         afistr, rfg->plist_export_bgp_name[afi],
+                         VTY_NEWLINE);
+              }
+            if (rfg->plist_export_zebra_name[afi])
+              {
+                vty_out (vty, "  export zebra %s prefix-list %s%s",
+                         afistr, rfg->plist_export_zebra_name[afi],
+                         VTY_NEWLINE);
+              }
+            /*
+             * currently we only support redist plists for bgp-direct.
+             * If we later add plist support for redistributing other
+             * protocols, we'll need to loop over protocols here
+             */
+            if (rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT][afi])
+              {
+                vty_out (vty, "  redistribute bgp-direct %s prefix-list %s%s",
+                         afistr,
+                         rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT][afi],
+                         VTY_NEWLINE);
+              }
+            if (rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT][afi])
+              {
+                vty_out (vty,
+                         "  redistribute bgp-direct-to-nve-groups %s prefix-list %s%s",
+                         afistr,
+                         rfg->plist_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT]
+                         [afi], VTY_NEWLINE);
+              }
+          }
+
+        if (rfg->routemap_export_bgp_name)
+          {
+            vty_out (vty, "  export bgp route-map %s%s",
+                     rfg->routemap_export_bgp_name, VTY_NEWLINE);
+          }
+        if (rfg->routemap_export_zebra_name)
+          {
+            vty_out (vty, "  export zebra route-map %s%s",
+                     rfg->routemap_export_zebra_name, VTY_NEWLINE);
+          }
+        if (rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT])
+          {
+            vty_out (vty, "  redistribute bgp-direct route-map %s%s",
+                     rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT],
+                     VTY_NEWLINE);
+          }
+        if (rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT])
+          {
+            vty_out (vty,
+                     "  redistribute bgp-direct-to-nve-groups route-map %s%s",
+                     rfg->routemap_redist_name[ZEBRA_ROUTE_BGP_DIRECT_EXT],
+                     VTY_NEWLINE);
+          }
+        vty_out (vty, "  exit-vrf-policy%s", VTY_NEWLINE);
+        vty_out (vty, "!%s", VTY_NEWLINE);
+      }
   if (hc->flags & BGP_VNC_CONFIG_ADV_UN_METHOD_ENCAP)
     {
       vty_out (vty, " vnc advertise-un-method encap-safi%s", VTY_NEWLINE);
@@ -4181,6 +4775,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
       }
 
     for (ALL_LIST_ELEMENTS (hc->nve_groups_sequential, node, nnode, rfg))
+      if (rfg->type == RFAPI_GROUP_CFG_NVE)
       {
         ++write;
         vty_out (vty, " vnc nve-group %s%s", rfg->name, VTY_NEWLINE);

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -335,6 +335,9 @@ is_valid_rfd (struct rfapi_descriptor *rfd)
   if (!rfd || rfd->bgp == NULL)
     return 0;
 
+  if (CHECK_FLAG(rfd->flags, RFAPI_HD_FLAG_IS_VRF)) /* assume VRF/internal are valid */
+    return 1;
+
   if (rfapi_find_handle (rfd->bgp, &rfd->vn_addr, &rfd->un_addr, &hh))
     return 0;
 
@@ -356,6 +359,9 @@ rfapi_check (void *handle)
 
   if (!rfd || rfd->bgp == NULL)
     return EINVAL;
+
+  if (CHECK_FLAG(rfd->flags, RFAPI_HD_FLAG_IS_VRF)) /* assume VRF/internal are valid */
+    return 0;
 
   if ((rc = rfapi_find_handle (rfd->bgp, &rfd->vn_addr, &rfd->un_addr, &hh)))
     return rc;
@@ -1347,7 +1353,6 @@ rfapi_rfp_set_cb_methods (void *rfp_start_val,
 /***********************************************************************
  *			NVE Sessions
  ***********************************************************************/
-
 /*
  * Caller must supply an already-allocated rfd with the "caller"
  * fields already set (vn_addr, un_addr, callback, cookie)
@@ -1472,6 +1477,57 @@ rfapi_open_inner (
   vnc_zebra_add_nve (bgp, rfd);
 
   return 0;
+}
+
+/* moved from rfapi_register */
+int
+rfapi_init_and_open(
+  struct bgp			*bgp,
+  struct rfapi_descriptor	*rfd,
+  struct rfapi_nve_group_cfg	*rfg)
+{
+  struct rfapi *h = bgp->rfapi;
+  char buf_vn[BUFSIZ];
+  char buf_un[BUFSIZ];
+  afi_t afi_vn, afi_un;
+  struct prefix pfx_un;
+  struct route_node             *rn;
+
+
+  rfapi_time (&rfd->open_time);
+
+  if (rfg->type == RFAPI_GROUP_CFG_VRF)
+    SET_FLAG(rfd->flags, RFAPI_HD_FLAG_IS_VRF);
+
+  rfapiRfapiIpAddr2Str (&rfd->vn_addr, buf_vn, BUFSIZ);
+  rfapiRfapiIpAddr2Str (&rfd->un_addr, buf_un, BUFSIZ);
+
+  vnc_zlog_debug_verbose ("%s: new RFD with VN=%s UN=%s cookie=%p",
+                          __func__, buf_vn, buf_un, rfd->cookie);
+
+  if (rfg->type != RFAPI_GROUP_CFG_VRF) /* unclear if needed for VRF */
+    {
+      listnode_add (&h->descriptors, rfd);
+      if (h->descriptors.count > h->stat.max_descriptors)
+        {
+          h->stat.max_descriptors = h->descriptors.count;
+        }
+
+      /*
+       * attach to UN radix tree
+       */
+      afi_vn = family2afi (rfd->vn_addr.addr_family);
+      afi_un = family2afi (rfd->un_addr.addr_family);
+      assert (afi_vn && afi_un);
+      assert (!rfapiRaddr2Qprefix (&rfd->un_addr, &pfx_un));
+
+      rn = route_node_get (&(h->un[afi_un]), &pfx_un);
+      assert (rn);
+      rfd->next = rn->info;
+      rn->info = rfd;
+      rfd->un_node = rn;
+    }  
+  return rfapi_open_inner (rfd, bgp, h, rfg);
 }
 
 struct rfapi_vn_option *
@@ -1991,13 +2047,9 @@ rfapi_open (
   struct prefix pfx_vn;
   struct prefix pfx_un;
 
-  struct route_node *rn;
   int rc;
   rfapi_handle hh = NULL;
   int reusing_provisional = 0;
-
-  afi_t afi_vn;
-  afi_t afi_un;
 
   {
     char buf[2][INET_ADDRSTRLEN];
@@ -2129,40 +2181,7 @@ rfapi_open (
 
   if (!reusing_provisional)
     {
-      rfapi_time (&rfd->open_time);
-
-      {
-        char buf_vn[BUFSIZ];
-        char buf_un[BUFSIZ];
-
-        rfapiRfapiIpAddr2Str (vn, buf_vn, BUFSIZ);
-        rfapiRfapiIpAddr2Str (un, buf_un, BUFSIZ);
-
-        vnc_zlog_debug_verbose ("%s: new HD with VN=%s UN=%s cookie=%p",
-                    __func__, buf_vn, buf_un, userdata);
-      }
-
-      listnode_add (&h->descriptors, rfd);
-      if (h->descriptors.count > h->stat.max_descriptors)
-        {
-          h->stat.max_descriptors = h->descriptors.count;
-        }
-
-      /*
-       * attach to UN radix tree
-       */
-      afi_vn = family2afi (rfd->vn_addr.addr_family);
-      afi_un = family2afi (rfd->un_addr.addr_family);
-      assert (afi_vn && afi_un);
-      assert (!rfapiRaddr2Qprefix (&rfd->un_addr, &pfx_un));
-
-      rn = route_node_get (&(h->un[afi_un]), &pfx_un);
-      assert (rn);
-      rfd->next = rn->info;
-      rn->info = rfd;
-      rfd->un_node = rn;
-
-      rc = rfapi_open_inner (rfd, bgp, h, rfg);
+      rc = rfapi_init_and_open(bgp, rfd, rfg);
       /*
        * This can fail only if the VN address is IPv6 and the group
        * specified auto-assignment of RDs, which only works for v4,

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -768,7 +768,6 @@ add_vnc_route (
           bgp_attr_extra_free (&attr);
           return;
         }
-      nexthop = un_addr;    /* UN used as MPLS NLRI nexthop */
     }
 
   if (local_pref)

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -2796,7 +2796,7 @@ rfapi_register (
 	NULL,
 	action == RFAPI_REGISTER_KILL);
 
-      if (0 == rfapiApDelete (bgp, rfd, &p, pfx_mac, &adv_tunnel))
+      if (0 == rfapiApDelete (bgp, rfd, &p, pfx_mac, &prd, &adv_tunnel))
         {
           if (adv_tunnel)
             rfapiTunnelRouteAnnounce (bgp, rfd, &rfd->max_prefix_lifetime);

--- a/bgpd/rfapi/rfapi_ap.c
+++ b/bgpd/rfapi/rfapi_ap.c
@@ -103,12 +103,11 @@ sl_adb_lifetime_cmp (void *adb1, void *adb2)
   return 0;
 }
 
-
 void
 rfapiApInit (struct rfapi_advertised_prefixes *ap)
 {
-  ap->ipN_by_prefix = skiplist_new (0, vnc_prefix_cmp, NULL);
-  ap->ip0_by_ether = skiplist_new (0, vnc_prefix_cmp, NULL);
+  ap->ipN_by_prefix = skiplist_new (0, rfapi_rib_key_cmp, NULL);
+  ap->ip0_by_ether = skiplist_new (0, rfapi_rib_key_cmp, NULL);
   ap->by_lifetime = skiplist_new (0, sl_adb_lifetime_cmp, NULL);
 }
 
@@ -192,7 +191,7 @@ rfapiApReadvertiseAll (struct bgp *bgp, struct rfapi_descriptor *rfd)
        * TBD this is not quite right. When pfx_ip is 0/32 or 0/128,
        * we need to substitute the VN address as the prefix
        */
-      add_vnc_route (rfd, bgp, SAFI_MPLS_VPN, &adb->prefix_ip, &prd,    /* RD to use (0 for ENCAP) */
+      add_vnc_route (rfd, bgp, SAFI_MPLS_VPN, &adb->u.s.prefix_ip, &prd,    /* RD to use (0 for ENCAP) */
                      &rfd->vn_addr,     /* nexthop */
                      &local_pref, &adb->lifetime, NULL, NULL,   /* struct rfapi_un_option */
                      NULL,      /* struct rfapi_vn_option */
@@ -221,11 +220,11 @@ rfapiApWithdrawAll (struct bgp *bgp, struct rfapi_descriptor *rfd)
       struct prefix pfx_vn_buf;
       struct prefix *pfx_ip;
 
-      if (!(RFAPI_0_PREFIX (&adb->prefix_ip) &&
-            RFAPI_HOST_PREFIX (&adb->prefix_ip)))
+      if (!(RFAPI_0_PREFIX (&adb->u.s.prefix_ip) &&
+            RFAPI_HOST_PREFIX (&adb->u.s.prefix_ip)))
         {
 
-          pfx_ip = &adb->prefix_ip;
+          pfx_ip = &adb->u.s.prefix_ip;
 
         }
       else
@@ -247,7 +246,7 @@ rfapiApWithdrawAll (struct bgp *bgp, struct rfapi_descriptor *rfd)
             }
         }
 
-      del_vnc_route (rfd, rfd->peer, bgp, SAFI_MPLS_VPN, pfx_ip ? pfx_ip : &pfx_vn_buf, &adb->prd,      /* RD to use (0 for ENCAP) */
+      del_vnc_route (rfd, rfd->peer, bgp, SAFI_MPLS_VPN, pfx_ip ? pfx_ip : &pfx_vn_buf, &adb->u.s.prd,      /* RD to use (0 for ENCAP) */
                      ZEBRA_ROUTE_BGP, BGP_ROUTE_RFP, NULL, 0);
     }
 }
@@ -404,19 +403,19 @@ rfapiApAdjustLifetimeStats (
         {
 
           void *cursor;
-          struct prefix *prefix;
-          struct rfapi_adb *adb;
+          struct rfapi_rib_key rk;
+          struct rfapi_adb    *adb;
           int rc;
 
           vnc_zlog_debug_verbose ("%s: walking to find new min/max", __func__);
 
           cursor = NULL;
           for (rc = skiplist_next (rfd->advertised.ipN_by_prefix,
-                                   (void **) &prefix, (void **) &adb,
+                                   (void **) &rk, (void **) &adb,
                                    &cursor); !rc;
                rc =
                skiplist_next (rfd->advertised.ipN_by_prefix,
-                              (void **) &prefix, (void **) &adb, &cursor))
+                              (void **) &rk, (void **) &adb, &cursor))
             {
 
               uint32_t lt = adb->lifetime;
@@ -428,10 +427,10 @@ rfapiApAdjustLifetimeStats (
             }
           cursor = NULL;
           for (rc = skiplist_next (rfd->advertised.ip0_by_ether,
-                                   (void **) &prefix, (void **) &adb,
+                                   (void **) &rk, (void **) &adb,
                                    &cursor); !rc;
                rc =
-               skiplist_next (rfd->advertised.ip0_by_ether, (void **) &prefix,
+               skiplist_next (rfd->advertised.ip0_by_ether, (void **) &rk,
                               (void **) &adb, &cursor))
             {
 
@@ -483,14 +482,15 @@ rfapiApAdd (
   struct rfapi_adb *adb;
   uint32_t old_lifetime = 0;
   int use_ip0 = 0;
+  struct rfapi_rib_key rk;
 
+  rfapi_rib_key_init(pfx_ip, prd, pfx_eth, &rk);
   if (RFAPI_0_PREFIX (pfx_ip) && RFAPI_HOST_PREFIX (pfx_ip))
     {
       use_ip0 = 1;
       assert (pfx_eth);
-
       rc =
-        skiplist_search (rfd->advertised.ip0_by_ether, pfx_eth,
+        skiplist_search (rfd->advertised.ip0_by_ether, &rk,
                          (void **) &adb);
 
     }
@@ -499,7 +499,7 @@ rfapiApAdd (
 
       /* find prefix in advertised prefixes list */
       rc =
-        skiplist_search (rfd->advertised.ipN_by_prefix, pfx_ip,
+        skiplist_search (rfd->advertised.ipN_by_prefix, &rk,
                          (void **) &adb);
     }
 
@@ -510,19 +510,17 @@ rfapiApAdd (
       adb = XCALLOC (MTYPE_RFAPI_ADB, sizeof (struct rfapi_adb));
       assert (adb);
       adb->lifetime = lifetime;
-      adb->prefix_ip = *pfx_ip;
-      if (pfx_eth)
-        adb->prefix_eth = *pfx_eth;
+      adb->u.key = rk;
 
       if (use_ip0)
         {
           assert (pfx_eth);
-          skiplist_insert (rfd->advertised.ip0_by_ether, &adb->prefix_eth,
+          skiplist_insert (rfd->advertised.ip0_by_ether, &adb->u.key,
                            adb);
         }
       else
         {
-          skiplist_insert (rfd->advertised.ipN_by_prefix, &adb->prefix_ip,
+          skiplist_insert (rfd->advertised.ipN_by_prefix, &adb->u.key,
                            adb);
         }
 
@@ -537,19 +535,12 @@ rfapiApAdd (
           adb->lifetime = lifetime;
           assert (!skiplist_insert (rfd->advertised.by_lifetime, adb, adb));
         }
-
-      if (!use_ip0 && pfx_eth && prefix_cmp (&adb->prefix_eth, pfx_eth))
-        {
-          /* mac address changed */
-          adb->prefix_eth = *pfx_eth;
-        }
     }
   adb->cost = cost;
   if (l2o)
     adb->l2o = *l2o;
   else
     memset (&adb->l2o, 0, sizeof (struct rfapi_l2address_option));
-  adb->prd = *prd;
 
   if (rfapiApAdjustLifetimeStats
       (rfd, (rc ? NULL : &old_lifetime), &lifetime))
@@ -568,16 +559,19 @@ rfapiApDelete (
   struct rfapi_descriptor	*rfd,
   struct prefix			*pfx_ip,
   struct prefix			*pfx_eth,
+  struct prefix_rd		*prd,
   int				*advertise_tunnel)	/* out */
 {
   int rc;
   struct rfapi_adb *adb;
   uint32_t old_lifetime;
   int use_ip0 = 0;
+  struct rfapi_rib_key rk;
 
   if (advertise_tunnel)
     *advertise_tunnel = 0;
 
+  rfapi_rib_key_init(pfx_ip, prd, pfx_eth, &rk);
   /* find prefix in advertised prefixes list */
   if (RFAPI_0_PREFIX (pfx_ip) && RFAPI_HOST_PREFIX (pfx_ip))
     {
@@ -585,7 +579,7 @@ rfapiApDelete (
       assert (pfx_eth);
 
       rc =
-        skiplist_search (rfd->advertised.ip0_by_ether, pfx_eth,
+        skiplist_search (rfd->advertised.ip0_by_ether, &rk,
                          (void **) &adb);
 
     }
@@ -594,7 +588,7 @@ rfapiApDelete (
 
       /* find prefix in advertised prefixes list */
       rc =
-        skiplist_search (rfd->advertised.ipN_by_prefix, pfx_ip,
+        skiplist_search (rfd->advertised.ipN_by_prefix, &rk,
                          (void **) &adb);
     }
 
@@ -607,11 +601,11 @@ rfapiApDelete (
 
   if (use_ip0)
     {
-      rc = skiplist_delete (rfd->advertised.ip0_by_ether, pfx_eth, NULL);
+      rc = skiplist_delete (rfd->advertised.ip0_by_ether, &rk, NULL);
     }
   else
     {
-      rc = skiplist_delete (rfd->advertised.ipN_by_prefix, pfx_ip, NULL);
+      rc = skiplist_delete (rfd->advertised.ipN_by_prefix, &rk, NULL);
     }
   assert (!rc);
 

--- a/bgpd/rfapi/rfapi_ap.h
+++ b/bgpd/rfapi/rfapi_ap.h
@@ -93,6 +93,7 @@ rfapiApDelete (
   struct rfapi_descriptor	*rfd,
   struct prefix			*pfx_ip,
   struct prefix			*pfx_eth,
+  struct prefix_rd		*prd,
   int				*advertise_tunnel); /* out */
 
 

--- a/bgpd/rfapi/rfapi_backend.h
+++ b/bgpd/rfapi/rfapi_backend.h
@@ -36,15 +36,6 @@ extern void rfapi_delete (struct bgp *);
 struct rfapi *bgp_rfapi_new (struct bgp *bgp);
 void bgp_rfapi_destroy (struct bgp *bgp, struct rfapi *h);
 
-struct rfapi_import_table *rfapiImportTableRefAdd (struct bgp *bgp,
-                                                   struct ecommunity
-                                                   *rt_import_list);
-
-void
-rfapiImportTableRefDelByIt (struct bgp *bgp,
-                            struct rfapi_import_table *it_target);
-
-
 extern void
 rfapiProcessUpdate (struct peer *peer,
                     void *rfd,

--- a/bgpd/rfapi/rfapi_encap_tlv.c
+++ b/bgpd/rfapi/rfapi_encap_tlv.c
@@ -131,8 +131,7 @@ rfapi_tunneltype_option_to_tlv (
       break;
 
     case BGP_ENCAP_TYPE_MPLS:
-      _RTTO_MAYBE_ADD_ENDPOINT_ADDRESS (mpls);
-      bgp_encap_type_mpls_to_tlv (&tto->bgpinfo.mpls, attr);
+      /* nothing to do for MPLS */
       break;
 
     case BGP_ENCAP_TYPE_MPLS_IN_GRE:

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -423,10 +423,7 @@ rfapiGetVncTunnelUnAddr (struct attr *attr, struct prefix *p)
   rfapiGetTunnelType (attr, &tun_type);
   if (p && tun_type == BGP_ENCAP_TYPE_MPLS) 
     {
-      /* MPLS carries UN address in next hop */
-      rfapiNexthop2Prefix (attr, p);
-      if (p->family != 0)
-        return 0;
+      return ENOENT;            /* no UN for MPLS */
     }
   if (attr && attr->extra)
     {

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -4944,6 +4944,7 @@ rfapiDeleteRemotePrefixesIt (
  *	un			if set, tunnel must match this prefix
  *	vn			if set, nexthop prefix must match this prefix
  *	p			if set, prefix must match this prefix
+ *      it                      if set, only look in this import table
  *
  * output
  *	pARcount		number of active routes deleted
@@ -4959,6 +4960,7 @@ rfapiDeleteRemotePrefixes (
     struct prefix	*un,
     struct prefix	*vn,
     struct prefix	*p,
+    struct rfapi_import_table *arg_it,
     int			delete_active,
     int			delete_holddown,
     uint32_t		*pARcount,
@@ -4996,7 +4998,11 @@ rfapiDeleteRemotePrefixes (
    * for the afi/safi combination
    */
 
-  for (it = h->imports; it; it = it->next)
+  if (arg_it)
+    it = arg_it;
+  else
+    it = h->imports;
+  for (; it; )
     {
 
       vnc_zlog_debug_verbose
@@ -5017,6 +5023,11 @@ rfapiDeleteRemotePrefixes (
 	&deleted_holddown_nve_count,
 	uniq_active_nves,
 	uniq_holddown_nves);
+
+      if (arg_it)
+        it = NULL;
+      else
+        it = it->next;
     }
 
   /*

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -4645,7 +4645,8 @@ bgp_rfapi_destroy (struct bgp *bgp, struct rfapi *h)
 }
 
 struct rfapi_import_table *
-rfapiImportTableRefAdd (struct bgp *bgp, struct ecommunity *rt_import_list)
+rfapiImportTableRefAdd (struct bgp *bgp, struct ecommunity *rt_import_list,
+                        struct rfapi_nve_group_cfg *rfg)
 {
   struct rfapi *h;
   struct rfapi_import_table *it;
@@ -4671,6 +4672,7 @@ rfapiImportTableRefAdd (struct bgp *bgp, struct ecommunity *rt_import_list)
       h->imports = it;
 
       it->rt_import_list = ecommunity_dup (rt_import_list);
+      it->rfg = rfg;
       it->monitor_exterior_orphans =
         skiplist_new (0, NULL, (void (*)(void *)) prefix_free);
 

--- a/bgpd/rfapi/rfapi_import.h
+++ b/bgpd/rfapi/rfapi_import.h
@@ -38,6 +38,7 @@
 struct rfapi_import_table
 {
   struct rfapi_import_table *next;
+  struct rfapi_nve_group_cfg *rfg;
   struct ecommunity *rt_import_list;    /* copied from nve grp */
   int refcount;                 /* nve grps and nves */
   uint32_t l2_logical_net_id;   /* L2 only: EVPN Eth Seg Id */
@@ -90,6 +91,11 @@ rfapiShowImportTable (
   struct route_table	*rt,
   int			isvpn);
 
+extern struct rfapi_import_table *
+rfapiImportTableRefAdd (
+  struct bgp *bgp,
+  struct ecommunity *rt_import_list,
+  struct rfapi_nve_group_cfg *rfg);
 
 extern void
 rfapiImportTableRefDelByIt (

--- a/bgpd/rfapi/rfapi_import.h
+++ b/bgpd/rfapi/rfapi_import.h
@@ -223,6 +223,7 @@ extern int rfapiEcommunityGetEthernetTag (
  *	un			if set, tunnel must match this prefix
  *	vn			if set, nexthop prefix must match this prefix
  *	p			if set, prefix must match this prefix
+ *      it                      if set, only look in this import table
  *
  * output
  *	pARcount		number of active routes deleted
@@ -238,6 +239,7 @@ rfapiDeleteRemotePrefixes (
   struct prefix	*un,
   struct prefix	*vn,
   struct prefix	*p,
+  struct rfapi_import_table *it,
   int		delete_active,
   int		delete_holddown,
   uint32_t	*pARcount,     /* active routes */

--- a/bgpd/rfapi/rfapi_private.h
+++ b/bgpd/rfapi/rfapi_private.h
@@ -35,21 +35,6 @@
 #include "rfapi.h"
 
 /*
- * RFAPI Advertisement Data Block
- *
- * Holds NVE prefix advertisement information
- */
-struct rfapi_adb
-{
-  struct prefix			prefix_ip;
-  struct prefix			prefix_eth;     /* now redundant with l2o */
-  struct prefix_rd		prd;
-  uint32_t			lifetime;
-  uint8_t			cost;
-  struct rfapi_l2address_option	l2o;
-};
-
-/*
  * Lists of rfapi_adb. Each rfapi_adb is referenced twice:
  *
  * 1. each is referenced in by_lifetime
@@ -61,7 +46,6 @@ struct rfapi_advertised_prefixes
   struct skiplist *ip0_by_ether;  /* ip prefix 0/32, 0/128 */
   struct skiplist *by_lifetime;   /* all */
 };
-
 
 struct rfapi_descriptor
 {
@@ -378,9 +362,6 @@ rfp_cost_to_localpref (uint8_t cost);
 
 extern int
 rfapi_set_autord_from_vn (struct prefix_rd *rd, struct rfapi_ip_addr *vn);
-
-extern void
-rfapiAdbFree (struct rfapi_adb *adb);
 
 extern struct rfapi_nexthop *
 rfapi_nexthop_new (struct rfapi_nexthop *copyme);

--- a/bgpd/rfapi/rfapi_private.h
+++ b/bgpd/rfapi/rfapi_private.h
@@ -151,6 +151,7 @@ struct rfapi_descriptor
 #define RFAPI_HD_FLAG_CALLBACK_SCHEDULED_AFI_ETHER	0x00000004
 #define RFAPI_HD_FLAG_PROVISIONAL			0x00000008
 #define RFAPI_HD_FLAG_CLOSING_ADMINISTRATIVELY		0x00000010
+#define RFAPI_HD_FLAG_IS_VRF             		0x00000012
 };
 
 #define RFAPI_QUEUED_FLAG(afi) (					\
@@ -451,5 +452,18 @@ DECLARE_MTYPE(RFAPI_RECENT_DELETE)
 DECLARE_MTYPE(RFAPI_L2ADDR_OPT)
 DECLARE_MTYPE(RFAPI_AP)
 DECLARE_MTYPE(RFAPI_MONITOR_ETH)
+
+
+/*
+ * Caller must supply an already-allocated rfd with the "caller"
+ * fields already set (vn_addr, un_addr, callback, cookie)
+ * The advertised_prefixes[] array elements should be NULL to
+ * have this function set them to newly-allocated radix trees.
+ */
+extern int
+rfapi_init_and_open(
+  struct bgp			*bgp,
+  struct rfapi_descriptor	*rfd,
+  struct rfapi_nve_group_cfg	*rfg);
 
 #endif /* _QUAGGA_BGP_RFAPI_PRIVATE_H */

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -405,10 +405,26 @@ rfapiRibStartTimer (
   assert (ri->timer);
 }
 
+extern void
+rfapi_rib_key_init (struct prefix        *prefix, /* may be NULL */
+                    struct prefix_rd     *rd,     /* may be NULL */
+                    struct prefix        *aux,    /* may be NULL */
+                    struct rfapi_rib_key *rk)
+  
+{
+  memset((void *)rk, 0, sizeof(struct rfapi_rib_key));
+  if (prefix)
+    rk->vn = *prefix;
+  if (rd)
+    rk->rd = *rd;
+  if (aux)
+    rk->aux_prefix = *aux;
+}
+
 /*
  * Compares two <struct rfapi_rib_key>s
  */
-static int
+int
 rfapi_rib_key_cmp (void *k1, void *k2)
 {
   struct rfapi_rib_key *a = (struct rfapi_rib_key *) k1;

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -498,9 +498,13 @@ rfapi_info_cmp (struct rfapi_info *a, struct rfapi_info *b)
 void
 rfapiRibClear (struct rfapi_descriptor *rfd)
 {
-  struct bgp *bgp = bgp_get_default ();
+  struct bgp *bgp;
   afi_t afi;
 
+  if (rfd->bgp)
+    bgp = rfd->bgp;
+  else
+    bgp = bgp_get_default ();
 #if DEBUG_L2_EXTRA
   vnc_zlog_debug_verbose ("%s: rfd=%p", __func__, rfd);
 #endif

--- a/bgpd/rfapi/rfapi_rib.h
+++ b/bgpd/rfapi/rfapi_rib.h
@@ -45,6 +45,27 @@ struct rfapi_rib_key
    */
   struct prefix aux_prefix;
 };
+#include "rfapi.h"
+
+/*
+ * RFAPI Advertisement Data Block
+ *
+ * Holds NVE prefix advertisement information
+ */
+struct rfapi_adb
+{
+  union {
+    struct {
+      struct prefix		prefix_ip;
+      struct prefix_rd		prd;
+      struct prefix		prefix_eth;
+    } s;                                        /* mainly for legacy use */
+    struct rfapi_rib_key        key;
+  } u;
+  uint32_t			lifetime;
+  uint8_t			cost;
+  struct rfapi_l2address_option	l2o;
+};
 
 struct rfapi_info
 {
@@ -150,5 +171,17 @@ rfapiRibCheckCounts (
 #else
 #define RFAPI_RIB_CHECK_COUNTS(checkstats, offset)
 #endif
+
+extern void
+rfapi_rib_key_init (struct prefix        *prefix, /* may be NULL */
+                    struct prefix_rd     *rd,     /* may be NULL */
+                    struct prefix        *aux,    /* may be NULL */
+                    struct rfapi_rib_key *rk);
+
+extern int
+rfapi_rib_key_cmp (void *k1, void *k2);
+
+extern void
+rfapiAdbFree (struct rfapi_adb *adb);
 
 #endif /* QUAGGA_HGP_RFAPI_RIB_H */

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -1853,14 +1853,14 @@ rfapiPrintDescriptor (struct vty *vty, struct rfapi_descriptor *rfd)
         {
 
           /* group like family prefixes together in output */
-          if (family != adb->prefix_ip.family)
+          if (family != adb->u.s.prefix_ip.family)
             continue;
 
-          prefix2str (&adb->prefix_ip, buf, BUFSIZ);
+          prefix2str (&adb->u.s.prefix_ip, buf, BUFSIZ);
           buf[BUFSIZ - 1] = 0;  /* guarantee NUL-terminated */
 
           vty_out (vty, "  Adv Pfx: %s%s", buf, HVTY_NEWLINE);
-          rfapiPrintAdvertisedInfo (vty, rfd, SAFI_MPLS_VPN, &adb->prefix_ip);
+          rfapiPrintAdvertisedInfo (vty, rfd, SAFI_MPLS_VPN, &adb->u.s.prefix_ip);
         }
     }
   for (rc =
@@ -1871,14 +1871,14 @@ rfapiPrintDescriptor (struct vty *vty, struct rfapi_descriptor *rfd)
                       &cursor))
     {
 
-      prefix2str (&adb->prefix_eth, buf, BUFSIZ);
+      prefix2str (&adb->u.s.prefix_eth, buf, BUFSIZ);
       buf[BUFSIZ - 1] = 0;      /* guarantee NUL-terminated */
 
       vty_out (vty, "  Adv Pfx: %s%s", buf, HVTY_NEWLINE);
 
       /* TBD update the following function to print ethernet info */
       /* Also need to pass/use rd */
-      rfapiPrintAdvertisedInfo (vty, rfd, SAFI_MPLS_VPN, &adb->prefix_ip);
+      rfapiPrintAdvertisedInfo (vty, rfd, SAFI_MPLS_VPN, &adb->u.s.prefix_ip);
     }
   vty_out (vty, "%s", HVTY_NEWLINE);
 }
@@ -3379,7 +3379,7 @@ rfapiDeleteLocalPrefixesByRFD (struct rfapi_local_reg_delete_arg *cda,
 
             if (pPrefix)
               {
-                if (!prefix_same (pPrefix, &adb->prefix_ip))
+                if (!prefix_same (pPrefix, &adb->u.s.prefix_ip))
                   {
 #if DEBUG_L2_EXTRA
                     vnc_zlog_debug_verbose ("%s: adb=%p, prefix doesn't match, skipping",
@@ -3390,7 +3390,7 @@ rfapiDeleteLocalPrefixesByRFD (struct rfapi_local_reg_delete_arg *cda,
               }
             if (pPrd) 
               {
-                if (memcmp(pPrd->val, adb->prd.val, 8) != 0)
+                if (memcmp(pPrd->val, adb->u.s.prd.val, 8) != 0)
                   {
 #if DEBUG_L2_EXTRA
                     vnc_zlog_debug_verbose ("%s: adb=%p, RD doesn't match, skipping",
@@ -3403,7 +3403,7 @@ rfapiDeleteLocalPrefixesByRFD (struct rfapi_local_reg_delete_arg *cda,
               {
                 if (memcmp
                     (cda->l2o.o.macaddr.octet,
-                     adb->prefix_eth.u.prefix_eth.octet, ETHER_ADDR_LEN))
+                     adb->u.s.prefix_eth.u.prefix_eth.octet, ETHER_ADDR_LEN))
                   {
 #if DEBUG_L2_EXTRA
                     vnc_zlog_debug_verbose ("%s: adb=%p, macaddr doesn't match, skipping",
@@ -3444,18 +3444,18 @@ rfapiDeleteLocalPrefixesByRFD (struct rfapi_local_reg_delete_arg *cda,
 
             this_advertisement_prefix_count = 1;
 
-            rfapiQprefix2Rprefix (&adb->prefix_ip, &rp);
+            rfapiQprefix2Rprefix (&adb->u.s.prefix_ip, &rp);
 
             memset (optary, 0, sizeof (optary));
 
             /* if mac addr present in advert,  make l2o vn option */
-            if (adb->prefix_eth.family == AF_ETHERNET)
+            if (adb->u.s.prefix_eth.family == AF_ETHERNET)
               {
                 if (opt != NULL)
                   opt->next = &optary[cur_opt];
                 opt = &optary[cur_opt++];
                 opt->type = RFAPI_VN_OPTION_TYPE_L2ADDR;
-                opt->v.l2addr.macaddr = adb->prefix_eth.u.prefix_eth;
+                opt->v.l2addr.macaddr = adb->u.s.prefix_eth.u.prefix_eth;
                 ++this_advertisement_prefix_count;
               }
             /*
@@ -3466,7 +3466,7 @@ rfapiDeleteLocalPrefixesByRFD (struct rfapi_local_reg_delete_arg *cda,
               opt->next = &optary[cur_opt];
             opt = &optary[cur_opt++];
             opt->type = RFAPI_VN_OPTION_TYPE_INTERNAL_RD;
-            opt->v.internal_rd = adb->prd;
+            opt->v.internal_rd = adb->u.s.prd;
 
 #if DEBUG_L2_EXTRA
             vnc_zlog_debug_verbose ("%s: ipN killing reg from adb %p ", __func__, adb);
@@ -3509,7 +3509,7 @@ rfapiDeleteLocalPrefixesByRFD (struct rfapi_local_reg_delete_arg *cda,
                 if (CHECK_FLAG (cda->l2o.flags, RFAPI_L2O_MACADDR))
                   {
                     if (memcmp (cda->l2o.o.macaddr.octet,
-                                adb->prefix_eth.u.prefix_eth.octet,
+                                adb->u.s.prefix_eth.u.prefix_eth.octet,
                                 ETHER_ADDR_LEN))
                       {
 
@@ -3536,7 +3536,7 @@ rfapiDeleteLocalPrefixesByRFD (struct rfapi_local_reg_delete_arg *cda,
 
                 struct rfapi_vn_option vn;
 
-                rfapiQprefix2Rprefix (&adb->prefix_ip, &rp);
+                rfapiQprefix2Rprefix (&adb->u.s.prefix_ip, &rp);
 
                 memset (&vn, 0, sizeof (vn));
                 vn.type = RFAPI_VN_OPTION_TYPE_L2ADDR;

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -490,14 +490,7 @@ rfapi_vty_out_vncinfo (
   if (bi->extra != NULL)
     vty_out (vty, " label=%u", decode_label (bi->extra->tag));
 
-  if (rfapiGetVncLifetime (bi->attr, &lifetime))
-    {
-      if (safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP)
-        {
-          vty_out (vty, " life=none");
-        }
-    }
-  else
+  if (!rfapiGetVncLifetime (bi->attr, &lifetime))
     {
       vty_out (vty, " life=%d", lifetime);
     }

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -3301,7 +3301,7 @@ rfapiDeleteLocalPrefixesByRFD (struct rfapi_local_reg_delete_arg *cda,
   struct rfapi_ip_prefix rprefix;
   struct rfapi_next_hop_entry *head = NULL;
   struct rfapi_next_hop_entry *tail = NULL;
-  int noop = 1;
+  int loop = 1;
 
 #if DEBUG_L2_EXTRA
   vnc_zlog_debug_verbose ("%s: entry", __func__);
@@ -3317,7 +3317,7 @@ rfapiDeleteLocalPrefixesByRFD (struct rfapi_local_reg_delete_arg *cda,
       rfapiQprefix2Rprefix (pPrefix, &rprefix);
     }
 
-  while (noop--)                /* to preserve old code structure */
+  while (loop--)                /* to preserve old code structure */
     {
       struct rfapi *h=cda->bgp->rfapi;;
       struct rfapi_adb *adb;

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -3301,7 +3301,6 @@ rfapiDeleteLocalPrefixesByRFD (struct rfapi_local_reg_delete_arg *cda,
   struct rfapi_ip_prefix rprefix;
   struct rfapi_next_hop_entry *head = NULL;
   struct rfapi_next_hop_entry *tail = NULL;
-  int loop = 1;
 
 #if DEBUG_L2_EXTRA
   vnc_zlog_debug_verbose ("%s: entry", __func__);
@@ -3317,7 +3316,7 @@ rfapiDeleteLocalPrefixesByRFD (struct rfapi_local_reg_delete_arg *cda,
       rfapiQprefix2Rprefix (pPrefix, &rprefix);
     }
 
-  while (loop--)                /* to preserve old code structure */
+  do                            /* to preserve old code structure */
     {
       struct rfapi *h=cda->bgp->rfapi;;
       struct rfapi_adb *adb;
@@ -3599,7 +3598,7 @@ rfapiDeleteLocalPrefixesByRFD (struct rfapi_local_reg_delete_arg *cda,
               skiplist_insert (cda->nves, hap, hap);
             }
         }
-    }
+    } while (0);                /*  to preserve old code structure */
 
   return 0;
 }

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -1446,17 +1446,24 @@ rfapiShowRemoteRegistrationsIt (
 
                   if (pLni)
                     {
-                      fp (out, "%s[%s] L2VPN Network 0x%x (%u) RT={%s}%s",
-                          HVTY_NEWLINE, type, *pLni, (*pLni & 0xfff), s,
-                          HVTY_NEWLINE);
+                      fp (out, "%s[%s] L2VPN Network 0x%x (%u) RT={%s}",
+                          HVTY_NEWLINE, type, *pLni, (*pLni & 0xfff), s);
                     }
                   else
                     {
-                      fp (out, "%s[%s] Prefix RT={%s}%s",
-                          HVTY_NEWLINE, type, s, HVTY_NEWLINE);
+                      fp (out, "%s[%s] Prefix RT={%s}",
+                          HVTY_NEWLINE, type, s);
                     }
                   XFREE (MTYPE_ECOMMUNITY_STR, s);
 
+                  if (it->rfg && it->rfg->name)
+                    {
+                      fp (out, " %s \"%s\"",
+                          (it->rfg->type == RFAPI_GROUP_CFG_VRF ? 
+                           "VRF" : "NVE group"),
+                          it->rfg->name);
+                    }
+                  fp (out, "%s", HVTY_NEWLINE);
                   if (show_expiring)
                     {
 #if RFAPI_REGISTRATIONS_REPORT_AGE

--- a/lib/command.c
+++ b/lib/command.c
@@ -2563,6 +2563,7 @@ node_parent ( enum node_type node )
     case BGP_VPNV6_NODE:
     case BGP_ENCAP_NODE:
     case BGP_ENCAPV6_NODE:
+    case BGP_VRF_POLICY_NODE:
     case BGP_VNC_DEFAULTS_NODE:
     case BGP_VNC_NVE_GROUP_NODE: 
     case BGP_VNC_L2_GROUP_NODE: 
@@ -2976,6 +2977,7 @@ DEFUN (config_exit,
     case BGP_VPNV6_NODE:
     case BGP_ENCAP_NODE:
     case BGP_ENCAPV6_NODE:
+    case BGP_VRF_POLICY_NODE:
     case BGP_VNC_DEFAULTS_NODE:
     case BGP_VNC_NVE_GROUP_NODE:
     case BGP_VNC_L2_GROUP_NODE:
@@ -3036,6 +3038,7 @@ DEFUN (config_end,
     case BGP_NODE:
     case BGP_ENCAP_NODE:
     case BGP_ENCAPV6_NODE:
+    case BGP_VRF_POLICY_NODE:
     case BGP_VNC_DEFAULTS_NODE:
     case BGP_VNC_NVE_GROUP_NODE:
     case BGP_VNC_L2_GROUP_NODE:

--- a/lib/command.h
+++ b/lib/command.h
@@ -98,6 +98,7 @@ enum node_type
   BGP_IPV6M_NODE,		/* BGP IPv6 multicast address family. */
   BGP_ENCAP_NODE,		/* BGP ENCAP SAFI */
   BGP_ENCAPV6_NODE,		/* BGP ENCAP SAFI */
+  BGP_VRF_POLICY_NODE,          /* BGP VRF policy */
   BGP_VNC_DEFAULTS_NODE,	/* BGP VNC nve defaults */
   BGP_VNC_NVE_GROUP_NODE,	/* BGP VNC nve group */
   BGP_VNC_L2_GROUP_NODE,	/* BGP VNC L2 group */

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -735,6 +735,7 @@ vty_end_config (struct vty *vty)
     case BGP_VPNV6_NODE:
     case BGP_ENCAP_NODE:
     case BGP_ENCAPV6_NODE:
+    case BGP_VRF_POLICY_NODE:
     case BGP_VNC_DEFAULTS_NODE:
     case BGP_VNC_NVE_GROUP_NODE:
     case BGP_VNC_L2_GROUP_NODE:

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -312,6 +312,10 @@ vtysh_execute_func (const char *line, int pager)
 	{
 	  vtysh_execute("exit-address-family");
 	}
+      else if (saved_node == BGP_VRF_POLICY_NODE && (tried == 1))
+	{
+	  vtysh_execute("exit-vrf-policy");
+	}
       else if ((saved_node == BGP_VNC_DEFAULTS_NODE
            || saved_node == BGP_VNC_NVE_GROUP_NODE
            || saved_node == BGP_VNC_L2_GROUP_NODE) && (tried == 1))
@@ -970,6 +974,12 @@ static struct cmd_node bgp_vnc_nve_group_node =
   "%s(config-router-vnc-nve-group)# "
 };
 
+static struct cmd_node bgp_vrf_policy_node = {
+  BGP_VRF_POLICY_NODE,
+  "%s(config-router-vrf-policy)# ",
+  1
+};
+
 static struct cmd_node bgp_vnc_l2_group_node =
 {
   BGP_VNC_L2_GROUP_NODE,
@@ -1275,6 +1285,17 @@ DEFUNSH (VTYSH_BGPD,
 }
 
 DEFUNSH (VTYSH_BGPD,
+         vnc_vrf_policy,
+         vnc_vrf_policy_cmd,
+         "vrf-policy NAME",
+         "Configure a VRF policy group\n"
+         "Group name\n")
+{
+  vty->node = BGP_VRF_POLICY_NODE;
+  return CMD_SUCCESS;
+}
+
+DEFUNSH (VTYSH_BGPD,
          vnc_l2_group,
          vnc_l2_group_cmd,
          "vnc l2-group NAME",
@@ -1553,6 +1574,7 @@ vtysh_exit (struct vty *vty)
     case BGP_IPV4M_NODE:
     case BGP_IPV6_NODE:
     case BGP_IPV6M_NODE:
+    case BGP_VRF_POLICY_NODE:
     case BGP_VNC_DEFAULTS_NODE:
     case BGP_VNC_NVE_GROUP_NODE:
     case BGP_VNC_L2_GROUP_NODE:
@@ -1624,6 +1646,17 @@ DEFUNSH (VTYSH_BGPD,
   if (vty->node == BGP_VNC_DEFAULTS_NODE
       || vty->node == BGP_VNC_NVE_GROUP_NODE
       || vty->node == BGP_VNC_L2_GROUP_NODE)
+    vty->node = BGP_NODE;
+  return CMD_SUCCESS;
+}
+
+DEFUNSH (VTYSH_BGPD,
+	 exit_vrf_policy,
+	 exit_vrf_policy_cmd,
+	 "exit-vrf-policy",
+	 "Exit from VRF  configuration mode\n")
+{
+  if (vty->node == BGP_VRF_POLICY_NODE)
     vty->node = BGP_NODE;
   return CMD_SUCCESS;
 }
@@ -3138,6 +3171,7 @@ vtysh_init_vty (void)
   install_node (&bgp_ipv4m_node, NULL);
   install_node (&bgp_ipv6_node, NULL);
   install_node (&bgp_ipv6m_node, NULL);
+  install_node (&bgp_vrf_policy_node, NULL);
   install_node (&bgp_vnc_defaults_node, NULL);
   install_node (&bgp_vnc_nve_group_node, NULL);
   install_node (&bgp_vnc_l2_group_node, NULL);
@@ -3175,6 +3209,7 @@ vtysh_init_vty (void)
   vtysh_install_default (BGP_IPV6_NODE);
   vtysh_install_default (BGP_IPV6M_NODE);
 #if ENABLE_BGP_VNC
+  vtysh_install_default (BGP_VRF_POLICY_NODE);
   vtysh_install_default (BGP_VNC_DEFAULTS_NODE);
   vtysh_install_default (BGP_VNC_NVE_GROUP_NODE);
   vtysh_install_default (BGP_VNC_L2_GROUP_NODE);
@@ -3246,6 +3281,8 @@ vtysh_init_vty (void)
   install_element (BGP_IPV6M_NODE, &vtysh_exit_bgpd_cmd);
   install_element (BGP_IPV6M_NODE, &vtysh_quit_bgpd_cmd);
 #if defined (ENABLE_BGP_VNC)
+  install_element (BGP_VRF_POLICY_NODE, &vtysh_exit_bgpd_cmd);
+  install_element (BGP_VRF_POLICY_NODE, &vtysh_quit_bgpd_cmd);
   install_element (BGP_VNC_DEFAULTS_NODE, &vtysh_exit_bgpd_cmd);
   install_element (BGP_VNC_DEFAULTS_NODE, &vtysh_quit_bgpd_cmd);
   install_element (BGP_VNC_NVE_GROUP_NODE, &vtysh_exit_bgpd_cmd);
@@ -3287,6 +3324,7 @@ vtysh_init_vty (void)
   install_element (BGP_ENCAPV6_NODE, &vtysh_end_all_cmd);
   install_element (BGP_IPV6_NODE, &vtysh_end_all_cmd);
   install_element (BGP_IPV6M_NODE, &vtysh_end_all_cmd);
+  install_element (BGP_VRF_POLICY_NODE, &vtysh_end_all_cmd);
   install_element (BGP_VNC_DEFAULTS_NODE, &vtysh_end_all_cmd);
   install_element (BGP_VNC_NVE_GROUP_NODE, &vtysh_end_all_cmd);
   install_element (BGP_VNC_L2_GROUP_NODE, &vtysh_end_all_cmd);
@@ -3338,6 +3376,7 @@ vtysh_init_vty (void)
   install_element (BGP_NODE, &address_family_encap_cmd);
   install_element (BGP_NODE, &address_family_encapv6_cmd);
 #if defined(ENABLE_BGP_VNC)
+  install_element (BGP_NODE, &vnc_vrf_policy_cmd);
   install_element (BGP_NODE, &vnc_defaults_cmd);
   install_element (BGP_NODE, &vnc_nve_group_cmd);
 #endif
@@ -3357,6 +3396,7 @@ vtysh_init_vty (void)
   install_element (BGP_IPV6_NODE, &exit_address_family_cmd);
   install_element (BGP_IPV6M_NODE, &exit_address_family_cmd);
 
+  install_element (BGP_VRF_POLICY_NODE, &exit_vrf_policy_cmd);
   install_element (BGP_VNC_DEFAULTS_NODE, &exit_vnc_config_cmd);
   install_element (BGP_VNC_NVE_GROUP_NODE, &exit_vnc_config_cmd);
   install_element (BGP_VNC_L2_GROUP_NODE, &exit_vnc_config_cmd);


### PR DESCRIPTION
Issues:
    bgpd: allow VPN next hop to be different AFI than NLRI next hop (Issue #71)
    bgpd: fix RD stomping by update group code (Issue #71)
    bgpd: partial revert of vpn/encap safi show changes (Issue #14)
          To remove commands duplicated in bgp_mplsvpn/_encap
          Also until vpn/encap specific show pieces are merged into
          generic afi/safi show.
Fixes/cleanup
    bgpd rfapi: fix issue where advertised prefixes were not being disambiguated
                   by RD
    bgpd rfapi: use VN as nexthop for MPLS tunnels too
         Also minor show format cleanup   
    bgpd rfapi: add NVE/VRF name to show vnc registrations
new commands (partail set from RD/RT discussion)
    bgpd: add vrf-policy config using existing vnc code
          add add/clear vrf prefix
