### PR TITLE
bgpd: str2prefix_rd support for AS4 format

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -337,12 +337,24 @@ str2prefix_rd (const char *str, struct prefix_rd *prd)
 
   if (! p2)
     {
+      unsigned long as_val;
+
       if (! all_digit (half))
         goto out;
 
-      stream_putw (s, RD_TYPE_AS);
-      stream_putw (s, atoi (half));
-      stream_putl (s, atol (p + 1));
+      as_val = atol(half);
+      if (as_val > 0xffff)
+        {
+          stream_putw (s, RD_TYPE_AS4);
+          stream_putl (s, atol (half));
+          stream_putw (s, atol (p + 1));
+        }
+      else
+        {
+          stream_putw (s, RD_TYPE_AS);
+          stream_putw (s, atol (half));
+          stream_putl (s, atol (p + 1));
+        }
     }
   else
     {

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -346,13 +346,13 @@ str2prefix_rd (const char *str, struct prefix_rd *prd)
       if (as_val > 0xffff)
         {
           stream_putw (s, RD_TYPE_AS4);
-          stream_putl (s, atol (half));
+          stream_putl (s, as_val);
           stream_putw (s, atol (p + 1));
         }
       else
         {
           stream_putw (s, RD_TYPE_AS);
-          stream_putw (s, atol (half));
+          stream_putw (s, as_val);
           stream_putl (s, atol (p + 1));
         }
     }


### PR DESCRIPTION
This commit improves the ability for str2prefix_rd command to support
AS4 format. Until now, only AS2 format and IP format was supported.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>