### PR TITLE
build: fix several ldpd XML-CLI build issues

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -292,8 +292,6 @@ if test $ac_cv_lib_json_c_json_object_get = no; then
   fi
 fi
 
-AX_PROG_PERL_MODULES(XML::LibXML, , AC_MSG_ERROR(XML::LibXML perl module is needed to compile))
-
 AC_ARG_ENABLE([dev_build],
     AS_HELP_STRING([--enable-dev-build], [build for development]))
 
@@ -1163,6 +1161,14 @@ AM_CONDITIONAL(OSPFD, test "x$OSPFD" = "xospfd")
 if test "${enable_ldpd}" = "no";then
   LDPD=""
 else
+  AX_PROG_PERL_MODULES(XML::LibXML, , [
+    if test -f "${srcdir}/ldpd/ldp_vty_cmds.c"; then
+      AC_MSG_WARN([XML::LibXML perl module not found, using pregenerated ldp_vty_cmds.c])
+    else
+      AC_MSG_ERROR([XML::LibXML perl module not found and pregenerated ldp_vty_cmds.c missing])
+    fi
+  ])
+
   LDPD="ldpd"
   AC_DEFINE(HAVE_LDPD, 1, ldpd)
 fi

--- a/ldpd/Makefile.am
+++ b/ldpd/Makefile.am
@@ -3,6 +3,7 @@
 AM_CPPFLAGS = -I.. -I$(top_srcdir) -I$(top_srcdir)/lib -I$(top_builddir)/lib
 DEFS = @DEFS@ -DSYSCONFDIR=\"$(sysconfdir)/\"
 INSTALL_SDATA=@INSTALL@ -m 600
+EXTRA_DIST=
 
 AM_CFLAGS = $(WERROR)
 
@@ -10,6 +11,7 @@ noinst_LIBRARIES = libldp.a
 sbin_PROGRAMS = ldpd
 
 BUILT_SOURCES = ldp_vty_cmds.c
+EXTRA_DIST += ldp_vty.xml
 
 libldp_a_SOURCES = \
 	accept.c address.c adjacency.c control.c hello.c init.c interface.c \

--- a/ldpd/ldp_vty.xml
+++ b/ldpd/ldp_vty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<file init="ldp_vty_init" cmdprefix="ldp" header="ldp_vty.h">
+<file init="ldp_vty_init" cmdprefix="ldp" header="ldpd/ldp_vty.h">
   <!-- address-family -->
   <options name="address-family">
     <option name="ipv4" help="IPv4 Address Family"/>

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,6 +1,7 @@
 AM_CPPFLAGS = -I.. -I$(top_srcdir) -I$(top_srcdir)/lib -I$(top_builddir)/lib
 DEFS = @DEFS@ -DSYSCONFDIR=\"$(sysconfdir)/\"
 AM_CFLAGS = $(WERROR)
+EXTRA_DIST =
 
 bin_PROGRAMS = permutations
 permutations_SOURCES = permutations.c
@@ -8,5 +9,6 @@ permutations_LDADD = ../lib/libzebra.la
 
 sbin_SCRIPTS = frr-reload.py frr
 
-EXTRA_DIST = frr.service frr-reload.py frr
+EXTRA_DIST += frr.service frr-reload.py frr
 
+EXTRA_DIST += xml2cli.pl

--- a/vtysh/Makefile.am
+++ b/vtysh/Makefile.am
@@ -59,10 +59,6 @@ if OSPF6D
 vtysh_scan += $(top_srcdir)/ospf6d/*.c
 endif
 
-if LDPD
-vtysh_scan += $(top_srcdir)/ldpd/ldp_vty_cmds.c
-endif
-
 if RIPD
 vtysh_scan += $(top_srcdir)/ripd/*.c
 endif
@@ -89,5 +85,22 @@ vtysh_cmd_FILES = $(vtysh_scan) \
 		  $(top_srcdir)/watchfrr/watchfrr_vty.c \
 	          $(BGP_VNC_RFAPI_SRC) $(BGP_VNC_RFP_SRC)
 
-vtysh_cmd.c: $(vtysh_cmd_FILES) extract.pl
-	./extract.pl $(vtysh_cmd_FILES) > vtysh_cmd.c
+# this is slightly iffy... ldp_vty_cmds.c can be located in either
+# $srcdir or $builddir depending on whether it's coming pre-built from a
+# dist tarball or being built.  automake uses VPATH to find it, but that
+# doesn't work here...
+# so after running "make ldp_vty_cmds.c", the file can be in either of the
+# two directories.  we need to do some magic to find out which.
+vtysh_cmd_DEPS = $(vtysh_cmd_FILES)
+if LDPD
+$(top_builddir)/ldpd/ldp_vty_cmds.c:
+	make -C "$(top_builddir)/ldpd" ldp_vty_cmds.c
+vtysh_cmd_DEPS += $(top_builddir)/ldpd/ldp_vty_cmds.c
+endif
+
+vtysh_cmd.c: $(vtysh_cmd_DEPS) extract.pl
+	if test -n "${LDPD}"; then \
+		ldpcmds="$(top_srcdir)/ldpd/ldp_vty_cmds.c"; \
+		test -f "$(top_builddir)/ldpd/ldp_vty_cmds.c" && ldpcmds="$(top_builddir)/ldpd/ldp_vty_cmds.c"; \
+	fi; \
+	./extract.pl $(vtysh_cmd_FILES) $${ldpcmds} > vtysh_cmd.c


### PR DESCRIPTION
- the location of ldp_vty_cmds.c can be either in srcdir or builddir,
  depending on whether a premade file from a dist tarball is used
- perl libxml support is only needed if that file is absent
- the actual perl script wasn't even included in the dist tarball
- the include location doesn't work when srcdir != builddir

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>