### PR TITLE
Mergedown vpn old format

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -41,11 +41,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgpd/rfapi/rfapi_backend.h"
 #endif
 
-#define BGP_VPNVX_HELP_STR       \
-  "Address Family \n"   \
-  "Address Family \n"
-
-static int
+extern int
 argv_find_and_parse_vpnvx(struct cmd_token **argv, int argc, int *index, afi_t *afi)
 {
   int ret = 0;
@@ -222,7 +218,7 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
 
       if (prefixlen < VPN_PREFIXLEN_MIN_BYTES*8)
 	{
-	  zlog_err ("%s [Error] Update packet error / VPNv4 (prefix length %d less than VPNv4 min length)",
+	  zlog_err ("%s [Error] Update packet error / VPN (prefix length %d less than VPN min length)",
 	            peer->host, prefixlen);
 	  return -1;
 	}
@@ -230,7 +226,7 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
       /* sanity check against packet data */
       if ((pnt + psize) > lim)
         {
-          zlog_err ("%s [Error] Update packet error / VPNv4 (prefix length %d exceeds packet size %u)",
+          zlog_err ("%s [Error] Update packet error / VPN (prefix length %d exceeds packet size %u)",
                     peer->host,
                     prefixlen, (uint)(lim-pnt));
           return -1;
@@ -239,7 +235,7 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
       /* sanity check against storage for the IP address portion */
       if ((psize - VPN_PREFIXLEN_MIN_BYTES) > (ssize_t) sizeof(p.u))
         {
-          zlog_err ("%s [Error] Update packet error / VPNv4 (psize %d exceeds storage size %zu)",
+          zlog_err ("%s [Error] Update packet error / VPN (psize %d exceeds storage size %zu)",
                     peer->host,
                     prefixlen - VPN_PREFIXLEN_MIN_BYTES*8, sizeof(p.u));
           return -1;
@@ -248,7 +244,7 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
       /* Sanity check against max bitlen of the address family */
       if ((psize - VPN_PREFIXLEN_MIN_BYTES) > prefix_blen (&p))
         {
-          zlog_err ("%s [Error] Update packet error / VPNv4 (psize %d exceeds family (%u) max byte len %u)",
+          zlog_err ("%s [Error] Update packet error / VPN (psize %d exceeds family (%u) max byte len %u)",
                     peer->host,
                     prefixlen - VPN_PREFIXLEN_MIN_BYTES*8, 
                     p.family, prefix_blen (&p));
@@ -319,7 +315,7 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
   /* Packet length consistency check. */
   if (pnt != lim)
     {
-      zlog_err ("%s [Error] Update packet error / VPNv4 (%zu data remaining after parsing)",
+      zlog_err ("%s [Error] Update packet error / VPN (%zu data remaining after parsing)",
                 peer->host, lim - pnt);
       return -1;
     }
@@ -1009,6 +1005,7 @@ DEFUN (show_bgp_ip_vpn_rd,
   return CMD_SUCCESS;
 }
 
+#ifdef KEEP_OLD_VPN_COMMANDS
 DEFUN (show_ip_bgp_vpn_all,
        show_ip_bgp_vpn_all_cmd,
        "show [ip] bgp <vpnv4|vpnv6>",
@@ -1377,6 +1374,7 @@ DEFUN (show_ip_bgp_vpn_rd_neighbor_advertised_routes,
     }
   return CMD_SUCCESS;
 }
+#endif /* KEEP_OLD_VPN_COMMANDS */
 
 void
 bgp_mplsvpn_init (void)
@@ -1389,6 +1387,7 @@ bgp_mplsvpn_init (void)
   install_element (BGP_VPNV6_NODE, &no_vpnv6_network_cmd);
 
   install_element (VIEW_NODE, &show_bgp_ip_vpn_rd_cmd);
+#ifdef KEEP_OLD_VPN_COMMANDS
   install_element (VIEW_NODE, &show_ip_bgp_vpn_all_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpn_rd_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpn_all_tags_cmd);
@@ -1397,4 +1396,5 @@ bgp_mplsvpn_init (void)
   install_element (VIEW_NODE, &show_ip_bgp_vpn_rd_neighbor_routes_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpn_all_neighbor_advertised_routes_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_vpn_rd_neighbor_advertised_routes_cmd);
+#endif /* KEEP_OLD_VPN_COMMANDS */
 }

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -55,6 +55,10 @@ typedef enum {
      (label) == MPLS_LABEL_IPV6_EXPLICIT_NULL || \
      (label) == MPLS_LABEL_IMPLICIT_NULL)
 
+#define BGP_VPNVX_HELP_STR       \
+  "Address Family \n"   \
+  "Address Family \n"
+
 struct rd_as
 {
   u_int16_t type;
@@ -93,5 +97,8 @@ extern void decode_vnc_eth (u_char *, struct rd_vnc_eth *);
 extern int str2prefix_rd (const char *, struct prefix_rd *);
 extern int str2tag (const char *, u_char *);
 extern char *prefix_rd2str (struct prefix_rd *, char *, size_t);
+
+extern int
+argv_find_and_parse_vpnvx(struct cmd_token **argv, int argc, int *index, afi_t *afi);
 
 #endif /* _QUAGGA_BGP_MPLSVPN_H */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9151,13 +9151,14 @@ DEFUN (show_ip_bgp_ipv4_neighbor_prefix_counts,
   return bgp_peer_counts (vty, peer, AFI_IP, SAFI_UNICAST, uj);
 }
 
-DEFUN (show_ip_bgp_vpnv4_neighbor_prefix_counts,
-       show_ip_bgp_vpnv4_neighbor_prefix_counts_cmd,
-       "show [ip] bgp vpnv4 all neighbors <A.B.C.D|X:X::X:X|WORD> prefix-counts [json]",
+#ifdef KEEP_OLD_VPN_COMMANDS
+DEFUN (show_ip_bgp_vpn_neighbor_prefix_counts,
+       show_ip_bgp_vpn_neighbor_prefix_counts_cmd,
+       "show [ip] bgp <vpnv4|vpnv6> all neighbors <A.B.C.D|X:X::X:X|WORD> prefix-counts [json]",
        SHOW_STR
        IP_STR
        BGP_STR
-       "Address Family\n"
+       BGP_VPNVX_HELP_STR
        "Display information about all VPNv4 NLRIs\n"
        "Detailed information on TCP and BGP neighbor connections\n"
        "Neighbor to display information about\n"
@@ -9177,13 +9178,13 @@ DEFUN (show_ip_bgp_vpnv4_neighbor_prefix_counts,
   return bgp_peer_counts (vty, peer, AFI_IP, SAFI_MPLS_VPN, uj);
 }
 
-DEFUN (show_ip_bgp_vpnv4_all_route_prefix,
-       show_ip_bgp_vpnv4_all_route_prefix_cmd,
-       "show [ip] bgp vpnv4 all <A.B.C.D|A.B.C.D/M> [json]",
+DEFUN (show_ip_bgp_vpn_all_route_prefix,
+       show_ip_bgp_vpn_all_route_prefix_cmd,
+       "show [ip] bgp <vpnv4|vpnv6> all <A.B.C.D|A.B.C.D/M> [json]",
        SHOW_STR
        IP_STR
        BGP_STR
-       "Address Family\n"
+       BGP_VPNVX_HELP_STR
        "Display information about all VPNv4 NLRIs\n"
        "Network in the BGP routing table to display\n"
        "Network in the BGP routing table to display\n"
@@ -9195,6 +9196,7 @@ DEFUN (show_ip_bgp_vpnv4_all_route_prefix,
   network = argv_find (argv, argc, "A.B.C.D/M", &idx) ? argv[idx]->arg : NULL;
   return bgp_show_route (vty, NULL, network, AFI_IP, SAFI_MPLS_VPN, NULL, 0, BGP_PATH_ALL, use_json(argc, argv));
 }
+#endif /* KEEP_OLD_VPN_COMMANDS */
 
 static void
 show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
@@ -10532,7 +10534,9 @@ bgp_route_init (void)
   install_element (VIEW_NODE, &show_ip_bgp_neighbor_received_prefix_filter_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_dampening_params_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_ipv4_dampening_parameters_cmd);
-  install_element (VIEW_NODE, &show_ip_bgp_vpnv4_all_route_prefix_cmd);
+#ifdef KEEP_OLD_VPN_COMMANDS
+  install_element (VIEW_NODE, &show_ip_bgp_vpn_all_route_prefix_cmd);
+#endif /* KEEP_OLD_VPN_COMMANDS */
 
  /* BGP dampening clear commands */
   install_element (ENABLE_NODE, &clear_ip_bgp_dampening_cmd);
@@ -10544,7 +10548,9 @@ bgp_route_init (void)
   install_element (ENABLE_NODE, &show_ip_bgp_neighbor_prefix_counts_cmd);
   install_element (ENABLE_NODE, &show_ip_bgp_instance_neighbor_prefix_counts_cmd);
   install_element (ENABLE_NODE, &show_ip_bgp_ipv4_neighbor_prefix_counts_cmd);
-  install_element (ENABLE_NODE, &show_ip_bgp_vpnv4_neighbor_prefix_counts_cmd);
+#ifdef KEEP_OLD_VPN_COMMANDS
+  install_element (ENABLE_NODE, &show_ip_bgp_vpn_neighbor_prefix_counts_cmd);
+#endif /* KEEP_OLD_VPN_COMMANDS */
   install_element (ENABLE_NODE, &show_bgp_ipv6_neighbor_prefix_counts_cmd);
   install_element (ENABLE_NODE, &show_bgp_instance_ipv6_neighbor_prefix_counts_cmd);
 

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5564,6 +5564,7 @@ DEFUN (address_family_ipv6_safi,
   return CMD_SUCCESS;
 }
 
+#ifdef KEEP_OLD_VPN_COMMANDS
 DEFUN (address_family_vpnv4,
        address_family_vpnv4_cmd,
        "address-family vpnv4 [unicast]",
@@ -5581,6 +5582,29 @@ DEFUN (address_family_vpnv6,
        "Enter Address Family command mode\n"
        "Address Family\n"
        "Address Family modifier\n")
+{
+  vty->node = BGP_VPNV6_NODE;
+  return CMD_SUCCESS;
+}
+#endif /* KEEP_OLD_VPN_COMMANDS */
+
+DEFUN (address_family_ipv4_vpn,
+       address_family_ipv4_vpn_cmd,
+       "address-family ipv4 vpn",
+       "Enter Address Family command mode\n"
+       "Address Family\n"
+       "Subsequent Address Family modifier\n")
+{
+  vty->node = BGP_VPNV4_NODE;
+  return CMD_SUCCESS;
+}
+
+DEFUN (address_family_ipv6_vpn,
+       address_family_ipv6_vpn_cmd,
+       "address-family ipv6 vpn",
+       "Enter Address Family command mode\n"
+       "Address Family\n"
+       "Subsequent Address Family modifier\n")
 {
   vty->node = BGP_VPNV6_NODE;
   return CMD_SUCCESS;
@@ -10684,9 +10708,12 @@ bgp_vty_init (void)
   install_element (BGP_NODE, &address_family_ipv4_safi_cmd);
   install_element (BGP_NODE, &address_family_ipv6_cmd);
   install_element (BGP_NODE, &address_family_ipv6_safi_cmd);
+#ifdef KEEP_OLD_VPN_COMMANDS
   install_element (BGP_NODE, &address_family_vpnv4_cmd);
-
   install_element (BGP_NODE, &address_family_vpnv6_cmd);
+#endif /* KEEP_OLD_VPN_COMMANDS */
+  install_element (BGP_NODE, &address_family_ipv4_vpn_cmd);
+  install_element (BGP_NODE, &address_family_ipv6_vpn_cmd);
 
   install_element (BGP_NODE, &address_family_encap_cmd);
   install_element (BGP_NODE, &address_family_encapv6_cmd);

--- a/configure.ac
+++ b/configure.ac
@@ -282,6 +282,8 @@ AC_ARG_ENABLE(rr-semantics,
   AS_HELP_STRING([--disable-rr-semantics], [disable the v6 Route Replace semantics]))
 AC_ARG_ENABLE([protobuf],
   AS_HELP_STRING([--enable-protobuf], [Enable experimental protobuf support]))
+AC_ARG_ENABLE([oldvpn_commands],
+  AS_HELP_STRING([--enable-old-vpn-commands], [Keep old vpn commands]))
 
 AC_CHECK_HEADERS(json-c/json.h)
 AC_CHECK_LIB(json-c, json_object_get, LIBS="$LIBS -ljson-c")
@@ -385,6 +387,13 @@ if test "$enable_protobuf" = "yes"; then
                         [have_protobuf=no; AC_MSG_RESULT([Couldn't find google/protobuf-c.h])])
       fi
    fi
+fi
+
+#
+# Logic for old vpn commans support.
+#
+if test "$enable_old_vpn_commands" = "yes"; then
+   AC_DEFINE(KEEP_OLD_VPN_COMMANDS,, [Define for compiling with old vpn commands])
 fi
 
 # Fail if the user explicity enabled protobuf support and we couldn't


### PR DESCRIPTION
Hi all,

this patch brings two elements:
- the usage of a configuration flag to unset some old (supposed ) vpn deprecated commands ( the old style ( --enable-old-vpn-commands )
- the identified vpn commands with old style have been deprecated

About yesterday's discussion about deprecated commands, one possible improvement of this patch could be to replace KEEP_OLD_VPN_COMMANDS with a more generic define. Like that, the user that uses quagga could still use old format of vpn commands, along with the new vpn format commands.

Also, note that if this flag is not used, some vpnvx commands will be lost. as not all vpnvx commands are not in the new format, this will cause some depreciation in the bgp vpn service. This is not so troublesome, in the sense that the vpn status on this master branch is not stable.
