### PR TITLE
lib: guard strict cli completions

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -541,8 +541,12 @@ completions_to_vec (struct list *completions)
     for (i = 0; i < vector_active (comps) && !exists; i++)
     {
       struct cmd_token *curr = vector_slot (comps, i);
+#ifdef VTYSH_DEBUG
       exists = !strcmp (curr->text, token->text) &&
                !strcmp (curr->desc, token->desc);
+#else
+      exists = !strcmp (curr->text, token->text);
+#endif /* VTYSH_DEBUG */
     }
 
     if (!exists)


### PR DESCRIPTION
Completions are checked for token and docstring equality before
deduplicating. Put an ifdef guard around checking docstrings because
many of them are inconsistent and may confuse users in a release build.

It is a good idea to enable VTYSH_DEBUG when adding new CLI in the
future to help check docstrings.

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>