### PR TITLE
Master version of basic vrf commands & some other missed fixes

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -969,7 +969,7 @@ bgp_show_mpls_vpn (struct vty *vty, afi_t afi, struct prefix_rd *prd,
 
 DEFUN (show_bgp_ip_vpn_rd,
        show_bgp_ip_vpn_rd_cmd,
-       "show [ip] bgp "BGP_AFI_CMD_STR" vpn [rd ASN:nn_or_IP-address:nn] [json]",
+       "show bgp "BGP_AFI_CMD_STR" vpn all [rd ASN:nn_or_IP-address:nn] [json]",
        SHOW_STR
        IP_STR
        BGP_STR
@@ -979,7 +979,7 @@ DEFUN (show_bgp_ip_vpn_rd,
        "VPN Route Distinguisher\n"
        JSON_STR)
 {
-  int idx_ext_community = 5;
+  int idx_rd = 5;
   int ret;
   struct prefix_rd prd;
   afi_t afi;
@@ -987,9 +987,9 @@ DEFUN (show_bgp_ip_vpn_rd,
 
   if (argv_find_and_parse_afi (argv, argc, &idx, &afi))
     {
-      if (argv[idx_ext_community]->arg)
+      if (argc >= 7 &&  argv[idx_rd]->arg)
         {
-          ret = str2prefix_rd (argv[idx_ext_community]->arg, &prd);
+          ret = str2prefix_rd (argv[idx_rd]->arg, &prd);
           if (! ret)
             {
               vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -30,6 +30,10 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 
 #define RD_ADDRSTRLEN  28
 
+#ifdef MPLS_LABEL_MAX
+# undef MPLS_LABEL_MAX
+#endif
+
 typedef enum {
     MPLS_LABEL_IPV4_EXPLICIT_NULL = 0,  /* [RFC3032] */
     MPLS_LABEL_ROUTER_ALERT       = 1,  /* [RFC3032] */
@@ -45,7 +49,9 @@ typedef enum {
     MPLS_LABEL_UNASSIGNED11       = 11,
     MPLS_LABEL_GAL                = 13, /* [RFC5586] */
     MPLS_LABEL_OAM_ALERT          = 14, /* [RFC3429] */
-    MPLS_LABEL_EXTENSION          = 15  /* [RFC7274] */
+    MPLS_LABEL_EXTENSION          = 15,  /* [RFC7274] */
+    MPLS_LABEL_MAX                = 1048575,
+    MPLS_LABEL_ILLEGAL            = 0xFFFFFFFF /* for internal use only */
 } mpls_special_label_t;
 
 #define MPLS_LABEL_IS_SPECIAL(label)             \

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9441,7 +9441,7 @@ peer_adj_routes (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
 
 DEFUN (show_ip_bgp_instance_neighbor_advertised_route,
        show_ip_bgp_instance_neighbor_advertised_route_cmd,
-       "show [ip] bgp [<view|vrf> WORD] [<ipv4 [<unicast|multicast>]|ipv6 [<unicast|multicast>]|encap [unicast]|vpnv4 [unicast]>] neighbors <A.B.C.D|X:X::X:X|WORD> [<received-routes|advertised-routes> [route-map WORD]] [json]",
+       "show [ip] bgp [<view|vrf> WORD] [<ipv4 [<unicast|multicast>]|ipv6 [<unicast|multicast>]|encap [unicast]|vpnv4 [unicast]>] neighbors <A.B.C.D|X:X::X:X|WORD> <received-routes|advertised-routes> [route-map WORD] [json]",
        SHOW_STR
        IP_STR
        BGP_STR

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5586,7 +5586,6 @@ DEFUN (address_family_vpnv6,
   vty->node = BGP_VPNV6_NODE;
   return CMD_SUCCESS;
 }
-#endif /* KEEP_OLD_VPN_COMMANDS */
 
 DEFUN (address_family_ipv4_vpn,
        address_family_ipv4_vpn_cmd,
@@ -5609,6 +5608,7 @@ DEFUN (address_family_ipv6_vpn,
   vty->node = BGP_VPNV6_NODE;
   return CMD_SUCCESS;
 }
+#endif /* KEEP_OLD_VPN_COMMANDS */
 
 DEFUN (address_family_encap,
        address_family_encap_cmd,
@@ -10711,9 +10711,9 @@ bgp_vty_init (void)
 #ifdef KEEP_OLD_VPN_COMMANDS
   install_element (BGP_NODE, &address_family_vpnv4_cmd);
   install_element (BGP_NODE, &address_family_vpnv6_cmd);
-#endif /* KEEP_OLD_VPN_COMMANDS */
   install_element (BGP_NODE, &address_family_ipv4_vpn_cmd);
   install_element (BGP_NODE, &address_family_ipv6_vpn_cmd);
+#endif /* KEEP_OLD_VPN_COMMANDS */
 
   install_element (BGP_NODE, &address_family_encap_cmd);
   install_element (BGP_NODE, &address_family_encapv6_cmd);

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -2463,7 +2463,7 @@ DEFUN (vnc_nve_group,
           rfg->rt_import_list =
             ecommunity_dup (bgp->rfapi_cfg->default_rt_import_list);
           rfg->rfapi_import_table =
-            rfapiImportTableRefAdd (bgp, rfg->rt_import_list);
+            rfapiImportTableRefAdd (bgp, rfg->rt_import_list, rfg);
         }
 
       /*
@@ -2903,7 +2903,7 @@ DEFUN (vnc_nve_group_rt_import,
    */
   if (rfg->rfapi_import_table)
     rfapiImportTableRefDelByIt (bgp, rfg->rfapi_import_table);
-  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list);
+  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list, rfg);
 
   if (is_export_bgp)
     vnc_direct_bgp_add_group (bgp, rfg);
@@ -3010,7 +3010,7 @@ DEFUN (vnc_nve_group_rt_both,
    */
   if (rfg->rfapi_import_table)
     rfapiImportTableRefDelByIt (bgp, rfg->rfapi_import_table);
-  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list);
+  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list, rfg);
 
   if (is_export_bgp)
     vnc_direct_bgp_add_group (bgp, rfg);
@@ -3494,7 +3494,7 @@ DEFUN (vnc_vrf_policy_rt_import,
    */
   if (rfg->rfapi_import_table)
     rfapiImportTableRefDelByIt (bgp, rfg->rfapi_import_table);
-  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list);
+  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list, rfg);
 
   if (is_export_bgp)
     vnc_direct_bgp_add_group (bgp, rfg);
@@ -3613,7 +3613,7 @@ DEFUN (vnc_vrf_policy_rt_both,
    */
   if (rfg->rfapi_import_table)
     rfapiImportTableRefDelByIt (bgp, rfg->rfapi_import_table);
-  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list);
+  rfg->rfapi_import_table = rfapiImportTableRefAdd (bgp, rfg->rt_import_list, rfg);
 
   if (is_export_bgp)
     vnc_direct_bgp_add_group (bgp, rfg);

--- a/bgpd/rfapi/bgp_rfapi_cfg.h
+++ b/bgpd/rfapi/bgp_rfapi_cfg.h
@@ -41,12 +41,21 @@ struct rfapi_l2_group_cfg
 };
 DECLARE_QOBJ_TYPE(rfapi_l2_group_cfg)
 
+typedef enum
+{
+  RFAPI_GROUP_CFG_NVE = 1,
+  RFAPI_GROUP_CFG_VRF,
+  RFAPI_GROUP_CFG_L2,
+  RFAPI_GROUP_CFG_MAX
+} rfapi_group_cfg_type_t;
+
 struct rfapi_nve_group_cfg
 {
   struct route_node *vn_node;   /* backref */
   struct route_node *un_node;   /* backref */
 
-  char *name;
+  rfapi_group_cfg_type_t type;  /* NVE|VPN */
+  char *name;                   /* unique by type! */
   struct prefix vn_prefix;
   struct prefix un_prefix;
 
@@ -54,8 +63,9 @@ struct rfapi_nve_group_cfg
   uint8_t l2rd;                 /* 0 = VN addr LSB */
   uint32_t response_lifetime;
   uint32_t flags;
-#define RFAPI_RFG_RESPONSE_LIFETIME	0x1
+#define RFAPI_RFG_RESPONSE_LIFETIME	0x01 /* bits */
 #define RFAPI_RFG_L2RD			0x02
+#define RFAPI_RFG_VPN_NH_SELF		0x04
   struct ecommunity *rt_import_list;
   struct ecommunity *rt_export_list;
   struct rfapi_import_table *rfapi_import_table;
@@ -99,6 +109,9 @@ struct rfapi_nve_group_cfg
   char *routemap_redist_name[ZEBRA_ROUTE_MAX];
   struct route_map *routemap_redist[ZEBRA_ROUTE_MAX];
 
+  /* for VRF type groups */
+  uint32_t                label;
+  struct rfapi_descriptor *rfd;
   QOBJ_FIELDS
 };
 DECLARE_QOBJ_TYPE(rfapi_nve_group_cfg)
@@ -287,6 +300,12 @@ bgp_rfapi_cfg_match_group (
   struct rfapi_cfg	*hc,
   struct prefix		*vn,
   struct prefix		*un);
+
+struct rfapi_nve_group_cfg *
+bgp_rfapi_cfg_match_byname (
+  struct bgp *bgp,
+  const char *name,
+  rfapi_group_cfg_type_t type);  /* _MAX = any */
 
 extern void
 vnc_prefix_list_update (struct bgp *bgp);

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -335,6 +335,9 @@ is_valid_rfd (struct rfapi_descriptor *rfd)
   if (!rfd || rfd->bgp == NULL)
     return 0;
 
+  if (CHECK_FLAG(rfd->flags, RFAPI_HD_FLAG_IS_VRF)) /* assume VRF/internal are valid */
+    return 1;
+
   if (rfapi_find_handle (rfd->bgp, &rfd->vn_addr, &rfd->un_addr, &hh))
     return 0;
 
@@ -356,6 +359,9 @@ rfapi_check (void *handle)
 
   if (!rfd || rfd->bgp == NULL)
     return EINVAL;
+
+  if (CHECK_FLAG(rfd->flags, RFAPI_HD_FLAG_IS_VRF)) /* assume VRF/internal are valid */
+    return 0;
 
   if ((rc = rfapi_find_handle (rfd->bgp, &rfd->vn_addr, &rfd->un_addr, &hh)))
     return rc;
@@ -1347,7 +1353,6 @@ rfapi_rfp_set_cb_methods (void *rfp_start_val,
 /***********************************************************************
  *			NVE Sessions
  ***********************************************************************/
-
 /*
  * Caller must supply an already-allocated rfd with the "caller"
  * fields already set (vn_addr, un_addr, callback, cookie)
@@ -1472,6 +1477,57 @@ rfapi_open_inner (
   vnc_zebra_add_nve (bgp, rfd);
 
   return 0;
+}
+
+/* moved from rfapi_register */
+int
+rfapi_init_and_open(
+  struct bgp			*bgp,
+  struct rfapi_descriptor	*rfd,
+  struct rfapi_nve_group_cfg	*rfg)
+{
+  struct rfapi *h = bgp->rfapi;
+  char buf_vn[BUFSIZ];
+  char buf_un[BUFSIZ];
+  afi_t afi_vn, afi_un;
+  struct prefix pfx_un;
+  struct route_node             *rn;
+
+
+  rfapi_time (&rfd->open_time);
+
+  if (rfg->type == RFAPI_GROUP_CFG_VRF)
+    SET_FLAG(rfd->flags, RFAPI_HD_FLAG_IS_VRF);
+
+  rfapiRfapiIpAddr2Str (&rfd->vn_addr, buf_vn, BUFSIZ);
+  rfapiRfapiIpAddr2Str (&rfd->un_addr, buf_un, BUFSIZ);
+
+  vnc_zlog_debug_verbose ("%s: new RFD with VN=%s UN=%s cookie=%p",
+                          __func__, buf_vn, buf_un, rfd->cookie);
+
+  if (rfg->type != RFAPI_GROUP_CFG_VRF) /* unclear if needed for VRF */
+    {
+      listnode_add (&h->descriptors, rfd);
+      if (h->descriptors.count > h->stat.max_descriptors)
+        {
+          h->stat.max_descriptors = h->descriptors.count;
+        }
+
+      /*
+       * attach to UN radix tree
+       */
+      afi_vn = family2afi (rfd->vn_addr.addr_family);
+      afi_un = family2afi (rfd->un_addr.addr_family);
+      assert (afi_vn && afi_un);
+      assert (!rfapiRaddr2Qprefix (&rfd->un_addr, &pfx_un));
+
+      rn = route_node_get (&(h->un[afi_un]), &pfx_un);
+      assert (rn);
+      rfd->next = rn->info;
+      rn->info = rfd;
+      rfd->un_node = rn;
+    }  
+  return rfapi_open_inner (rfd, bgp, h, rfg);
 }
 
 struct rfapi_vn_option *
@@ -1991,13 +2047,9 @@ rfapi_open (
   struct prefix pfx_vn;
   struct prefix pfx_un;
 
-  struct route_node *rn;
   int rc;
   rfapi_handle hh = NULL;
   int reusing_provisional = 0;
-
-  afi_t afi_vn;
-  afi_t afi_un;
 
   {
     char buf[2][INET_ADDRSTRLEN];
@@ -2129,40 +2181,7 @@ rfapi_open (
 
   if (!reusing_provisional)
     {
-      rfapi_time (&rfd->open_time);
-
-      {
-        char buf_vn[BUFSIZ];
-        char buf_un[BUFSIZ];
-
-        rfapiRfapiIpAddr2Str (vn, buf_vn, BUFSIZ);
-        rfapiRfapiIpAddr2Str (un, buf_un, BUFSIZ);
-
-        vnc_zlog_debug_verbose ("%s: new HD with VN=%s UN=%s cookie=%p",
-                    __func__, buf_vn, buf_un, userdata);
-      }
-
-      listnode_add (&h->descriptors, rfd);
-      if (h->descriptors.count > h->stat.max_descriptors)
-        {
-          h->stat.max_descriptors = h->descriptors.count;
-        }
-
-      /*
-       * attach to UN radix tree
-       */
-      afi_vn = family2afi (rfd->vn_addr.addr_family);
-      afi_un = family2afi (rfd->un_addr.addr_family);
-      assert (afi_vn && afi_un);
-      assert (!rfapiRaddr2Qprefix (&rfd->un_addr, &pfx_un));
-
-      rn = route_node_get (&(h->un[afi_un]), &pfx_un);
-      assert (rn);
-      rfd->next = rn->info;
-      rn->info = rfd;
-      rfd->un_node = rn;
-
-      rc = rfapi_open_inner (rfd, bgp, h, rfg);
+      rc = rfapi_init_and_open(bgp, rfd, rfg);
       /*
        * This can fail only if the VN address is IPv6 and the group
        * specified auto-assignment of RDs, which only works for v4,

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -2777,7 +2777,7 @@ rfapi_register (
 	NULL,
 	action == RFAPI_REGISTER_KILL);
 
-      if (0 == rfapiApDelete (bgp, rfd, &p, pfx_mac, &adv_tunnel))
+      if (0 == rfapiApDelete (bgp, rfd, &p, pfx_mac, &prd, &adv_tunnel))
         {
           if (adv_tunnel)
             rfapiTunnelRouteAnnounce (bgp, rfd, &rfd->max_prefix_lifetime);

--- a/bgpd/rfapi/rfapi_ap.c
+++ b/bgpd/rfapi/rfapi_ap.c
@@ -103,12 +103,11 @@ sl_adb_lifetime_cmp (void *adb1, void *adb2)
   return 0;
 }
 
-
 void
 rfapiApInit (struct rfapi_advertised_prefixes *ap)
 {
-  ap->ipN_by_prefix = skiplist_new (0, vnc_prefix_cmp, NULL);
-  ap->ip0_by_ether = skiplist_new (0, vnc_prefix_cmp, NULL);
+  ap->ipN_by_prefix = skiplist_new (0, rfapi_rib_key_cmp, NULL);
+  ap->ip0_by_ether = skiplist_new (0, rfapi_rib_key_cmp, NULL);
   ap->by_lifetime = skiplist_new (0, sl_adb_lifetime_cmp, NULL);
 }
 
@@ -192,7 +191,7 @@ rfapiApReadvertiseAll (struct bgp *bgp, struct rfapi_descriptor *rfd)
        * TBD this is not quite right. When pfx_ip is 0/32 or 0/128,
        * we need to substitute the VN address as the prefix
        */
-      add_vnc_route (rfd, bgp, SAFI_MPLS_VPN, &adb->prefix_ip, &prd,    /* RD to use (0 for ENCAP) */
+      add_vnc_route (rfd, bgp, SAFI_MPLS_VPN, &adb->u.s.prefix_ip, &prd,    /* RD to use (0 for ENCAP) */
                      &rfd->vn_addr,     /* nexthop */
                      &local_pref, &adb->lifetime, NULL, NULL,   /* struct rfapi_un_option */
                      NULL,      /* struct rfapi_vn_option */
@@ -221,11 +220,11 @@ rfapiApWithdrawAll (struct bgp *bgp, struct rfapi_descriptor *rfd)
       struct prefix pfx_vn_buf;
       struct prefix *pfx_ip;
 
-      if (!(RFAPI_0_PREFIX (&adb->prefix_ip) &&
-            RFAPI_HOST_PREFIX (&adb->prefix_ip)))
+      if (!(RFAPI_0_PREFIX (&adb->u.s.prefix_ip) &&
+            RFAPI_HOST_PREFIX (&adb->u.s.prefix_ip)))
         {
 
-          pfx_ip = &adb->prefix_ip;
+          pfx_ip = &adb->u.s.prefix_ip;
 
         }
       else
@@ -247,7 +246,7 @@ rfapiApWithdrawAll (struct bgp *bgp, struct rfapi_descriptor *rfd)
             }
         }
 
-      del_vnc_route (rfd, rfd->peer, bgp, SAFI_MPLS_VPN, pfx_ip ? pfx_ip : &pfx_vn_buf, &adb->prd,      /* RD to use (0 for ENCAP) */
+      del_vnc_route (rfd, rfd->peer, bgp, SAFI_MPLS_VPN, pfx_ip ? pfx_ip : &pfx_vn_buf, &adb->u.s.prd,      /* RD to use (0 for ENCAP) */
                      ZEBRA_ROUTE_BGP, BGP_ROUTE_RFP, NULL, 0);
     }
 }
@@ -404,19 +403,19 @@ rfapiApAdjustLifetimeStats (
         {
 
           void *cursor;
-          struct prefix *prefix;
-          struct rfapi_adb *adb;
+          struct rfapi_rib_key rk;
+          struct rfapi_adb    *adb;
           int rc;
 
           vnc_zlog_debug_verbose ("%s: walking to find new min/max", __func__);
 
           cursor = NULL;
           for (rc = skiplist_next (rfd->advertised.ipN_by_prefix,
-                                   (void **) &prefix, (void **) &adb,
+                                   (void **) &rk, (void **) &adb,
                                    &cursor); !rc;
                rc =
                skiplist_next (rfd->advertised.ipN_by_prefix,
-                              (void **) &prefix, (void **) &adb, &cursor))
+                              (void **) &rk, (void **) &adb, &cursor))
             {
 
               uint32_t lt = adb->lifetime;
@@ -428,10 +427,10 @@ rfapiApAdjustLifetimeStats (
             }
           cursor = NULL;
           for (rc = skiplist_next (rfd->advertised.ip0_by_ether,
-                                   (void **) &prefix, (void **) &adb,
+                                   (void **) &rk, (void **) &adb,
                                    &cursor); !rc;
                rc =
-               skiplist_next (rfd->advertised.ip0_by_ether, (void **) &prefix,
+               skiplist_next (rfd->advertised.ip0_by_ether, (void **) &rk,
                               (void **) &adb, &cursor))
             {
 
@@ -483,14 +482,15 @@ rfapiApAdd (
   struct rfapi_adb *adb;
   uint32_t old_lifetime = 0;
   int use_ip0 = 0;
+  struct rfapi_rib_key rk;
 
+  rfapi_rib_key_init(pfx_ip, prd, pfx_eth, &rk);
   if (RFAPI_0_PREFIX (pfx_ip) && RFAPI_HOST_PREFIX (pfx_ip))
     {
       use_ip0 = 1;
       assert (pfx_eth);
-
       rc =
-        skiplist_search (rfd->advertised.ip0_by_ether, pfx_eth,
+        skiplist_search (rfd->advertised.ip0_by_ether, &rk,
                          (void **) &adb);
 
     }
@@ -499,7 +499,7 @@ rfapiApAdd (
 
       /* find prefix in advertised prefixes list */
       rc =
-        skiplist_search (rfd->advertised.ipN_by_prefix, pfx_ip,
+        skiplist_search (rfd->advertised.ipN_by_prefix, &rk,
                          (void **) &adb);
     }
 
@@ -510,19 +510,17 @@ rfapiApAdd (
       adb = XCALLOC (MTYPE_RFAPI_ADB, sizeof (struct rfapi_adb));
       assert (adb);
       adb->lifetime = lifetime;
-      adb->prefix_ip = *pfx_ip;
-      if (pfx_eth)
-        adb->prefix_eth = *pfx_eth;
+      adb->u.key = rk;
 
       if (use_ip0)
         {
           assert (pfx_eth);
-          skiplist_insert (rfd->advertised.ip0_by_ether, &adb->prefix_eth,
+          skiplist_insert (rfd->advertised.ip0_by_ether, &adb->u.key,
                            adb);
         }
       else
         {
-          skiplist_insert (rfd->advertised.ipN_by_prefix, &adb->prefix_ip,
+          skiplist_insert (rfd->advertised.ipN_by_prefix, &adb->u.key,
                            adb);
         }
 
@@ -537,19 +535,12 @@ rfapiApAdd (
           adb->lifetime = lifetime;
           assert (!skiplist_insert (rfd->advertised.by_lifetime, adb, adb));
         }
-
-      if (!use_ip0 && pfx_eth && prefix_cmp (&adb->prefix_eth, pfx_eth))
-        {
-          /* mac address changed */
-          adb->prefix_eth = *pfx_eth;
-        }
     }
   adb->cost = cost;
   if (l2o)
     adb->l2o = *l2o;
   else
     memset (&adb->l2o, 0, sizeof (struct rfapi_l2address_option));
-  adb->prd = *prd;
 
   if (rfapiApAdjustLifetimeStats
       (rfd, (rc ? NULL : &old_lifetime), &lifetime))
@@ -568,16 +559,19 @@ rfapiApDelete (
   struct rfapi_descriptor	*rfd,
   struct prefix			*pfx_ip,
   struct prefix			*pfx_eth,
+  struct prefix_rd		*prd,
   int				*advertise_tunnel)	/* out */
 {
   int rc;
   struct rfapi_adb *adb;
   uint32_t old_lifetime;
   int use_ip0 = 0;
+  struct rfapi_rib_key rk;
 
   if (advertise_tunnel)
     *advertise_tunnel = 0;
 
+  rfapi_rib_key_init(pfx_ip, prd, pfx_eth, &rk);
   /* find prefix in advertised prefixes list */
   if (RFAPI_0_PREFIX (pfx_ip) && RFAPI_HOST_PREFIX (pfx_ip))
     {
@@ -585,7 +579,7 @@ rfapiApDelete (
       assert (pfx_eth);
 
       rc =
-        skiplist_search (rfd->advertised.ip0_by_ether, pfx_eth,
+        skiplist_search (rfd->advertised.ip0_by_ether, &rk,
                          (void **) &adb);
 
     }
@@ -594,7 +588,7 @@ rfapiApDelete (
 
       /* find prefix in advertised prefixes list */
       rc =
-        skiplist_search (rfd->advertised.ipN_by_prefix, pfx_ip,
+        skiplist_search (rfd->advertised.ipN_by_prefix, &rk,
                          (void **) &adb);
     }
 
@@ -607,11 +601,11 @@ rfapiApDelete (
 
   if (use_ip0)
     {
-      rc = skiplist_delete (rfd->advertised.ip0_by_ether, pfx_eth, NULL);
+      rc = skiplist_delete (rfd->advertised.ip0_by_ether, &rk, NULL);
     }
   else
     {
-      rc = skiplist_delete (rfd->advertised.ipN_by_prefix, pfx_ip, NULL);
+      rc = skiplist_delete (rfd->advertised.ipN_by_prefix, &rk, NULL);
     }
   assert (!rc);
 

--- a/bgpd/rfapi/rfapi_ap.h
+++ b/bgpd/rfapi/rfapi_ap.h
@@ -93,6 +93,7 @@ rfapiApDelete (
   struct rfapi_descriptor	*rfd,
   struct prefix			*pfx_ip,
   struct prefix			*pfx_eth,
+  struct prefix_rd		*prd,
   int				*advertise_tunnel); /* out */
 
 

--- a/bgpd/rfapi/rfapi_backend.h
+++ b/bgpd/rfapi/rfapi_backend.h
@@ -36,15 +36,6 @@ extern void rfapi_delete (struct bgp *);
 struct rfapi *bgp_rfapi_new (struct bgp *bgp);
 void bgp_rfapi_destroy (struct bgp *bgp, struct rfapi *h);
 
-struct rfapi_import_table *rfapiImportTableRefAdd (struct bgp *bgp,
-                                                   struct ecommunity
-                                                   *rt_import_list);
-
-void
-rfapiImportTableRefDelByIt (struct bgp *bgp,
-                            struct rfapi_import_table *it_target);
-
-
 extern void
 rfapiProcessUpdate (struct peer *peer,
                     void *rfd,

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -4943,6 +4943,7 @@ rfapiDeleteRemotePrefixesIt (
  *	un			if set, tunnel must match this prefix
  *	vn			if set, nexthop prefix must match this prefix
  *	p			if set, prefix must match this prefix
+ *      it                      if set, only look in this import table
  *
  * output
  *	pARcount		number of active routes deleted
@@ -4958,6 +4959,7 @@ rfapiDeleteRemotePrefixes (
     struct prefix	*un,
     struct prefix	*vn,
     struct prefix	*p,
+    struct rfapi_import_table *arg_it,
     int			delete_active,
     int			delete_holddown,
     uint32_t		*pARcount,
@@ -4995,7 +4997,11 @@ rfapiDeleteRemotePrefixes (
    * for the afi/safi combination
    */
 
-  for (it = h->imports; it; it = it->next)
+  if (arg_it)
+    it = arg_it;
+  else
+    it = h->imports;
+  for (; it; )
     {
 
       vnc_zlog_debug_verbose
@@ -5016,6 +5022,11 @@ rfapiDeleteRemotePrefixes (
 	&deleted_holddown_nve_count,
 	uniq_active_nves,
 	uniq_holddown_nves);
+
+      if (arg_it)
+        it = NULL;
+      else
+        it = it->next;
     }
 
   /*

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -4644,7 +4644,8 @@ bgp_rfapi_destroy (struct bgp *bgp, struct rfapi *h)
 }
 
 struct rfapi_import_table *
-rfapiImportTableRefAdd (struct bgp *bgp, struct ecommunity *rt_import_list)
+rfapiImportTableRefAdd (struct bgp *bgp, struct ecommunity *rt_import_list,
+                        struct rfapi_nve_group_cfg *rfg)
 {
   struct rfapi *h;
   struct rfapi_import_table *it;
@@ -4670,6 +4671,7 @@ rfapiImportTableRefAdd (struct bgp *bgp, struct ecommunity *rt_import_list)
       h->imports = it;
 
       it->rt_import_list = ecommunity_dup (rt_import_list);
+      it->rfg = rfg;
       it->monitor_exterior_orphans =
         skiplist_new (0, NULL, (void (*)(void *)) prefix_free);
 

--- a/bgpd/rfapi/rfapi_import.h
+++ b/bgpd/rfapi/rfapi_import.h
@@ -38,6 +38,7 @@
 struct rfapi_import_table
 {
   struct rfapi_import_table *next;
+  struct rfapi_nve_group_cfg *rfg;
   struct ecommunity *rt_import_list;    /* copied from nve grp */
   int refcount;                 /* nve grps and nves */
   uint32_t l2_logical_net_id;   /* L2 only: EVPN Eth Seg Id */
@@ -90,6 +91,11 @@ rfapiShowImportTable (
   struct route_table	*rt,
   int			isvpn);
 
+extern struct rfapi_import_table *
+rfapiImportTableRefAdd (
+  struct bgp *bgp,
+  struct ecommunity *rt_import_list,
+  struct rfapi_nve_group_cfg *rfg);
 
 extern void
 rfapiImportTableRefDelByIt (

--- a/bgpd/rfapi/rfapi_import.h
+++ b/bgpd/rfapi/rfapi_import.h
@@ -223,6 +223,7 @@ extern int rfapiEcommunityGetEthernetTag (
  *	un			if set, tunnel must match this prefix
  *	vn			if set, nexthop prefix must match this prefix
  *	p			if set, prefix must match this prefix
+ *      it                      if set, only look in this import table
  *
  * output
  *	pARcount		number of active routes deleted
@@ -238,6 +239,7 @@ rfapiDeleteRemotePrefixes (
   struct prefix	*un,
   struct prefix	*vn,
   struct prefix	*p,
+  struct rfapi_import_table *it,
   int		delete_active,
   int		delete_holddown,
   uint32_t	*pARcount,     /* active routes */

--- a/bgpd/rfapi/rfapi_private.h
+++ b/bgpd/rfapi/rfapi_private.h
@@ -135,6 +135,7 @@ struct rfapi_descriptor
 #define RFAPI_HD_FLAG_CALLBACK_SCHEDULED_AFI_ETHER	0x00000004
 #define RFAPI_HD_FLAG_PROVISIONAL			0x00000008
 #define RFAPI_HD_FLAG_CLOSING_ADMINISTRATIVELY		0x00000010
+#define RFAPI_HD_FLAG_IS_VRF             		0x00000012
 };
 
 #define RFAPI_QUEUED_FLAG(afi) (					\
@@ -432,5 +433,18 @@ DECLARE_MTYPE(RFAPI_RECENT_DELETE)
 DECLARE_MTYPE(RFAPI_L2ADDR_OPT)
 DECLARE_MTYPE(RFAPI_AP)
 DECLARE_MTYPE(RFAPI_MONITOR_ETH)
+
+
+/*
+ * Caller must supply an already-allocated rfd with the "caller"
+ * fields already set (vn_addr, un_addr, callback, cookie)
+ * The advertised_prefixes[] array elements should be NULL to
+ * have this function set them to newly-allocated radix trees.
+ */
+extern int
+rfapi_init_and_open(
+  struct bgp			*bgp,
+  struct rfapi_descriptor	*rfd,
+  struct rfapi_nve_group_cfg	*rfg);
 
 #endif /* _QUAGGA_BGP_RFAPI_PRIVATE_H */

--- a/bgpd/rfapi/rfapi_private.h
+++ b/bgpd/rfapi/rfapi_private.h
@@ -35,21 +35,6 @@
 #include "rfapi.h"
 
 /*
- * RFAPI Advertisement Data Block
- *
- * Holds NVE prefix advertisement information
- */
-struct rfapi_adb
-{
-  struct prefix			prefix_ip;
-  struct prefix			prefix_eth;     /* now redundant with l2o */
-  struct prefix_rd		prd;
-  uint32_t			lifetime;
-  uint8_t			cost;
-  struct rfapi_l2address_option	l2o;
-};
-
-/*
  * Lists of rfapi_adb. Each rfapi_adb is referenced twice:
  *
  * 1. each is referenced in by_lifetime
@@ -61,7 +46,6 @@ struct rfapi_advertised_prefixes
   struct skiplist *ip0_by_ether;  /* ip prefix 0/32, 0/128 */
   struct skiplist *by_lifetime;   /* all */
 };
-
 
 struct rfapi_descriptor
 {
@@ -377,9 +361,6 @@ rfp_cost_to_localpref (uint8_t cost);
 
 extern int
 rfapi_set_autord_from_vn (struct prefix_rd *rd, struct rfapi_ip_addr *vn);
-
-extern void
-rfapiAdbFree (struct rfapi_adb *adb);
 
 extern struct rfapi_nexthop *
 rfapi_nexthop_new (struct rfapi_nexthop *copyme);

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -405,10 +405,26 @@ rfapiRibStartTimer (
   assert (ri->timer);
 }
 
+extern void
+rfapi_rib_key_init (struct prefix        *prefix, /* may be NULL */
+                    struct prefix_rd     *rd,     /* may be NULL */
+                    struct prefix        *aux,    /* may be NULL */
+                    struct rfapi_rib_key *rk)
+  
+{
+  memset((void *)rk, 0, sizeof(struct rfapi_rib_key));
+  if (prefix)
+    rk->vn = *prefix;
+  if (rd)
+    rk->rd = *rd;
+  if (aux)
+    rk->aux_prefix = *aux;
+}
+
 /*
  * Compares two <struct rfapi_rib_key>s
  */
-static int
+int
 rfapi_rib_key_cmp (void *k1, void *k2)
 {
   struct rfapi_rib_key *a = (struct rfapi_rib_key *) k1;

--- a/bgpd/rfapi/rfapi_rib.c
+++ b/bgpd/rfapi/rfapi_rib.c
@@ -514,9 +514,13 @@ rfapi_info_cmp (struct rfapi_info *a, struct rfapi_info *b)
 void
 rfapiRibClear (struct rfapi_descriptor *rfd)
 {
-  struct bgp *bgp = bgp_get_default ();
+  struct bgp *bgp;
   afi_t afi;
 
+  if (rfd->bgp)
+    bgp = rfd->bgp;
+  else
+    bgp = bgp_get_default ();
 #if DEBUG_L2_EXTRA
   vnc_zlog_debug_verbose ("%s: rfd=%p", __func__, rfd);
 #endif

--- a/bgpd/rfapi/rfapi_rib.h
+++ b/bgpd/rfapi/rfapi_rib.h
@@ -45,6 +45,27 @@ struct rfapi_rib_key
    */
   struct prefix aux_prefix;
 };
+#include "rfapi.h"
+
+/*
+ * RFAPI Advertisement Data Block
+ *
+ * Holds NVE prefix advertisement information
+ */
+struct rfapi_adb
+{
+  union {
+    struct {
+      struct prefix		prefix_ip;
+      struct prefix_rd		prd;
+      struct prefix		prefix_eth;
+    } s;                                        /* mainly for legacy use */
+    struct rfapi_rib_key        key;
+  } u;
+  uint32_t			lifetime;
+  uint8_t			cost;
+  struct rfapi_l2address_option	l2o;
+};
 
 struct rfapi_info
 {
@@ -150,5 +171,17 @@ rfapiRibCheckCounts (
 #else
 #define RFAPI_RIB_CHECK_COUNTS(checkstats, offset)
 #endif
+
+extern void
+rfapi_rib_key_init (struct prefix        *prefix, /* may be NULL */
+                    struct prefix_rd     *rd,     /* may be NULL */
+                    struct prefix        *aux,    /* may be NULL */
+                    struct rfapi_rib_key *rk);
+
+extern int
+rfapi_rib_key_cmp (void *k1, void *k2);
+
+extern void
+rfapiAdbFree (struct rfapi_adb *adb);
 
 #endif /* QUAGGA_HGP_RFAPI_RIB_H */

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -3004,9 +3004,12 @@ struct rfapi_local_reg_delete_arg
   /*
    * match parameters
    */
+  struct bgp           *bgp;
   struct rfapi_ip_addr	un_address;	/* AF==0: wildcard */
   struct rfapi_ip_addr	vn_address;	/* AF==0: wildcard */
   struct prefix		prefix;		/* AF==0: wildcard */
+  struct prefix_rd	rd;		/* plen!=64: wildcard */
+  struct rfapi_nve_group_cfg *rfg;      /* NULL: wildcard */
 
   struct rfapi_l2address_option_match l2o;
 
@@ -3106,22 +3109,26 @@ nve_addr_cmp (void *k1, void *k2)
 
 static int
 parse_deleter_args (
-  struct vty				*vty,
-  struct cmd_token			*carg_prefix,
-  struct cmd_token			*carg_vn,
-  struct cmd_token			*carg_un,
-  struct cmd_token			*carg_l2addr,
-  struct cmd_token			*carg_vni,
-  struct rfapi_local_reg_delete_arg	*rcdarg)
+  struct vty			    *vty,
+  struct bgp                        *bgp,
+  const char                        *arg_prefix,
+  const char                        *arg_vn,
+  const char                        *arg_un,
+  const char                        *arg_l2addr,
+  const char                        *arg_vni,
+  const char                        *arg_rd,
+  struct rfapi_nve_group_cfg        *arg_rfg,
+  struct rfapi_local_reg_delete_arg *rcdarg)
 {
-  const char *arg_prefix = carg_prefix ? carg_prefix->arg : NULL;
-  const char *arg_vn = carg_vn ? carg_vn->arg : NULL;
-  const char *arg_un = carg_un ? carg_un->arg : NULL;
-  const char *arg_l2addr = carg_l2addr ? carg_l2addr->arg : NULL;
-  const char *arg_vni = carg_vni ? carg_vni->arg : NULL;
   int rc = CMD_WARNING;
 
-    memset (rcdarg, 0, sizeof (struct rfapi_local_reg_delete_arg));
+  memset (rcdarg, 0, sizeof (struct rfapi_local_reg_delete_arg));
+
+  rcdarg->vty = vty;
+  if (bgp == NULL)
+    bgp = bgp_get_default();
+  rcdarg->bgp = bgp;
+  rcdarg->rfg = arg_rfg;        /* may be NULL */
 
   if (arg_vn && strcmp (arg_vn, "*"))
     {
@@ -3167,7 +3174,41 @@ parse_deleter_args (
           rcdarg->l2o.flags |= RFAPI_L2O_LNI;
         }
     }
-  return 0;
+  if (arg_rd)
+    {
+      if (!str2prefix_rd (arg_rd, &rcdarg->rd))
+        {
+          vty_out (vty, "Malformed RD \"%s\"%s",
+                   arg_rd, VTY_NEWLINE);
+          return rc;
+        }
+    }
+
+  return CMD_SUCCESS;
+}
+
+static int
+parse_deleter_tokens (
+  struct vty				*vty,
+  struct bgp                            *bgp,
+  struct cmd_token			*carg_prefix,
+  struct cmd_token			*carg_vn,
+  struct cmd_token			*carg_un,
+  struct cmd_token			*carg_l2addr,
+  struct cmd_token			*carg_vni,
+  struct cmd_token			*carg_rd,
+  struct rfapi_nve_group_cfg            *arg_rfg,
+  struct rfapi_local_reg_delete_arg	*rcdarg)
+{
+  const char *arg_prefix = carg_prefix ? carg_prefix->arg : NULL;
+  const char *arg_vn     = carg_vn ? carg_vn->arg : NULL;
+  const char *arg_un     = carg_un ? carg_un->arg : NULL;
+  const char *arg_l2addr = carg_l2addr ? carg_l2addr->arg : NULL;
+  const char *arg_vni    = carg_vni ? carg_vni->arg : NULL;
+  const char *arg_rd     = carg_rd ? carg_rd->arg : NULL;
+  return parse_deleter_args (vty, bgp,arg_prefix, arg_vn, arg_un,
+                             arg_l2addr, arg_vni, arg_rd,
+                             arg_rfg, rcdarg);
 }
 
 static void
@@ -3271,51 +3312,37 @@ clear_vnc_responses (struct rfapi_local_reg_delete_arg *cda)
  * TBD need to count deleted prefixes and nves?
  *
  * ENXIO	BGP or VNC not configured
- */
+ */ 
 static int
-rfapiDeleteLocalPrefixes (struct rfapi_local_reg_delete_arg *cda)
+rfapiDeleteLocalPrefixesByRFD (struct rfapi_local_reg_delete_arg *cda,
+                               struct rfapi_descriptor *rfd)
 {
-  struct rfapi_ip_addr *pUn;    /* NULL = wildcard */
-  struct rfapi_ip_addr *pVn;    /* NULL = wildcard */
-  struct prefix *pPrefix;       /* NULL = wildcard */
+  struct rfapi_ip_addr *pUn;     /* NULL = wildcard */
+  struct rfapi_ip_addr *pVn;     /* NULL = wildcard */
+  struct prefix        *pPrefix; /* NULL = wildcard */
+  struct prefix_rd     *pPrd;    /* NULL = wildcard */
 
-  struct rfapi *h;
-  struct listnode *node;
-  struct rfapi_descriptor *rfd;
   struct rfapi_ip_prefix rprefix;
-  struct bgp *bgp_default = bgp_get_default ();
   struct rfapi_next_hop_entry *head = NULL;
   struct rfapi_next_hop_entry *tail = NULL;
-  struct rfapi_cfg *rfapi_cfg;
 
 #if DEBUG_L2_EXTRA
-    vnc_zlog_debug_verbose ("%s: entry", __func__);
+  vnc_zlog_debug_verbose ("%s: entry", __func__);
 #endif
 
-  if (!bgp_default)
-      return ENXIO;
-
-    pUn = (cda->un_address.addr_family ? &cda->un_address : NULL);
-    pVn = (cda->vn_address.addr_family ? &cda->vn_address : NULL);
-    pPrefix = (cda->prefix.family ? &cda->prefix : NULL);
-
-    h = bgp_default->rfapi;
-    rfapi_cfg = bgp_default->rfapi_cfg;
-
-  if (!h || !rfapi_cfg)
-      return ENXIO;
+  pUn = (cda->un_address.addr_family ? &cda->un_address : NULL);
+  pVn = (cda->vn_address.addr_family ? &cda->vn_address : NULL);
+  pPrefix = (cda->prefix.family ? &cda->prefix : NULL);
+  pPrd = (cda->rd.prefixlen == 64 ? &cda->rd : NULL);
 
   if (pPrefix)
     {
       rfapiQprefix2Rprefix (pPrefix, &rprefix);
     }
 
-#if DEBUG_L2_EXTRA
-  vnc_zlog_debug_verbose ("%s: starting descriptor loop", __func__);
-#endif
-
-  for (ALL_LIST_ELEMENTS_RO (&h->descriptors, node, rfd))
+  do                            /* to preserve old code structure */
     {
+      struct rfapi *h=cda->bgp->rfapi;;
       struct rfapi_adb *adb;
       int rc;
       int deleted_from_this_nve;
@@ -3384,6 +3411,17 @@ rfapiDeleteLocalPrefixes (struct rfapi_local_reg_delete_arg *cda)
                     continue;
                   }
               }
+            if (pPrd) 
+              {
+                if (memcmp(pPrd->val, adb->u.s.prd.val, 8) != 0)
+                  {
+#if DEBUG_L2_EXTRA
+                    vnc_zlog_debug_verbose ("%s: adb=%p, RD doesn't match, skipping",
+                                __func__, adb);
+#endif
+                    continue;
+                  }
+              }
             if (CHECK_FLAG (cda->l2o.flags, RFAPI_L2O_MACADDR))
               {
                 if (memcmp
@@ -3422,47 +3460,43 @@ rfapiDeleteLocalPrefixes (struct rfapi_local_reg_delete_arg *cda)
 
         for (ALL_LIST_ELEMENTS_RO (adb_delete_list, node, adb))
           {
-
-            struct rfapi_vn_option vn1;
-            struct rfapi_vn_option vn2;
-            struct rfapi_vn_option *pVn;
             int this_advertisement_prefix_count;
+            struct rfapi_vn_option optary[3];
+            struct rfapi_vn_option *opt = NULL;
+            int                     cur_opt = 0;
 
             this_advertisement_prefix_count = 1;
 
             rfapiQprefix2Rprefix (&adb->u.s.prefix_ip, &rp);
 
+            memset (optary, 0, sizeof (optary));
+
             /* if mac addr present in advert,  make l2o vn option */
             if (adb->u.s.prefix_eth.family == AF_ETHERNET)
               {
-                memset (&vn1, 0, sizeof (vn1));
-                memset (&vn2, 0, sizeof (vn2));
-
-                vn1.type = RFAPI_VN_OPTION_TYPE_L2ADDR;
-                vn1.v.l2addr.macaddr = adb->u.s.prefix_eth.u.prefix_eth;
-
-                /*
-                 * use saved RD value instead of trying to invert
-                 * complex L2-style RD computation in rfapi_register()
-                 */
-                vn2.type = RFAPI_VN_OPTION_TYPE_INTERNAL_RD;
-                vn2.v.internal_rd = adb->u.s.prd;
-
-                vn1.next = &vn2;
-
-                pVn = &vn1;
+                if (opt != NULL)
+                  opt->next = &optary[cur_opt];
+                opt = &optary[cur_opt++];
+                opt->type = RFAPI_VN_OPTION_TYPE_L2ADDR;
+                opt->v.l2addr.macaddr = adb->u.s.prefix_eth.u.prefix_eth;
                 ++this_advertisement_prefix_count;
               }
-            else
-              {
-                pVn = NULL;
-              }
+            /*
+             * use saved RD value instead of trying to invert
+             * complex RD computation in rfapi_register()
+             */
+            if (opt != NULL)
+              opt->next = &optary[cur_opt];
+            opt = &optary[cur_opt++];
+            opt->type = RFAPI_VN_OPTION_TYPE_INTERNAL_RD;
+            opt->v.internal_rd = adb->u.s.prd;
 
 #if DEBUG_L2_EXTRA
             vnc_zlog_debug_verbose ("%s: ipN killing reg from adb %p ", __func__, adb);
 #endif
 
-            rc = rfapi_register (rfd, &rp, 0, NULL, pVn, RFAPI_REGISTER_KILL);
+            rc = rfapi_register (rfd, &rp, 0, NULL, 
+                                 (cur_opt ? optary : NULL), RFAPI_REGISTER_KILL);
             if (!rc)
               {
                 cda->pfx_count += this_advertisement_prefix_count;
@@ -3588,9 +3622,42 @@ rfapiDeleteLocalPrefixes (struct rfapi_local_reg_delete_arg *cda)
               skiplist_insert (cda->nves, hap, hap);
             }
         }
-    }
+    } while (0);                /*  to preserve old code structure */
 
   return 0;
+}
+
+static int
+rfapiDeleteLocalPrefixes (struct rfapi_local_reg_delete_arg *cda)
+{
+  int rc = 0;
+
+  if (cda->rfg)
+    {
+      if (cda->rfg->rfd)        /* if not open, nothing to delete */
+        rc = rfapiDeleteLocalPrefixesByRFD (cda, cda->rfg->rfd);
+    }
+  else
+    {
+      struct bgp *bgp = cda->bgp;
+      struct rfapi *h;
+      struct rfapi_cfg *rfapi_cfg;
+
+      struct listnode *node;
+      struct rfapi_descriptor *rfd;
+      if (!bgp)
+        return ENXIO;
+      h = bgp->rfapi;
+      rfapi_cfg = bgp->rfapi_cfg;
+      if (!h || !rfapi_cfg)
+        return ENXIO;
+      vnc_zlog_debug_verbose ("%s: starting descriptor loop", __func__);
+      for (ALL_LIST_ELEMENTS_RO (&h->descriptors, node, rfd))
+        {
+          rc = rfapiDeleteLocalPrefixesByRFD (cda, rfd);
+        }
+    }
+  return rc;
 }
 
 /*
@@ -3607,6 +3674,8 @@ clear_vnc_prefix (struct rfapi_local_reg_delete_arg *cda)
   struct prefix *pUN = NULL;
   struct prefix *pVN = NULL;
   struct prefix *pPrefix = NULL;
+
+  struct rfapi_import_table *it = NULL;
 
   /*
    * Delete matching remote prefixes in holddown
@@ -3625,7 +3694,11 @@ clear_vnc_prefix (struct rfapi_local_reg_delete_arg *cda)
     {
       pPrefix = &cda->prefix;
     }
-  rfapiDeleteRemotePrefixes (pUN, pVN, pPrefix,
+  if (cda->rfg)
+    {
+      it = cda->rfg->rfapi_import_table;
+    }
+  rfapiDeleteRemotePrefixes (pUN, pVN, pPrefix, it,
                              0, 1, &cda->remote_active_pfx_count,
                              &cda->remote_active_nve_count,
                              &cda->remote_holddown_pfx_count,
@@ -3710,7 +3783,7 @@ DEFUN (clear_vnc_nve_all,
   struct rfapi_local_reg_delete_arg cda;
   int rc;
 
-  if ((rc = parse_deleter_args (vty, NULL, NULL, NULL, NULL, NULL, &cda)))
+  if ((rc = parse_deleter_args (vty, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, &cda)))
     return rc;
 
   cda.vty = vty;
@@ -3743,7 +3816,7 @@ DEFUN (clear_vnc_nve_vn_un,
   int rc;
 
   if ((rc =
-       parse_deleter_args (vty, NULL, argv[4], argv[6], NULL, NULL, &cda)))
+       parse_deleter_tokens (vty, NULL, NULL, argv[4], argv[6], NULL, NULL, NULL, NULL, &cda)))
     return rc;
 
   cda.vty = vty;
@@ -3776,7 +3849,7 @@ DEFUN (clear_vnc_nve_un_vn,
   int rc;
 
   if ((rc =
-       parse_deleter_args (vty, NULL, argv[6], argv[4], NULL, NULL, &cda)))
+       parse_deleter_tokens (vty, NULL, NULL, argv[6], argv[4], NULL, NULL, NULL, NULL, &cda)))
     return rc;
 
   cda.vty = vty;
@@ -3804,7 +3877,7 @@ DEFUN (clear_vnc_nve_vn,
   struct rfapi_local_reg_delete_arg cda;
   int rc;
 
-  if ((rc = parse_deleter_args (vty, NULL, argv[4], NULL, NULL, NULL, &cda)))
+  if ((rc = parse_deleter_tokens (vty, NULL, NULL, argv[4], NULL, NULL, NULL, NULL, NULL, &cda)))
     return rc;
 
   cda.vty = vty;
@@ -3831,7 +3904,7 @@ DEFUN (clear_vnc_nve_un,
   struct rfapi_local_reg_delete_arg cda;
   int rc;
 
-  if ((rc = parse_deleter_args (vty, NULL, NULL, argv[6], NULL, NULL, &cda)))
+  if ((rc = parse_deleter_tokens (vty, NULL, NULL, NULL, argv[6], NULL, NULL, NULL, NULL, &cda)))
     return rc;
 
   cda.vty = vty;
@@ -3874,7 +3947,7 @@ DEFUN (clear_vnc_prefix_vn_un,
   int rc;
 
   if ((rc =
-       parse_deleter_args (vty, argv[3], argv[5], argv[7], NULL, NULL, &cda)))
+       parse_deleter_tokens (vty, NULL, argv[3], argv[5], argv[7], NULL, NULL, NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -3904,7 +3977,7 @@ DEFUN (clear_vnc_prefix_un_vn,
   int rc;
 
   if ((rc =
-       parse_deleter_args (vty, argv[3], argv[7], argv[5], NULL, NULL, &cda)))
+       parse_deleter_tokens (vty, NULL, argv[3], argv[7], argv[5], NULL, NULL, NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -3930,7 +4003,7 @@ DEFUN (clear_vnc_prefix_un,
   int rc;
 
   if ((rc =
-       parse_deleter_args (vty, argv[3], NULL, argv[5], NULL, NULL, &cda)))
+       parse_deleter_tokens (vty, NULL, argv[3], NULL, argv[5], NULL, NULL, NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -3956,7 +4029,7 @@ DEFUN (clear_vnc_prefix_vn,
   int rc;
 
   if ((rc =
-       parse_deleter_args (vty, argv[3], argv[5], NULL, NULL, NULL, &cda)))
+       parse_deleter_tokens (vty, NULL, argv[3], argv[5], NULL, NULL, NULL, NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -3978,7 +4051,7 @@ DEFUN (clear_vnc_prefix_all,
   struct rfapi_local_reg_delete_arg cda;
   int rc;
 
-  if ((rc = parse_deleter_args (vty, argv[3], NULL, NULL, NULL, NULL, &cda)))
+  if ((rc = parse_deleter_tokens (vty, NULL, argv[3], NULL, NULL, NULL, NULL, NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -4020,8 +4093,8 @@ DEFUN (clear_vnc_mac_vn_un,
 
   /* pfx vn un L2 VNI */
   if ((rc =
-       parse_deleter_args (vty, NULL, argv[7], argv[9], argv[3], argv[5],
-                           &cda)))
+       parse_deleter_tokens (vty, NULL, NULL, argv[7], argv[9], argv[3], argv[5],
+                           NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -4054,8 +4127,8 @@ DEFUN (clear_vnc_mac_un_vn,
 
   /* pfx vn un L2 VNI */
   if ((rc =
-       parse_deleter_args (vty, NULL, argv[9], argv[7], argv[3], argv[5],
-                           &cda)))
+       parse_deleter_tokens (vty, NULL, NULL, argv[9], argv[7], argv[3], argv[5],
+                           NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -4084,7 +4157,7 @@ DEFUN (clear_vnc_mac_un,
 
   /* pfx vn un L2 VNI */
   if ((rc =
-       parse_deleter_args (vty, NULL, NULL, argv[7], argv[3], argv[5], &cda)))
+       parse_deleter_tokens (vty, NULL, NULL, NULL, argv[7], argv[3], argv[5], NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -4113,7 +4186,7 @@ DEFUN (clear_vnc_mac_vn,
 
   /* pfx vn un L2 VNI */
   if ((rc =
-       parse_deleter_args (vty, NULL, argv[7], NULL, argv[3], argv[5], &cda)))
+       parse_deleter_tokens (vty, NULL, NULL, argv[7], NULL, argv[3], argv[5], NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -4139,7 +4212,7 @@ DEFUN (clear_vnc_mac_all,
 
   /* pfx vn un L2 VNI */
   if ((rc =
-       parse_deleter_args (vty, NULL, NULL, NULL, argv[3], argv[5], &cda)))
+       parse_deleter_tokens (vty, NULL, NULL, NULL, NULL, argv[3], argv[5], NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -4180,8 +4253,8 @@ DEFUN (clear_vnc_mac_vn_un_prefix,
 
   /* pfx vn un L2 VNI */
   if ((rc =
-       parse_deleter_args (vty, argv[11], argv[7], argv[9], argv[3], argv[5],
-                           &cda)))
+       parse_deleter_tokens (vty, NULL, argv[11], argv[7], argv[9], argv[3], argv[5],
+                           NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -4222,8 +4295,8 @@ DEFUN (clear_vnc_mac_un_vn_prefix,
 
   /* pfx vn un L2 VNI */
   if ((rc =
-       parse_deleter_args (vty, argv[11], argv[9], argv[7], argv[3], argv[5],
-                           &cda)))
+       parse_deleter_tokens (vty, NULL, argv[11], argv[9], argv[7], argv[3], argv[5],
+                           NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -4256,8 +4329,8 @@ DEFUN (clear_vnc_mac_un_prefix,
 
   /* pfx vn un L2 VNI */
   if ((rc =
-       parse_deleter_args (vty, argv[9], NULL, argv[7], argv[3], argv[5],
-                           &cda)))
+       parse_deleter_tokens (vty, NULL, argv[9], NULL, argv[7], argv[3], argv[5],
+                           NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -4290,8 +4363,8 @@ DEFUN (clear_vnc_mac_vn_prefix,
 
   /* pfx vn un L2 VNI */
   if ((rc =
-       parse_deleter_args (vty, argv[9], argv[7], NULL, argv[3], argv[5],
-                           &cda)))
+       parse_deleter_tokens (vty, NULL, argv[9], argv[7], NULL, argv[3], argv[5],
+                           NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -4320,7 +4393,7 @@ DEFUN (clear_vnc_mac_all_prefix,
 
   /* pfx vn un L2 VNI */
   if ((rc =
-       parse_deleter_args (vty, argv[7], NULL, NULL, argv[3], argv[5], &cda)))
+       parse_deleter_tokens (vty, NULL, argv[7], NULL, NULL, argv[3], argv[5], NULL, NULL, &cda)))
     return rc;
   cda.vty = vty;
   clear_vnc_prefix (&cda);
@@ -4928,6 +5001,361 @@ notcfg:
   return CMD_WARNING;
 }
 
+/************************************************************************
+ *		Add prefix with vrf
+ *
+ * add [vrf <vrf-name>] prefix <prefix>
+ *     [rd <value>] [label <value>] [local-preference <0-4294967295>]
+ ************************************************************************/
+static int
+vnc_add_vrf_prefix (struct vty *vty,
+                    const char *arg_vrf,
+                    const char *arg_prefix,
+                    const char *arg_rd,     /* optional */
+                    const char *arg_label,  /* optional */
+                    const char *arg_pref)   /* optional */
+{
+  struct bgp                 *bgp;
+  struct rfapi_nve_group_cfg *rfg;
+  struct prefix               pfx;
+  struct rfapi_ip_prefix      rpfx;
+  uint32_t                    pref = 0;
+  struct rfapi_vn_option      optary[3];
+  struct rfapi_vn_option      *opt = NULL;
+  int                         cur_opt = 0;
+
+  bgp = bgp_get_default (); /* assume main instance for now */
+  if (!bgp)
+    {
+      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  if (!bgp->rfapi || !bgp->rfapi_cfg)
+    {
+      vty_out (vty, "VRF support not configured%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  rfg = bgp_rfapi_cfg_match_byname (bgp,  arg_vrf, RFAPI_GROUP_CFG_VRF);
+  /* arg checks */
+  if (!rfg)
+    {
+      vty_out (vty, "VRF \"%s\" appears not to be configured.%s",
+               arg_vrf, VTY_NEWLINE);
+          return CMD_WARNING;
+    }
+  if (!rfg->rt_export_list || !rfg->rfapi_import_table)
+    {
+      vty_out (vty, "VRF \"%s\" is missing RT import/export RT configuration.%s",
+               arg_vrf, VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  if (!rfg->rd.family && !arg_rd)
+    {
+      vty_out (vty, "VRF \"%s\" isn't configured with an RD, so RD must be provided.%s",
+               arg_vrf, VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  if (rfg->label > MPLS_LABEL_MAX && !arg_label)
+    {
+      vty_out (vty, "VRF \"%s\" isn't configured with a default labels, so a label must be provided.%s",
+               arg_vrf, VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  if (!str2prefix (arg_prefix, &pfx))
+    {
+      vty_out (vty, "Malformed prefix \"%s\"%s",
+               arg_prefix, VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  rfapiQprefix2Rprefix (&pfx, &rpfx);
+  memset (optary, 0, sizeof (optary));
+  if (arg_rd)
+    {
+      if (opt != NULL)
+        opt->next = &optary[cur_opt];
+      opt = &optary[cur_opt++];
+      opt->type = RFAPI_VN_OPTION_TYPE_INTERNAL_RD;
+      if (!str2prefix_rd (arg_rd, &opt->v.internal_rd))
+        {
+          vty_out (vty, "Malformed RD \"%s\"%s",
+                   arg_rd, VTY_NEWLINE);
+          return CMD_WARNING;
+        }
+    }
+  if (rfg->label <= MPLS_LABEL_MAX || arg_label)
+    {
+      struct rfapi_l2address_option	*l2o;
+      if (opt != NULL)
+        opt->next = &optary[cur_opt];
+      opt = &optary[cur_opt++];
+      opt->type  = RFAPI_VN_OPTION_TYPE_L2ADDR;
+      l2o =  &opt->v.l2addr;
+      if (arg_label)
+        {
+          int32_t label;
+          VTY_GET_INTEGER_RANGE ("Label value", label, arg_label, 0, MPLS_LABEL_MAX);
+          l2o->label = label;
+        }
+      else
+        l2o->label = rfg->label;
+    }
+  if (arg_pref)
+    {
+      char *endptr = NULL;
+      pref = strtoul (arg_pref, &endptr, 10);
+      if (*endptr != '\0')
+        {
+          vty_out (vty, "%% Invalid local-preference value \"%s\"%s", arg_pref, VTY_NEWLINE);
+          return CMD_WARNING;
+         }
+    }
+  rpfx.cost = 255 - (pref & 255) ;
+  if (rfg->rfd == NULL)         /* need new rfapi_handle */
+    {
+      /* based on rfapi_open */
+      struct rfapi_descriptor *rfd;
+      rfd = XCALLOC (MTYPE_RFAPI_DESC, sizeof (struct rfapi_descriptor));
+      rfd->bgp = bgp;
+      rfg->rfd = rfd;
+      /* leave most fields empty as will get from (dynamic) config when needed */
+      rfd->default_tunneltype_option.type = BGP_ENCAP_TYPE_MPLS;
+      rfd->cookie = rfg;
+      if (rfg->vn_prefix.family &&
+          !CHECK_FLAG(rfg->flags, RFAPI_RFG_VPN_NH_SELF))
+        {
+          rfapiQprefix2Raddr(&rfg->vn_prefix, &rfd->vn_addr);
+        }
+      else
+        {
+          memset(&rfd->vn_addr, 0, sizeof(struct rfapi_ip_addr));
+          rfd->vn_addr.addr_family = AF_INET;
+          rfd->vn_addr.addr.v4 = bgp->router_id;
+        }
+      rfd->un_addr = rfd->vn_addr; /* sigh, need something in UN for lookups */
+      vnc_zlog_debug_verbose ("%s: Opening RFD for VRF %s",
+                              __func__, rfg->name);
+      rfapi_init_and_open(bgp, rfd, rfg);
+    }
+
+  if (!rfapi_register (rfg->rfd, &rpfx, RFAPI_INFINITE_LIFETIME, NULL,
+                       (cur_opt ? optary : NULL), RFAPI_REGISTER_ADD))
+    {
+      struct rfapi_next_hop_entry *head = NULL;
+      struct rfapi_next_hop_entry *tail = NULL;
+      struct rfapi_vn_option *vn_opt_new;
+
+      vnc_zlog_debug_verbose ("%s: rfapi_register succeeded", __func__);
+
+      if (bgp->rfapi->rfp_methods.local_cb)
+        {
+          struct rfapi_descriptor *r = (struct rfapi_descriptor *) rfg->rfd;
+          vn_opt_new = rfapi_vn_options_dup (opt);
+
+          rfapiAddDeleteLocalRfpPrefix (&r->un_addr, &r->vn_addr, &rpfx,
+                                        1, RFAPI_INFINITE_LIFETIME,
+                                        vn_opt_new, &head, &tail);
+          if (head)
+            {
+              bgp->rfapi->flags |= RFAPI_INCALLBACK;
+              (*bgp->rfapi->rfp_methods.local_cb) (head, r->cookie);
+              bgp->rfapi->flags &= ~RFAPI_INCALLBACK;
+            }
+          head = tail = NULL;
+        }
+      vnc_zlog_debug_verbose ("%s completed, count=%d/%d",  __func__,
+                              rfg->rfapi_import_table->local_count[AFI_IP],
+                              rfg->rfapi_import_table->local_count[AFI_IP6]);
+      return CMD_SUCCESS;
+    }
+
+  vnc_zlog_debug_verbose ("%s: rfapi_register failed", __func__);
+  vty_out (vty, "Add failed.%s", VTY_NEWLINE);
+  return CMD_WARNING;
+}
+
+DEFUN (add_vrf_prefix_rd_label_pref,
+       add_vrf_prefix_rd_label_pref_cmd,
+      "add vrf NAME prefix <A.B.C.D/M|X:X::X:X/M> [rd ASN:nn_or_IP-address] [label (0-1048575)] [preference (0-4294967295)]",
+       "Add\n"
+       "To a VRF\n"
+       "VRF name\n"
+       "Add/modify prefix related information\n"
+       "IPv4 prefix\n"
+       "IPv6 prefix\n"
+       "Override configured VRF Route Distinguisher\n"
+       "<as-number>:<number> or <ip-address>:<number>\n"
+       "Override configured VRF label"
+       "Label Value <0-1048575>\n"
+       "Set advertised local preference\n"
+       "local preference (higher=more preferred)\n")
+{
+  char *arg_vrf    = argv[2]->arg;
+  char *arg_prefix = argv[4]->arg;
+  char *arg_rd     = NULL;      /* optional */
+  char *arg_label  = NULL;      /* optional */
+  char *arg_pref   = NULL;      /* optional */
+  int  pargc = 5;
+  argc--;                        /* don't parse argument */
+  while (pargc < argc) 
+    {
+      switch (argv[pargc++]->arg[0])
+        {
+        case 'r':
+          arg_rd    = argv[pargc]->arg;
+          break;
+        case 'l':
+          arg_label = argv[pargc]->arg;
+          break;
+        case 'p':
+          arg_pref  = argv[pargc]->arg;
+          break;
+        default:
+          break;
+        }
+      pargc ++;
+    }
+  
+  return vnc_add_vrf_prefix (vty, arg_vrf, arg_prefix, arg_rd, arg_label, arg_pref);
+}
+
+/************************************************************************
+ *		del prefix with vrf
+ *
+ * clear [vrf <vrf-name>] prefix <prefix> [rd <value>]
+ ************************************************************************/
+static int
+rfapi_cfg_group_it_count(struct rfapi_nve_group_cfg *rfg)
+{
+  int count = 0;
+  afi_t afi = AFI_MAX;
+  while (afi-- > 0)
+    {
+      count += rfg->rfapi_import_table->local_count[afi];
+    }
+  return count;
+}
+
+static void
+clear_vnc_vrf_closer (struct rfapi_nve_group_cfg *rfg)
+{
+  struct rfapi_descriptor *rfd = rfg->rfd;
+  afi_t                    afi;
+
+  if (rfd == NULL)
+    return;
+  /* check if IT is empty */
+  for (afi = 0; 
+       afi < AFI_MAX && rfg->rfapi_import_table->local_count[afi] == 0; 
+       afi++);
+
+  if (afi == AFI_MAX)
+    {
+      vnc_zlog_debug_verbose ("%s: closing RFD for VRF %s",
+                              __func__, rfg->name);
+      rfg->rfd = NULL;
+      rfapi_close(rfd);
+    }
+  else
+    {
+      vnc_zlog_debug_verbose ("%s: VRF %s afi=%d count=%d",
+                              __func__, rfg->name, afi, 
+                              rfg->rfapi_import_table->local_count[afi]);
+    }
+}
+
+static int
+vnc_clear_vrf (struct vty *vty,
+               struct bgp *bgp,
+               const char *arg_vrf,
+               const char *arg_prefix, /* NULL = all */
+               const char *arg_rd)     /* optional */
+{
+  struct rfapi_nve_group_cfg        *rfg;
+  struct rfapi_local_reg_delete_arg  cda;
+  int                                rc;
+  int                                start_count;
+
+  if (bgp == NULL)
+    bgp = bgp_get_default (); /* assume main instance for now */
+  if (!bgp)
+    {
+      vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  if (!bgp->rfapi || !bgp->rfapi_cfg)
+    {
+      vty_out (vty, "VRF support not configured%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  rfg = bgp_rfapi_cfg_match_byname (bgp,  arg_vrf, RFAPI_GROUP_CFG_VRF);
+  /* arg checks */
+  if (!rfg)
+    {
+      vty_out (vty, "VRF \"%s\" appears not to be configured.%s",
+               arg_vrf, VTY_NEWLINE);
+          return CMD_WARNING;
+    }
+  rc = parse_deleter_args (vty, bgp, arg_prefix, NULL, NULL, NULL, NULL,
+                           arg_rd, rfg, &cda);
+  if (rc != CMD_SUCCESS)        /* parse error */
+    return rc;
+
+  start_count = rfapi_cfg_group_it_count(rfg);
+  clear_vnc_prefix (&cda);
+  clear_vnc_vrf_closer (rfg);
+  vty_out (vty, "Cleared %u out of %d prefixes.%s", 
+           cda.pfx_count, start_count, VTY_NEWLINE);
+  return CMD_SUCCESS;
+}
+
+DEFUN (clear_vrf_prefix_rd,
+       clear_vrf_prefix_rd_cmd,
+       "clear vrf NAME [prefix <A.B.C.D/M|X:X::X:X/M>] [rd ASN:nn_or_IP-address]",
+       "Clear stored data\n"
+       "From a VRF\n"
+       "VRF name\n"
+       "Prefix related information\n"
+       "IPv4 prefix\n"
+       "IPv6 prefix\n"
+       "Specific VRF Route Distinguisher\n"
+       "<as-number>:<number> or <ip-address>:<number>\n")
+{
+  char *arg_vrf    = argv[2]->arg;
+  char *arg_prefix = NULL;       /* optional */
+  char *arg_rd     = NULL;       /* optional */
+  int  pargc = 3;
+  argc--;                       /* don't check parameter */
+  while (pargc < argc) 
+    {
+      switch (argv[pargc++]->arg[0])
+        {
+        case 'r':
+          arg_rd     = argv[pargc]->arg;
+          break;
+        case 'p':
+          arg_prefix = argv[pargc]->arg;
+          break;
+        default:
+          break;
+        }
+      pargc ++;
+    }
+  return vnc_clear_vrf (vty, NULL, arg_vrf, arg_prefix, arg_rd);
+}
+
+DEFUN (clear_vrf_all,
+       clear_vrf_all_cmd,
+       "clear vrf NAME all",
+       "Clear stored data\n"
+       "From a VRF\n"
+       "VRF name\n"
+       "All prefixes\n")
+{
+  char *arg_vrf    = argv[2]->arg;
+  return vnc_clear_vrf (vty, NULL, arg_vrf, NULL, NULL);
+}
+
 void rfapi_vty_init ()
 {
   install_element (ENABLE_NODE, &add_vnc_prefix_cost_life_lnh_cmd);
@@ -4950,6 +5378,8 @@ void rfapi_vty_init ()
   install_element (ENABLE_NODE, &add_vnc_mac_vni_cost_cmd);
   install_element (ENABLE_NODE, &add_vnc_mac_vni_life_cmd);
   install_element (ENABLE_NODE, &add_vnc_mac_vni_cmd);
+
+  install_element (ENABLE_NODE, &add_vrf_prefix_rd_label_pref_cmd);
 
   install_element (ENABLE_NODE, &clear_vnc_nve_all_cmd);
   install_element (ENABLE_NODE, &clear_vnc_nve_vn_un_cmd);
@@ -4974,6 +5404,9 @@ void rfapi_vty_init ()
   install_element (ENABLE_NODE, &clear_vnc_mac_un_prefix_cmd);
   install_element (ENABLE_NODE, &clear_vnc_mac_vn_prefix_cmd);
   install_element (ENABLE_NODE, &clear_vnc_mac_all_prefix_cmd);
+
+  install_element (ENABLE_NODE, &clear_vrf_prefix_rd_cmd);
+  install_element (ENABLE_NODE, &clear_vrf_all_cmd);
 
   install_element (ENABLE_NODE, &vnc_clear_counters_cmd);
 

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -1446,17 +1446,24 @@ rfapiShowRemoteRegistrationsIt (
 
                   if (pLni)
                     {
-                      fp (out, "%s[%s] L2VPN Network 0x%x (%u) RT={%s}%s",
-                          HVTY_NEWLINE, type, *pLni, (*pLni & 0xfff), s,
-                          HVTY_NEWLINE);
+                      fp (out, "%s[%s] L2VPN Network 0x%x (%u) RT={%s}",
+                          HVTY_NEWLINE, type, *pLni, (*pLni & 0xfff), s);
                     }
                   else
                     {
-                      fp (out, "%s[%s] Prefix RT={%s}%s",
-                          HVTY_NEWLINE, type, s, HVTY_NEWLINE);
+                      fp (out, "%s[%s] Prefix RT={%s}",
+                          HVTY_NEWLINE, type, s);
                     }
                   XFREE (MTYPE_ECOMMUNITY_STR, s);
 
+                  if (it->rfg && it->rfg->name)
+                    {
+                      fp (out, " %s \"%s\"",
+                          (it->rfg->type == RFAPI_GROUP_CFG_VRF ? 
+                           "VRF" : "NVE group"),
+                          it->rfg->name);
+                    }
+                  fp (out, "%s", HVTY_NEWLINE);
                   if (show_expiring)
                     {
 #if RFAPI_REGISTRATIONS_REPORT_AGE

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -1846,14 +1846,14 @@ rfapiPrintDescriptor (struct vty *vty, struct rfapi_descriptor *rfd)
         {
 
           /* group like family prefixes together in output */
-          if (family != adb->prefix_ip.family)
+          if (family != adb->u.s.prefix_ip.family)
             continue;
 
-          prefix2str (&adb->prefix_ip, buf, BUFSIZ);
+          prefix2str (&adb->u.s.prefix_ip, buf, BUFSIZ);
           buf[BUFSIZ - 1] = 0;  /* guarantee NUL-terminated */
 
           vty_out (vty, "  Adv Pfx: %s%s", buf, HVTY_NEWLINE);
-          rfapiPrintAdvertisedInfo (vty, rfd, SAFI_MPLS_VPN, &adb->prefix_ip);
+          rfapiPrintAdvertisedInfo (vty, rfd, SAFI_MPLS_VPN, &adb->u.s.prefix_ip);
         }
     }
   for (rc =
@@ -1864,14 +1864,14 @@ rfapiPrintDescriptor (struct vty *vty, struct rfapi_descriptor *rfd)
                       &cursor))
     {
 
-      prefix2str (&adb->prefix_eth, buf, BUFSIZ);
+      prefix2str (&adb->u.s.prefix_eth, buf, BUFSIZ);
       buf[BUFSIZ - 1] = 0;      /* guarantee NUL-terminated */
 
       vty_out (vty, "  Adv Pfx: %s%s", buf, HVTY_NEWLINE);
 
       /* TBD update the following function to print ethernet info */
       /* Also need to pass/use rd */
-      rfapiPrintAdvertisedInfo (vty, rfd, SAFI_MPLS_VPN, &adb->prefix_ip);
+      rfapiPrintAdvertisedInfo (vty, rfd, SAFI_MPLS_VPN, &adb->u.s.prefix_ip);
     }
   vty_out (vty, "%s", HVTY_NEWLINE);
 }
@@ -3375,7 +3375,7 @@ rfapiDeleteLocalPrefixes (struct rfapi_local_reg_delete_arg *cda)
 
             if (pPrefix)
               {
-                if (!prefix_same (pPrefix, &adb->prefix_ip))
+                if (!prefix_same (pPrefix, &adb->u.s.prefix_ip))
                   {
 #if DEBUG_L2_EXTRA
                     vnc_zlog_debug_verbose ("%s: adb=%p, prefix doesn't match, skipping",
@@ -3388,7 +3388,7 @@ rfapiDeleteLocalPrefixes (struct rfapi_local_reg_delete_arg *cda)
               {
                 if (memcmp
                     (cda->l2o.o.macaddr.octet,
-                     adb->prefix_eth.u.prefix_eth.octet, ETHER_ADDR_LEN))
+                     adb->u.s.prefix_eth.u.prefix_eth.octet, ETHER_ADDR_LEN))
                   {
 #if DEBUG_L2_EXTRA
                     vnc_zlog_debug_verbose ("%s: adb=%p, macaddr doesn't match, skipping",
@@ -3430,24 +3430,23 @@ rfapiDeleteLocalPrefixes (struct rfapi_local_reg_delete_arg *cda)
 
             this_advertisement_prefix_count = 1;
 
-            rfapiQprefix2Rprefix (&adb->prefix_ip, &rp);
+            rfapiQprefix2Rprefix (&adb->u.s.prefix_ip, &rp);
 
             /* if mac addr present in advert,  make l2o vn option */
-            if (adb->prefix_eth.family == AF_ETHERNET)
+            if (adb->u.s.prefix_eth.family == AF_ETHERNET)
               {
-
                 memset (&vn1, 0, sizeof (vn1));
                 memset (&vn2, 0, sizeof (vn2));
 
                 vn1.type = RFAPI_VN_OPTION_TYPE_L2ADDR;
-                vn1.v.l2addr.macaddr = adb->prefix_eth.u.prefix_eth;
+                vn1.v.l2addr.macaddr = adb->u.s.prefix_eth.u.prefix_eth;
 
                 /*
                  * use saved RD value instead of trying to invert
                  * complex L2-style RD computation in rfapi_register()
                  */
                 vn2.type = RFAPI_VN_OPTION_TYPE_INTERNAL_RD;
-                vn2.v.internal_rd = adb->prd;
+                vn2.v.internal_rd = adb->u.s.prd;
 
                 vn1.next = &vn2;
 
@@ -3499,7 +3498,7 @@ rfapiDeleteLocalPrefixes (struct rfapi_local_reg_delete_arg *cda)
                 if (CHECK_FLAG (cda->l2o.flags, RFAPI_L2O_MACADDR))
                   {
                     if (memcmp (cda->l2o.o.macaddr.octet,
-                                adb->prefix_eth.u.prefix_eth.octet,
+                                adb->u.s.prefix_eth.u.prefix_eth.octet,
                                 ETHER_ADDR_LEN))
                       {
 
@@ -3526,7 +3525,7 @@ rfapiDeleteLocalPrefixes (struct rfapi_local_reg_delete_arg *cda)
 
                 struct rfapi_vn_option vn;
 
-                rfapiQprefix2Rprefix (&adb->prefix_ip, &rp);
+                rfapiQprefix2Rprefix (&adb->u.s.prefix_ip, &rp);
 
                 memset (&vn, 0, sizeof (vn));
                 vn.type = RFAPI_VN_OPTION_TYPE_L2ADDR;

--- a/lib/command.c
+++ b/lib/command.c
@@ -741,6 +741,7 @@ node_parent ( enum node_type node )
     case BGP_VPNV6_NODE:
     case BGP_ENCAP_NODE:
     case BGP_ENCAPV6_NODE:
+    case BGP_VRF_POLICY_NODE:
     case BGP_VNC_DEFAULTS_NODE:
     case BGP_VNC_NVE_GROUP_NODE:
     case BGP_VNC_L2_GROUP_NODE:
@@ -1106,6 +1107,7 @@ cmd_exit (struct vty *vty)
     case BGP_VPNV6_NODE:
     case BGP_ENCAP_NODE:
     case BGP_ENCAPV6_NODE:
+    case BGP_VRF_POLICY_NODE:
     case BGP_VNC_DEFAULTS_NODE:
     case BGP_VNC_NVE_GROUP_NODE:
     case BGP_VNC_L2_GROUP_NODE:
@@ -1169,6 +1171,7 @@ DEFUN (config_end,
     case BGP_NODE:
     case BGP_ENCAP_NODE:
     case BGP_ENCAPV6_NODE:
+    case BGP_VRF_POLICY_NODE:
     case BGP_VNC_DEFAULTS_NODE:
     case BGP_VNC_NVE_GROUP_NODE:
     case BGP_VNC_L2_GROUP_NODE:

--- a/lib/command.h
+++ b/lib/command.h
@@ -99,6 +99,7 @@ enum node_type
   BGP_IPV6M_NODE,               /* BGP IPv6 multicast address family. */
   BGP_ENCAP_NODE,               /* BGP ENCAP SAFI */
   BGP_ENCAPV6_NODE,             /* BGP ENCAP SAFI */
+  BGP_VRF_POLICY_NODE,          /* BGP VRF policy */
   BGP_VNC_DEFAULTS_NODE,	/* BGP VNC nve defaults */
   BGP_VNC_NVE_GROUP_NODE,	/* BGP VNC nve group */
   BGP_VNC_L2_GROUP_NODE,	/* BGP VNC L2 group */

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -742,6 +742,7 @@ vty_end_config (struct vty *vty)
     case BGP_VPNV6_NODE:
     case BGP_ENCAP_NODE:
     case BGP_ENCAPV6_NODE:
+    case BGP_VRF_POLICY_NODE:
     case BGP_VNC_DEFAULTS_NODE:
     case BGP_VNC_NVE_GROUP_NODE:
     case BGP_VNC_L2_GROUP_NODE:

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -312,6 +312,10 @@ vtysh_execute_func (const char *line, int pager)
 	{
 	  vtysh_execute("exit-address-family");
 	}
+      else if (saved_node == BGP_VRF_POLICY_NODE && (tried == 1))
+	{
+	  vtysh_execute("exit-vrf-policy");
+	}
       else if ((saved_node == BGP_VNC_DEFAULTS_NODE
            || saved_node == BGP_VNC_NVE_GROUP_NODE
            || saved_node == BGP_VNC_L2_GROUP_NODE) && (tried == 1))
@@ -963,6 +967,11 @@ static struct cmd_node bgp_vnc_nve_group_node =
   "%s(config-router-vnc-nve-group)# "
 };
 
+static struct cmd_node bgp_vrf_policy_node = {
+  BGP_VRF_POLICY_NODE,
+  "%s(config-router-vrf-policy)# "
+};
+
 static struct cmd_node bgp_vnc_l2_group_node =
 {
   BGP_VNC_L2_GROUP_NODE,
@@ -1206,6 +1215,17 @@ DEFUNSH (VTYSH_BGPD,
          "Group name\n")
 {
   vty->node = BGP_VNC_NVE_GROUP_NODE;
+  return CMD_SUCCESS;
+}
+
+DEFUNSH (VTYSH_BGPD,
+         vnc_vrf_policy,
+         vnc_vrf_policy_cmd,
+         "vrf-policy NAME",
+         "Configure a VRF policy group\n"
+         "Group name\n")
+{
+  vty->node = BGP_VRF_POLICY_NODE;
   return CMD_SUCCESS;
 }
 
@@ -1481,6 +1501,7 @@ vtysh_exit (struct vty *vty)
     case BGP_IPV4M_NODE:
     case BGP_IPV6_NODE:
     case BGP_IPV6M_NODE:
+    case BGP_VRF_POLICY_NODE:
     case BGP_VNC_DEFAULTS_NODE:
     case BGP_VNC_NVE_GROUP_NODE:
     case BGP_VNC_L2_GROUP_NODE:
@@ -1556,6 +1577,17 @@ DEFUNSH (VTYSH_BGPD,
   if (vty->node == BGP_VNC_DEFAULTS_NODE
       || vty->node == BGP_VNC_NVE_GROUP_NODE
       || vty->node == BGP_VNC_L2_GROUP_NODE)
+    vty->node = BGP_NODE;
+  return CMD_SUCCESS;
+}
+
+DEFUNSH (VTYSH_BGPD,
+	 exit_vrf_policy,
+	 exit_vrf_policy_cmd,
+	 "exit-vrf-policy",
+	 "Exit from VRF  configuration mode\n")
+{
+  if (vty->node == BGP_VRF_POLICY_NODE)
     vty->node = BGP_NODE;
   return CMD_SUCCESS;
 }
@@ -3042,6 +3074,7 @@ vtysh_init_vty (void)
   install_node (&bgp_ipv4m_node, NULL);
   install_node (&bgp_ipv6_node, NULL);
   install_node (&bgp_ipv6m_node, NULL);
+  install_node (&bgp_vrf_policy_node, NULL);
   install_node (&bgp_vnc_defaults_node, NULL);
   install_node (&bgp_vnc_nve_group_node, NULL);
   install_node (&bgp_vnc_l2_group_node, NULL);
@@ -3079,6 +3112,7 @@ vtysh_init_vty (void)
   vtysh_install_default (BGP_IPV6_NODE);
   vtysh_install_default (BGP_IPV6M_NODE);
 #if ENABLE_BGP_VNC
+  vtysh_install_default (BGP_VRF_POLICY_NODE);
   vtysh_install_default (BGP_VNC_DEFAULTS_NODE);
   vtysh_install_default (BGP_VNC_NVE_GROUP_NODE);
   vtysh_install_default (BGP_VNC_L2_GROUP_NODE);
@@ -3150,6 +3184,8 @@ vtysh_init_vty (void)
   install_element (BGP_IPV6M_NODE, &vtysh_exit_bgpd_cmd);
   install_element (BGP_IPV6M_NODE, &vtysh_quit_bgpd_cmd);
 #if defined (ENABLE_BGP_VNC)
+  install_element (BGP_VRF_POLICY_NODE, &vtysh_exit_bgpd_cmd);
+  install_element (BGP_VRF_POLICY_NODE, &vtysh_quit_bgpd_cmd);
   install_element (BGP_VNC_DEFAULTS_NODE, &vtysh_exit_bgpd_cmd);
   install_element (BGP_VNC_DEFAULTS_NODE, &vtysh_quit_bgpd_cmd);
   install_element (BGP_VNC_NVE_GROUP_NODE, &vtysh_exit_bgpd_cmd);
@@ -3191,6 +3227,7 @@ vtysh_init_vty (void)
   install_element (BGP_ENCAPV6_NODE, &vtysh_end_all_cmd);
   install_element (BGP_IPV6_NODE, &vtysh_end_all_cmd);
   install_element (BGP_IPV6M_NODE, &vtysh_end_all_cmd);
+  install_element (BGP_VRF_POLICY_NODE, &vtysh_end_all_cmd);
   install_element (BGP_VNC_DEFAULTS_NODE, &vtysh_end_all_cmd);
   install_element (BGP_VNC_NVE_GROUP_NODE, &vtysh_end_all_cmd);
   install_element (BGP_VNC_L2_GROUP_NODE, &vtysh_end_all_cmd);
@@ -3239,6 +3276,7 @@ vtysh_init_vty (void)
   install_element (BGP_NODE, &address_family_encapv4_cmd);
   install_element (BGP_NODE, &address_family_encapv6_cmd);
 #if defined(ENABLE_BGP_VNC)
+  install_element (BGP_NODE, &vnc_vrf_policy_cmd);
   install_element (BGP_NODE, &vnc_defaults_cmd);
   install_element (BGP_NODE, &vnc_nve_group_cmd);
   install_element (BGP_NODE, &vnc_l2_group_cmd);
@@ -3256,6 +3294,7 @@ vtysh_init_vty (void)
   install_element (BGP_IPV6_NODE, &exit_address_family_cmd);
   install_element (BGP_IPV6M_NODE, &exit_address_family_cmd);
 
+  install_element (BGP_VRF_POLICY_NODE, &exit_vrf_policy_cmd);
   install_element (BGP_VNC_DEFAULTS_NODE, &exit_vnc_config_cmd);
   install_element (BGP_VNC_NVE_GROUP_NODE, &exit_vnc_config_cmd);
   install_element (BGP_VNC_L2_GROUP_NODE, &exit_vnc_config_cmd);


### PR DESCRIPTION
FIX
    bgpd: disambiguate different forms of
          show bgp ipv4 vpn
          address-family ipv4&6 vpn
 VRF
   bgpd rfapi: add NVE/VRF name to show vnc registrations
    bgpd: add vrf-policy config using existing vnc code
          add add/clear vrf prefix
          + Modified for FRR master parser
FIX
    bgpd rfapi: fix issue where advertised prefixes were not being disambiguated
                   by RD
