### PR TITLE
Provide EVPN basic support on master branch + EVPN Route Target 5 Support

### DIFF
--- a/bgpd/Makefile.am
+++ b/bgpd/Makefile.am
@@ -78,7 +78,8 @@ libbgp_a_SOURCES = \
 	bgp_dump.c bgp_snmp.c bgp_ecommunity.c bgp_mplsvpn.c bgp_nexthop.c \
 	bgp_damp.c bgp_table.c bgp_advertise.c bgp_vty.c bgp_mpath.c \
         bgp_nht.c bgp_updgrp.c bgp_updgrp_packet.c bgp_updgrp_adv.c bgp_bfd.c \
-	bgp_encap.c bgp_encap_tlv.c $(BGP_VNC_RFAPI_SRC) bgp_attr_evpn.c
+	bgp_encap.c bgp_encap_tlv.c $(BGP_VNC_RFAPI_SRC) bgp_attr_evpn.c \
+	bgp_evpn.c
 
 noinst_HEADERS = \
 	bgp_memory.h \
@@ -88,7 +89,7 @@ noinst_HEADERS = \
 	bgp_ecommunity.h bgp_mplsvpn.h bgp_nexthop.h bgp_damp.h bgp_table.h \
 	bgp_advertise.h bgp_snmp.h bgp_vty.h bgp_mpath.h bgp_nht.h \
         bgp_updgrp.h bgp_bfd.h bgp_encap.h bgp_encap_tlv.h bgp_encap_types.h \
-	$(BGP_VNC_RFAPI_HD) bgp_attr_evpn.h
+	$(BGP_VNC_RFAPI_HD) bgp_attr_evpn.h bgp_evpn.h
 
 bgpd_SOURCES = bgp_main.c
 bgpd_LDADD = libbgp.a  $(BGP_VNC_RFP_LIB) ../lib/libzebra.la @LIBCAP@ @LIBM@

--- a/bgpd/Makefile.am
+++ b/bgpd/Makefile.am
@@ -78,7 +78,7 @@ libbgp_a_SOURCES = \
 	bgp_dump.c bgp_snmp.c bgp_ecommunity.c bgp_mplsvpn.c bgp_nexthop.c \
 	bgp_damp.c bgp_table.c bgp_advertise.c bgp_vty.c bgp_mpath.c \
         bgp_nht.c bgp_updgrp.c bgp_updgrp_packet.c bgp_updgrp_adv.c bgp_bfd.c \
-	bgp_encap.c bgp_encap_tlv.c $(BGP_VNC_RFAPI_SRC)
+	bgp_encap.c bgp_encap_tlv.c $(BGP_VNC_RFAPI_SRC) bgp_attr_evpn.c
 
 noinst_HEADERS = \
 	bgp_memory.h \
@@ -88,7 +88,7 @@ noinst_HEADERS = \
 	bgp_ecommunity.h bgp_mplsvpn.h bgp_nexthop.h bgp_damp.h bgp_table.h \
 	bgp_advertise.h bgp_snmp.h bgp_vty.h bgp_mpath.h bgp_nht.h \
         bgp_updgrp.h bgp_bfd.h bgp_encap.h bgp_encap_tlv.h bgp_encap_types.h \
-	$(BGP_VNC_RFAPI_HD) 
+	$(BGP_VNC_RFAPI_HD) bgp_attr_evpn.h
 
 bgpd_SOURCES = bgp_main.c
 bgpd_LDADD = libbgp.a  $(BGP_VNC_RFP_LIB) ../lib/libzebra.la @LIBCAP@ @LIBM@

--- a/bgpd/Makefile.am
+++ b/bgpd/Makefile.am
@@ -79,7 +79,7 @@ libbgp_a_SOURCES = \
 	bgp_damp.c bgp_table.c bgp_advertise.c bgp_vty.c bgp_mpath.c \
         bgp_nht.c bgp_updgrp.c bgp_updgrp_packet.c bgp_updgrp_adv.c bgp_bfd.c \
 	bgp_encap.c bgp_encap_tlv.c $(BGP_VNC_RFAPI_SRC) bgp_attr_evpn.c \
-	bgp_evpn.c
+	bgp_evpn.c bgp_evpn_vty.c bgp_vpn.c
 
 noinst_HEADERS = \
 	bgp_memory.h \
@@ -89,7 +89,7 @@ noinst_HEADERS = \
 	bgp_ecommunity.h bgp_mplsvpn.h bgp_nexthop.h bgp_damp.h bgp_table.h \
 	bgp_advertise.h bgp_snmp.h bgp_vty.h bgp_mpath.h bgp_nht.h \
         bgp_updgrp.h bgp_bfd.h bgp_encap.h bgp_encap_tlv.h bgp_encap_types.h \
-	$(BGP_VNC_RFAPI_HD) bgp_attr_evpn.h bgp_evpn.h
+	$(BGP_VNC_RFAPI_HD) bgp_attr_evpn.h bgp_evpn.h bgp_evpn_vty.h bgp_vpn.h
 
 bgpd_SOURCES = bgp_main.c
 bgpd_LDADD = libbgp.a  $(BGP_VNC_RFP_LIB) ../lib/libzebra.la @LIBCAP@ @LIBM@

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3310,8 +3310,9 @@ bgp_packet_attribute (struct bgp *bgp, struct peer *peer,
       stream_put_ipv4 (s, attr->extra->aggregator_addr.s_addr);
     }
 
-  if ((afi == AFI_IP || afi == AFI_IP6) &&
-      (safi == SAFI_ENCAP || safi == SAFI_MPLS_VPN))
+  if (((afi == AFI_IP || afi == AFI_IP6) &&
+       (safi == SAFI_ENCAP || safi == SAFI_MPLS_VPN)) ||
+      (afi == AFI_L2VPN && safi == SAFI_EVPN))
     {
 	/* Tunnel Encap attribute */
 	bgp_packet_mpattr_tea(bgp, peer, s, attr, BGP_ATTR_ENCAP);

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -49,6 +49,8 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 # include "bgp_encap_types.h"
 # include "bgp_vnc_types.h"
 #endif
+#include "bgp_encap_types.h"
+#include "bgp_evpn.h"
 
 /* Attribute strings for logging. */
 static const struct message attr_str [] = 
@@ -2798,7 +2800,7 @@ void
 bgp_packet_mpattr_prefix (struct stream *s, afi_t afi, safi_t safi,
 			  struct prefix *p, struct prefix_rd *prd,
                           u_char *tag, int addpath_encode,
-                          u_int32_t addpath_tx_id)
+                          u_int32_t addpath_tx_id, struct attr *attr)
 {
   if (safi == SAFI_MPLS_VPN)
     {
@@ -2809,6 +2811,10 @@ bgp_packet_mpattr_prefix (struct stream *s, afi_t afi, safi_t safi,
       stream_put (s, tag, 3);
       stream_put (s, prd->val, 8);
       stream_put (s, &p->u.prefix, PSIZE (p->prefixlen));
+    }
+  else if ((safi == SAFI_EVPN))
+    {
+      bgp_packet_mpattr_route_type_5(s, p, prd, tag, attr);
     }
   else
     stream_put_prefix_addpath (s, p, addpath_encode, addpath_tx_id);
@@ -2965,7 +2971,7 @@ bgp_packet_attribute (struct bgp *bgp, struct peer *peer,
                                      AFI_MAX), /* get from NH */
                                     vecarr, attr);
       bgp_packet_mpattr_prefix(s, afi, safi, p, prd, tag,
-                               addpath_encode, addpath_tx_id);
+                               addpath_encode, addpath_tx_id, attr);
       bgp_packet_mpattr_end(s, mpattrlen_pos);
     }
 
@@ -3351,21 +3357,10 @@ void
 bgp_packet_mpunreach_prefix (struct stream *s, struct prefix *p,
 			     afi_t afi, safi_t safi, struct prefix_rd *prd,
 			     u_char *tag, int addpath_encode,
-                             u_int32_t addpath_tx_id)
+                             u_int32_t addpath_tx_id, struct attr *attr)
 {
-  if (safi == SAFI_MPLS_VPN)
-    {
-      /* addpath TX ID */
-      if (addpath_encode)
-        stream_putl(s, addpath_tx_id);
-
-      stream_putc (s, p->prefixlen + 88);
-      stream_put (s, tag, 3);
-      stream_put (s, prd->val, 8);
-      stream_put (s, &p->u.prefix, PSIZE (p->prefixlen));
-    }
-  else
-    stream_put_prefix_addpath (s, p, addpath_encode, addpath_tx_id);
+  return bgp_packet_mpattr_prefix (s, afi, safi, p, prd,
+                                   tag, addpath_encode, addpath_tx_id, attr);
 }
 
 void

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2752,6 +2752,39 @@ bgp_packet_mpattr_start (struct stream *s, afi_t afi, safi_t safi, afi_t nh_afi,
 	break;
       }
       break;
+    case AFI_L2VPN:
+      switch (safi)
+      {
+      case SAFI_EVPN:
+          if (attr->extra->mp_nexthop_len == BGP_ATTR_NHLEN_VPNV4)
+            {
+              stream_putc (s, 12);
+              stream_putl (s, 0);   /* RD = 0, per RFC */
+              stream_putl (s, 0);
+              stream_put (s, &attr->extra->mp_nexthop_global_in, 4);
+            }
+          else if (attr->extra->mp_nexthop_len == BGP_ATTR_NHLEN_IPV6_GLOBAL)
+            {
+              stream_putc (s, 24);
+              stream_putl (s, 0);   /* RD = 0, per RFC */
+              stream_putl (s, 0);
+              stream_put (s, &attr->extra->mp_nexthop_global, IPV6_MAX_BYTELEN);
+            }
+          else if (attr->extra->mp_nexthop_len == BGP_ATTR_NHLEN_IPV6_GLOBAL_AND_LL)
+            {
+              stream_putc (s, 48);
+              stream_putl (s, 0);   /* RD = 0, per RFC */
+              stream_putl (s, 0);
+              stream_put (s, &attr->extra->mp_nexthop_global, IPV6_MAX_BYTELEN);
+              stream_putl (s, 0);   /* RD = 0, per RFC */
+              stream_putl (s, 0);
+              stream_put (s, &attr->extra->mp_nexthop_local, IPV6_MAX_BYTELEN);
+            }
+	  break;
+        break;
+      default:
+        break;
+      }
     default:
       break;
     }

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -417,6 +417,18 @@ encap_finish (void)
 #endif
 }
 
+static bool
+overlay_index_same(const struct attr_extra *ae1, const struct attr_extra *ae2)
+{
+  if(!ae1 && ae2)
+    return false;
+  if(!ae2 && ae1)
+    return false;
+  if(!ae1 && !ae2)
+    return false;
+  return !memcmp(&(ae1->evpn_overlay), &(ae2->evpn_overlay), sizeof(struct overlay_index));
+}
+
 /* Unknown transit attribute. */
 static struct hash *transit_hash;
 
@@ -725,7 +737,8 @@ attrhash_cmp (const void *p1, const void *p2)
 #if ENABLE_BGP_VNC
 	  && encap_same(ae1->vnc_subtlvs, ae2->vnc_subtlvs)
 #endif
-          && IPV4_ADDR_SAME (&ae1->originator_id, &ae2->originator_id))
+          && IPV4_ADDR_SAME (&ae1->originator_id, &ae2->originator_id)
+          && overlay_index_same(ae1, ae2))
         return 1;
       else if (ae1 || ae2)
         return 0;

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -291,7 +291,8 @@ extern size_t bgp_packet_mpattr_start(struct stream *s, afi_t afi, safi_t safi,
 extern void bgp_packet_mpattr_prefix(struct stream *s, afi_t afi, safi_t safi,
 				     struct prefix *p, struct prefix_rd *prd,
 				     u_char *tag, int addpath_encode,
-                                     u_int32_t addpath_tx_id);
+                                     u_int32_t addpath_tx_id,
+                                     struct attr *);
 extern size_t bgp_packet_mpattr_prefix_size(afi_t afi, safi_t safi,
                                             struct prefix *p);
 extern void bgp_packet_mpattr_end(struct stream *s, size_t sizep);
@@ -300,7 +301,7 @@ extern size_t bgp_packet_mpunreach_start (struct stream *s, afi_t afi,
 					  safi_t safi);
 extern void bgp_packet_mpunreach_prefix (struct stream *s, struct prefix *p,
 			     afi_t afi, safi_t safi, struct prefix_rd *prd,
-			     u_char *tag, int, u_int32_t);
+                             u_char *tag, int, u_int32_t, struct attr *);
 extern void bgp_packet_mpunreach_end (struct stream *s, size_t attrlen_pnt);
 
 static inline int

--- a/bgpd/bgp_attr.h
+++ b/bgpd/bgp_attr.h
@@ -21,6 +21,8 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #ifndef _QUAGGA_BGP_ATTR_H
 #define _QUAGGA_BGP_ATTR_H
 
+#include "bgp_attr_evpn.h"
+
 /* Simple bit mapping. */
 #define BITMAP_NBBY 8
 
@@ -80,6 +82,13 @@ struct bgp_tea_options {
 
 #endif
 
+/* Overlay Index Info */
+struct overlay_index
+{
+  struct eth_segment_id eth_s_id;
+  union gw_addr gw_ip;
+};
+
 /* Additional/uncommon BGP attributes.
  * lazily allocated as and when a struct attr
  * requires it.
@@ -128,6 +137,8 @@ struct attr_extra
 #if ENABLE_BGP_VNC
   struct bgp_attr_encap_subtlv *vnc_subtlvs;		/* VNC-specific */
 #endif
+  /* EVPN */
+  struct overlay_index evpn_overlay;
 };
 
 /* BGP core attribute structure. */

--- a/bgpd/bgp_attr_evpn.c
+++ b/bgpd/bgp_attr_evpn.c
@@ -21,6 +21,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include <zebra.h>
 
 #include "command.h"
+#include "filter.h"
 #include "prefix.h"
 #include "log.h"
 #include "memory.h"

--- a/bgpd/bgp_attr_evpn.c
+++ b/bgpd/bgp_attr_evpn.c
@@ -1,0 +1,262 @@
+/* Ethernet-VPN Attribute handling file
+   Copyright (C) 2016 6WIND
+
+This file is part of GNU Quagga
+
+GNU Zebra is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation; either version 2, or (at your option) any
+later version.
+
+GNU Zebra is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GNU Zebra; see the file COPYING.  If not, write to the Free
+Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+02111-1307, USA.  */
+
+#include <zebra.h>
+
+#include "command.h"
+#include "prefix.h"
+#include "log.h"
+#include "memory.h"
+#include "stream.h"
+
+#include "bgpd/bgp_attr_evpn.h"
+
+static uint8_t convertchartohexa (uint8_t *hexa, int *error)
+{
+  if( (*hexa == '0') || (*hexa == '1') || (*hexa == '2') ||
+      (*hexa == '3') || (*hexa == '4') || (*hexa == '5') ||
+      (*hexa == '6') || (*hexa == '7') || (*hexa == '8') ||
+      (*hexa == '9'))
+    return (uint8_t)(*hexa)-'0';
+  if((*hexa == 'a') || (*hexa == 'A'))
+    return 0xa;
+  if((*hexa == 'b') || (*hexa == 'B'))
+    return 0xb;
+  if((*hexa == 'c') || (*hexa == 'C'))
+    return 0xc;
+  if((*hexa == 'd') || (*hexa == 'D'))
+    return 0xd;
+  if((*hexa == 'e') || (*hexa == 'E'))
+    return 0xe;
+  if((*hexa == 'f') || (*hexa == 'F'))
+    return 0xf;
+  *error = -1;
+  return 0;
+}
+
+/* converts to internal representation of mac address
+ * returns 1 on success, 0 otherwise 
+ * format accepted: AA:BB:CC:DD:EE:FF
+ * if mac parameter is null, then check only
+ */
+int
+str2mac (const char *str, char *mac)
+{
+  unsigned int k=0, i, j;
+  uint8_t *ptr, *ptr2;
+  size_t len;
+  uint8_t car;
+
+  if (!str)
+    return 0;
+
+  if (str[0] == ':' && str[1] == '\0')
+    return 1;
+
+  i = 0;
+  ptr = (uint8_t *)str;
+  while (i < 6)
+    {
+      uint8_t temp[5];
+      int error = 0;
+      ptr2 = (uint8_t *)strchr((const char *)ptr, ':');
+      if (ptr2 == NULL)
+	{
+	  /* if last occurence return ok */
+	  if(i != 5)
+            {
+              zlog_err("[%s]: format non recognized",mac);
+              return 0;
+            }
+          len = strlen((char *)ptr);
+	} 
+      else
+        {
+          len = ptr2 - ptr;
+        }
+      if(len > 5)
+        {
+          zlog_err("[%s]: format non recognized",mac);
+         return 0;
+        }
+      memcpy(temp, ptr, len);
+      for(j=0;j< len;j++)
+	{
+	  if (k >= MAC_LEN)
+	    return 0;
+          if(mac)
+            mac[k] = 0;
+          car = convertchartohexa (&temp[j], &error);
+	  if (error)
+	    return 0;
+	  if(mac)
+            mac[k] = car << 4;
+	  j++;
+          if(j == len)
+            return 0;
+          car = convertchartohexa (&temp[j], &error) & 0xf;
+	  if (error)
+	    return 0;
+	  if(mac)
+            mac[k] |= car & 0xf;
+	  k++;
+	  i++;
+	}
+      ptr = ptr2;
+      if(ptr == NULL)
+        break;
+      ptr++;
+    }
+  if(mac && 0)
+    {
+      zlog_err("leave correct : %02x:%02x:%02x:%02x:%02x:%02x",
+               mac[0] & 0xff, mac[1] & 0xff, mac[2] & 0xff,
+               mac[3] & 0xff, mac[4] & 0xff, mac[5] & 0xff);
+    }
+  return 1;
+}
+
+/* converts to an esi
+ * returns 1 on success, 0 otherwise
+ * format accepted: AA:BB:CC:DD:EE:FF:GG:HH:II:JJ
+ * if id is null, check only is done
+ */
+int
+str2esi (const char *str, struct eth_segment_id *id)
+{
+  unsigned int k=0, i, j;
+  uint8_t *ptr, *ptr2;
+  size_t len;
+  uint8_t car;
+
+  if (!str)
+    return 0;
+  if (str[0] == ':' && str[1] == '\0')
+    return 1;
+
+  i = 0;
+  ptr = (uint8_t *)str;
+  while (i < 10)
+    {
+      uint8_t temp[5];
+      int error = 0;
+      ptr2 = (uint8_t *)strchr((const char *)ptr, ':');
+      if (ptr2 == NULL)
+	{
+	  /* if last occurence return ok */
+	  if(i != 9)
+            {
+              zlog_err("[%s]: format non recognized",str);
+              return 0;
+            }
+          len = strlen((char *)ptr);
+	}
+      else
+        {
+          len = ptr2 - ptr;
+        }
+      memcpy(temp, ptr, len);
+      if(len > 5)
+        {
+          zlog_err("[%s]: format non recognized",str);
+         return 0;
+        }
+      for(j=0;j< len;j++)
+	{
+	  if (k >= ESI_LEN)
+	    return 0;
+          if(id)
+            id->val[k] = 0;
+          car = convertchartohexa (&temp[j], &error);
+          if (error)
+            return 0;
+          if(id)
+            id->val[k] = car << 4;
+          j++;
+          if(j == len)
+            return 0;
+          car = convertchartohexa (&temp[j], &error) & 0xf;
+          if (error)
+            return 0;
+          if(id)
+            id->val[k] |= car & 0xf;
+         k++;
+         i++;
+	}
+      ptr = ptr2;
+      if(ptr == NULL)
+        break;
+      ptr++;
+    }
+  if(id && 0)
+    {
+      zlog_err("leave correct : %02x:%02x:%02x:%02x:%02x",
+               id->val[0], id->val[1], id->val[2], id->val[3], id->val[4]);
+      zlog_err("%02x:%02x:%02x:%02x:%02x",
+               id->val[5], id->val[6], id->val[7], id->val[8], id->val[9]);
+    }
+  return 1;
+}
+
+char *
+esi2str (struct eth_segment_id *id)
+{
+  char *ptr;
+  u_char *val;
+
+  if(!id)
+    return NULL;
+
+  val = id->val;
+  ptr = (char *) malloc ((ESI_LEN*2+ESI_LEN-1+1)*sizeof(char));
+
+  snprintf (ptr, (ESI_LEN*2+ESI_LEN-1+1),
+            "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x",
+            val[0], val[1], val[2], val[3], val[4],
+            val[5], val[6], val[7], val[8], val[9]);
+
+  return ptr;
+}
+
+char *
+mac2str (char *mac)
+{
+  char *ptr;
+
+  if(!mac)
+    return NULL;
+
+  ptr = (char *) malloc ((MAC_LEN*2+MAC_LEN-1+1)*sizeof(char));
+
+  snprintf (ptr, (MAC_LEN*2+MAC_LEN-1+1), "%02x:%02x:%02x:%02x:%02x:%02x",
+           (uint8_t) mac[0], (uint8_t)mac[1], (uint8_t)mac[2], (uint8_t)mac[3],
+           (uint8_t)mac[4], (uint8_t)mac[5]);
+
+  return ptr;
+}
+
+char *ecom_mac2str(char *ecom_mac)
+{
+  char *en;
+
+  en = ecom_mac;
+  en+=2;
+  return mac2str(en);
+}

--- a/bgpd/bgp_attr_evpn.c
+++ b/bgpd/bgp_attr_evpn.c
@@ -27,7 +27,27 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "memory.h"
 #include "stream.h"
 
+#include "bgpd/bgpd.h"
+#include "bgpd/bgp_attr.h"
+#include "bgpd/bgp_route.h"
 #include "bgpd/bgp_attr_evpn.h"
+#include "bgpd/bgp_ecommunity.h"
+
+void bgp_add_routermac_ecom (struct attr* attr, char * routermac)
+{
+  struct ecommunity_val routermac_ecom;
+
+  if(attr->extra)
+    {
+      memset(&routermac_ecom, 0, sizeof(struct ecommunity_val));
+      routermac_ecom.val[0] = ECOMMUNITY_ENCODE_EVPN;
+      routermac_ecom.val[1] = ECOMMUNITY_EVPN_SUBTYPE_ROUTERMAC;
+      memcpy(&routermac_ecom.val[2], routermac, MAC_LEN);
+      if(!attr->extra->ecommunity)
+        attr->extra->ecommunity = ecommunity_new ();
+      ecommunity_add_val(attr->extra->ecommunity, &routermac_ecom);
+    }
+}
 
 static uint8_t convertchartohexa (uint8_t *hexa, int *error)
 {

--- a/bgpd/bgp_attr_evpn.h
+++ b/bgpd/bgp_attr_evpn.h
@@ -1,0 +1,55 @@
+/* E-VPN attribute handling structure file
+   Copyright (C) 2016 6WIND
+
+This file is part of GNU Quagga.
+
+GNU Quagga is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation; either version 2, or (at your option) any
+later version.
+
+GNU Quagga is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GNU Quagga; see the file COPYING.  If not, write to the Free
+Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+02111-1307, USA.  */
+
+#ifndef _QUAGGA_BGP_ATTR_EVPN_H
+#define _QUAGGA_BGP_ATTR_EVPN_H
+
+/* value of first byte of ESI */
+#define ESI_TYPE_ARBITRARY 0 /* */
+#define ESI_TYPE_LACP      1 /* <> */
+#define ESI_TYPE_BRIDGE    2 /* <Root bridge Mac-6B>:<Root Br Priority-2B>:00 */
+#define ESI_TYPE_MAC       3 /* <Syst Mac Add-6B>:<Local Discriminator Value-3B> */
+#define ESI_TYPE_ROUTER    4 /* <RouterId-4B>:<Local Discriminator Value-4B> */
+#define ESI_TYPE_AS        5 /* <AS-4B>:<Local Discriminator Value-4B> */
+#define MAX_ESI {0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff}
+#define ESI_LEN 10
+
+#define MAX_ET 0xffffffff
+u_long eth_tag_id;
+
+struct eth_segment_id
+{
+  u_char val[ESI_LEN];
+};
+
+#define MAC_LEN 6
+
+union gw_addr {
+  struct in_addr ipv4;
+  struct in6_addr ipv6;
+};
+
+extern int str2esi (const char *str, struct eth_segment_id *id);
+extern int str2mac (const char *str, char *mac);
+extern char *esi2str (struct eth_segment_id *id);
+extern char *mac2str (char *mac);
+extern char *ecom_mac2str(char *ecom_mac);
+
+#endif /* _QUAGGA_BGP_ATTR_EVPN_H */

--- a/bgpd/bgp_attr_evpn.h
+++ b/bgpd/bgp_attr_evpn.h
@@ -46,6 +46,12 @@ union gw_addr {
   struct in6_addr ipv6;
 };
 
+struct bgp_route_evpn
+{
+  struct eth_segment_id eth_s_id;
+  union gw_addr gw_ip;
+};
+
 extern int str2esi (const char *str, struct eth_segment_id *id);
 extern int str2mac (const char *str, char *mac);
 extern char *esi2str (struct eth_segment_id *id);

--- a/bgpd/bgp_attr_evpn.h
+++ b/bgpd/bgp_attr_evpn.h
@@ -60,5 +60,5 @@ extern char *mac2str (char *mac);
 extern char *ecom_mac2str(char *ecom_mac);
 
 extern void bgp_add_routermac_ecom (struct attr* attr, char * routermac);
-
+extern int bgp_build_evpn_prefix (int type, uint32_t eth_tag, struct prefix *dst);
 #endif /* _QUAGGA_BGP_ATTR_EVPN_H */

--- a/bgpd/bgp_attr_evpn.h
+++ b/bgpd/bgp_attr_evpn.h
@@ -33,6 +33,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 
 #define MAX_ET 0xffffffff
 u_long eth_tag_id;
+struct attr;
 
 struct eth_segment_id
 {
@@ -57,5 +58,7 @@ extern int str2mac (const char *str, char *mac);
 extern char *esi2str (struct eth_segment_id *id);
 extern char *mac2str (char *mac);
 extern char *ecom_mac2str(char *ecom_mac);
+
+extern void bgp_add_routermac_ecom (struct attr* attr, char * routermac);
 
 #endif /* _QUAGGA_BGP_ATTR_EVPN_H */

--- a/bgpd/bgp_clist.c
+++ b/bgpd/bgp_clist.c
@@ -862,14 +862,14 @@ extcommunity_list_set (struct community_list_handler *ch,
     }
 
   if (ecom)
-    ecom->str = ecommunity_ecom2str (ecom, ECOMMUNITY_FORMAT_DISPLAY);
+    ecom->str = ecommunity_ecom2str (ecom, ECOMMUNITY_FORMAT_DISPLAY, 0);
 
   entry = community_entry_new ();
   entry->direct = direct;
   entry->style = style;
   entry->any = (str ? 0 : 1);
   if (ecom)
-    entry->config = ecommunity_ecom2str (ecom, ECOMMUNITY_FORMAT_COMMUNITY_LIST);
+    entry->config = ecommunity_ecom2str (ecom, ECOMMUNITY_FORMAT_COMMUNITY_LIST, 0);
   else if (regex)
     entry->config = XSTRDUP (MTYPE_COMMUNITY_LIST_CONFIG, str);
   else

--- a/bgpd/bgp_debug.c
+++ b/bgpd/bgp_debug.c
@@ -38,6 +38,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgpd/bgp_debug.h"
 #include "bgpd/bgp_community.h"
 #include "bgpd/bgp_updgrp.h"
+#include "bgpd/bgp_mplsvpn.h"
 
 unsigned long conf_bgp_debug_as4;
 unsigned long conf_bgp_debug_neighbor_events;
@@ -2085,4 +2086,32 @@ bgp_debug_zebra (struct prefix *p)
     }
 
   return 0;
+}
+
+const char *
+bgp_debug_rdpfxpath2str (struct prefix_rd *prd, union prefixconstptr pu,
+                         int addpath_valid, u_int32_t addpath_id,
+                         char *str, int size)
+{
+  char rd_buf[RD_ADDRSTRLEN];
+  char pfx_buf[PREFIX_STRLEN];
+  char pathid_buf[20];
+
+  if (size < BGP_PRD_PATH_STRLEN)
+    return NULL;
+
+  /* Note: Path-id is created by default, but only included in update sometimes. */
+  pathid_buf[0] = '\0';
+  if (addpath_valid)
+    sprintf(pathid_buf, " with addpath ID %d", addpath_id);
+
+  if (prd)
+    snprintf (str, size, "RD %s %s%s",
+              prefix_rd2str(prd, rd_buf, sizeof (rd_buf)),
+              prefix2str (pu, pfx_buf, sizeof (pfx_buf)), pathid_buf);
+  else
+    snprintf (str, size, "%s%s",
+              prefix2str (pu, pfx_buf, sizeof (pfx_buf)), pathid_buf);
+
+  return str;
 }

--- a/bgpd/bgp_debug.h
+++ b/bgpd/bgp_debug.h
@@ -36,6 +36,9 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 /* dump detail */
 #define DUMP_DETAIL   32
 
+/* RD + Prefix + Path-Id */
+#define BGP_PRD_PATH_STRLEN (PREFIX_STRLEN + RD_ADDRSTRLEN + 20)
+
 extern int dump_open;
 extern int dump_update;
 extern int dump_keepalive;
@@ -151,4 +154,6 @@ extern int bgp_debug_bestpath(struct prefix *p);
 extern int bgp_debug_zebra(struct prefix *p);
 
 extern int bgp_debug_count(void);
+extern const char *bgp_debug_rdpfxpath2str (struct prefix_rd *, union prefixconstptr,
+                                            int, u_int32_t, char *, int);
 #endif /* _QUAGGA_BGP_DEBUG_H */

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -212,7 +212,7 @@ ecommunity_intern (struct ecommunity *ecom)
   find->refcnt++;
 
   if (! find->str)
-    find->str = ecommunity_ecom2str (find, ECOMMUNITY_FORMAT_DISPLAY, 0);
+    find->str = ecommunity_ecom2str (find, ECOMMUNITY_FORMAT_DISPLAY, ECOMMUNITY_ROUTE_TARGET);
 
   return find;
 }

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -790,3 +790,65 @@ ecommunity_match (const struct ecommunity *ecom1,
   else
     return 0;
 }
+
+/* return first occurence of type */
+extern struct ecommunity_val *ecommunity_lookup (const struct ecommunity *ecom, uint8_t type, uint8_t subtype)
+{
+  u_int8_t *p;
+  int c;
+  struct ecommunity_val *ecom_val;
+
+  /* If the value already exists in the structure return 0.  */
+  c = 0;
+  for (p = ecom->val; c < ecom->size; p += ECOMMUNITY_SIZE, c++)
+    {
+      if(p == NULL)
+        {
+          continue;
+        }
+      if(p[0] == type && p[1] == subtype)
+        return (struct ecommunity_val *)p;
+    }
+  return NULL;
+}
+
+/* remove ext. community matching type and subtype
+ * return 1 on success ( removed ), 0 otherwise (not present)
+ */
+extern int ecommunity_strip (struct ecommunity *ecom, uint8_t type, uint8_t subtype)
+{
+  u_int8_t *p;
+  int c, found = 0;
+  /* When this is fist value, just add it.  */
+  if (ecom == NULL || ecom->val == NULL)
+    {
+      return 0;
+    }
+
+  /* If the value already exists in the structure return 0.  */
+  c = 0;
+  for (p = ecom->val; c < ecom->size; p += ECOMMUNITY_SIZE, c++)
+    {
+      if (p[0] == type && p[1] == subtype)
+        {
+          found = 1;
+          break;
+        }
+    }
+  if (found == 0)
+    return 0;
+  /* Strip The selected value */
+  ecom->size--;
+  /* size is reduced. no memmove to do */
+  p = XMALLOC (MTYPE_ECOMMUNITY_VAL, ecom->size * ECOMMUNITY_SIZE);
+  if (c != 0)
+    memcpy(p, ecom->val, c * ECOMMUNITY_SIZE);
+  if( (ecom->size - c) != 0)
+    memcpy(p + (c) * ECOMMUNITY_SIZE,
+           ecom->val + (c +1)* ECOMMUNITY_SIZE,
+           (ecom->size - c) * ECOMMUNITY_SIZE);
+  /* shift last ecommunities */
+  XFREE (MTYPE_ECOMMUNITY, ecom->val);
+  ecom->val = p;
+  return 1;
+}

--- a/bgpd/bgp_ecommunity.c
+++ b/bgpd/bgp_ecommunity.c
@@ -174,7 +174,7 @@ char *
 ecommunity_str (struct ecommunity *ecom)
 {
   if (! ecom->str)
-    ecom->str = ecommunity_ecom2str (ecom, ECOMMUNITY_FORMAT_DISPLAY);
+    ecom->str = ecommunity_ecom2str (ecom, ECOMMUNITY_FORMAT_DISPLAY, 0);
   return ecom->str;
 }
 
@@ -212,7 +212,7 @@ ecommunity_intern (struct ecommunity *ecom)
   find->refcnt++;
 
   if (! find->str)
-    find->str = ecommunity_ecom2str (find, ECOMMUNITY_FORMAT_DISPLAY);
+    find->str = ecommunity_ecom2str (find, ECOMMUNITY_FORMAT_DISPLAY, 0);
 
   return find;
 }
@@ -600,9 +600,12 @@ ecommunity_str2com (const char *str, int type, int keyword_included)
    ECOMMUNITY_FORMAT_ROUTE_MAP
    ECOMMUNITY_FORMAT_COMMUNITY_LIST
    ECOMMUNITY_FORMAT_DISPLAY
+
+   Filter is added to display only ECOMMUNITY_ROUTE_TARGET in some cases. 
+   0 value displays all
 */
 char *
-ecommunity_ecom2str (struct ecommunity *ecom, int format)
+ecommunity_ecom2str (struct ecommunity *ecom, int format, int filter)
 {
   int i;
   u_int8_t *pnt;
@@ -667,6 +670,11 @@ ecommunity_ecom2str (struct ecommunity *ecom, int format)
           break;
 
         case ECOMMUNITY_ENCODE_OPAQUE:
+          if(filter == ECOMMUNITY_ROUTE_TARGET)
+            {
+              first = 0;
+              continue;
+            }
           if (*pnt == ECOMMUNITY_OPAQUE_SUBTYPE_ENCAP)
             {
               uint16_t tunneltype;
@@ -677,8 +685,32 @@ ecommunity_ecom2str (struct ecommunity *ecom, int format)
               first = 0;
               continue;
             }
-            /* fall through */
-
+          len = sprintf (str_buf + str_pnt, "?");
+          str_pnt += len;
+          first = 0;
+          continue;
+        case ECOMMUNITY_ENCODE_EVPN:
+          if(filter == ECOMMUNITY_ROUTE_TARGET)
+            {
+              first = 0;
+              continue;
+            }
+          if (*pnt == ECOMMUNITY_SITE_ORIGIN)
+            {
+              char macaddr[6];
+              pnt++;
+              memcpy(&macaddr, pnt, 6);
+              len = sprintf(str_buf + str_pnt, "EVPN:%02x:%02x:%02x:%02x:%02x:%02x",
+                            macaddr[0], macaddr[1], macaddr[2],
+                            macaddr[3], macaddr[4], macaddr[5]);
+              str_pnt += len;
+              first = 0;
+              continue;
+            }
+          len = sprintf (str_buf + str_pnt, "?");
+          str_pnt += len;
+          first = 0;
+          continue;
         default:
           len = sprintf (str_buf + str_pnt, "?");
           str_pnt += len;

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -31,6 +31,12 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #define ECOMMUNITY_ROUTE_TARGET             0x02
 #define ECOMMUNITY_SITE_ORIGIN              0x03
 
+#define ECOMMUNITY_EVPN_SUBTYPE_MACMOBILITY  0x00
+#define ECOMMUNITY_EVPN_SUBTYPE_ESI_LABEL    0x01
+#define ECOMMUNITY_EVPN_SUBTYPE_ES_IMPORT_RT 0x02
+#define ECOMMUNITY_EVPN_SUBTYPE_ROUTERMAC    0x03
+#define ECOMMUNITY_EVPN_SUBTYPE_DEF_GW       0x0d
+
 /* Low-order octet of the Extended Communities type field for OPAQUE types */
 #define ECOMMUNITY_OPAQUE_SUBTYPE_ENCAP     0x0c
 
@@ -84,8 +90,11 @@ extern struct ecommunity *ecommunity_str2com (const char *, int, int);
 extern char *ecommunity_ecom2str (struct ecommunity *, int);
 extern int ecommunity_match (const struct ecommunity *, const struct ecommunity *);
 extern char *ecommunity_str (struct ecommunity *);
+extern struct ecommunity_val *ecommunity_lookup (const struct ecommunity *, uint8_t, uint8_t );
 
 /* for vpn */
 extern struct ecommunity *ecommunity_new (void);
 extern int ecommunity_add_val (struct ecommunity *, struct ecommunity_val *);
+extern int ecommunity_strip (struct ecommunity *ecom, uint8_t type, uint8_t subtype);
+extern struct ecommunity *ecommunity_new (void);
 #endif /* _QUAGGA_BGP_ECOMMUNITY_H */

--- a/bgpd/bgp_ecommunity.h
+++ b/bgpd/bgp_ecommunity.h
@@ -26,6 +26,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #define ECOMMUNITY_ENCODE_IP                0x01
 #define ECOMMUNITY_ENCODE_AS4               0x02
 #define ECOMMUNITY_ENCODE_OPAQUE            0x03
+#define ECOMMUNITY_ENCODE_EVPN              0x06
 
 /* Low-order octet of the Extended Communities type field.  */
 #define ECOMMUNITY_ROUTE_TARGET             0x02
@@ -87,10 +88,11 @@ extern int ecommunity_cmp (const void *, const void *);
 extern void ecommunity_unintern (struct ecommunity **);
 extern unsigned int ecommunity_hash_make (void *);
 extern struct ecommunity *ecommunity_str2com (const char *, int, int);
-extern char *ecommunity_ecom2str (struct ecommunity *, int);
+extern char *ecommunity_ecom2str (struct ecommunity *, int, int);
 extern int ecommunity_match (const struct ecommunity *, const struct ecommunity *);
 extern char *ecommunity_str (struct ecommunity *);
 extern struct ecommunity_val *ecommunity_lookup (const struct ecommunity *, uint8_t, uint8_t );
+extern int ecommunity_add_val (struct ecommunity *ecom, struct ecommunity_val *eval);
 
 /* for vpn */
 extern struct ecommunity *ecommunity_new (void);

--- a/bgpd/bgp_encap.c
+++ b/bgpd/bgp_encap.c
@@ -332,22 +332,6 @@ show_adj_route_encap (struct vty *vty, struct peer *peer, struct prefix_rd *prd)
   return CMD_SUCCESS;
 }
 
-enum bgp_show_type
-{
-  bgp_show_type_normal,
-  bgp_show_type_regexp,
-  bgp_show_type_prefix_list,
-  bgp_show_type_filter_list,
-  bgp_show_type_neighbor,
-  bgp_show_type_cidr_only,
-  bgp_show_type_prefix_longer,
-  bgp_show_type_community_all,
-  bgp_show_type_community,
-  bgp_show_type_community_exact,
-  bgp_show_type_community_list,
-  bgp_show_type_community_list_exact
-};
-
 static int
 bgp_show_encap (
     struct vty *vty,

--- a/bgpd/bgp_encap.c
+++ b/bgpd/bgp_encap.c
@@ -226,7 +226,8 @@ DEFUN (encap_network,
   int idx_ipv4 = 1;
   int idx_rd = 3;
   int idx_word = 5;
-  return bgp_static_set_safi (SAFI_ENCAP, vty, argv[idx_ipv4]->arg, argv[idx_rd]->arg, argv[idx_word]->arg, NULL);
+  return bgp_static_set_safi (SAFI_ENCAP, vty, argv[idx_ipv4]->arg, argv[idx_rd]->arg, argv[idx_word]->arg,
+                              NULL, 0, NULL, NULL, NULL, NULL);
 }
 
 /* For testing purpose, static route of ENCAP. */
@@ -244,7 +245,8 @@ DEFUN (no_encap_network,
   int idx_ipv4 = 2;
   int idx_rd = 4;
   int idx_word = 6;
-  return bgp_static_unset_safi (SAFI_ENCAP, vty, argv[idx_ipv4]->arg, argv[idx_rd]->arg, argv[idx_word]->arg);
+  return bgp_static_unset_safi (SAFI_ENCAP, vty, argv[idx_ipv4]->arg, argv[idx_rd]->arg, argv[idx_word]->arg,
+                                0, NULL, NULL, NULL);
 }
 
 static int

--- a/bgpd/bgp_encap.c
+++ b/bgpd/bgp_encap.c
@@ -187,7 +187,7 @@ bgp_nlri_parse_encap(
 
       if (attr) {
 	bgp_update (peer, &p, 0, attr, afi, SAFI_ENCAP,
-		    ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, NULL, 0);
+		    ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, NULL, 0, NULL);
 #if ENABLE_BGP_VNC
 	rfapiProcessUpdate(peer, NULL, &p, &prd, attr, afi, SAFI_ENCAP,
                            ZEBRA_ROUTE_BGP,  BGP_ROUTE_NORMAL, NULL);
@@ -198,7 +198,7 @@ bgp_nlri_parse_encap(
                              ZEBRA_ROUTE_BGP, 0);
 #endif
 	bgp_withdraw (peer, &p, 0, attr, afi, SAFI_ENCAP,
-		      ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, NULL);
+		      ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, NULL, NULL);
       }
     }
 

--- a/bgpd/bgp_encap_types.h
+++ b/bgpd/bgp_encap_types.h
@@ -167,10 +167,15 @@ struct bgp_encap_type_mpls_in_ip_tunnel_with_ipsec_transport_mode {
     struct bgp_tea_subtlv_remote_endpoint       st_endpoint;    /* optional */
 };
 
+#define VXLAN_ENCAP_MASK_VNID_VALID 0x80000000
+#define VXLAN_ENCAP_MASK_MAC_VALID  0x40000000
+
 struct bgp_encap_type_vxlan {
     uint32_t					valid_subtlvs;
     struct bgp_tea_subtlv_remote_endpoint       st_endpoint;    /* optional */
-    /* No subtlvs defined in spec? */
+    /* draft-ietf-idr-tunnel-encaps-02 */
+    uint32_t                                    vnid; /* does not include V and M bit */
+    uint8_t                                     *mac_address;   /* optional */
 };
 
 struct bgp_encap_type_nvgre {

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -59,8 +59,7 @@ bgp_nlri_parse_evpn (struct peer *peer, struct attr *attr,
 
 #if !defined(HAVE_EVPN)
   return -1;
-#endif /* HAVE_EVPN */
-
+#else
   p_evpn_p = &p.u.prefix_evpn;
   pnt = packet->nlri;
   lim = pnt + packet->length;
@@ -183,7 +182,7 @@ bgp_nlri_parse_evpn (struct peer *peer, struct attr *attr,
   /* Packet length consistency check. */
   if (pnt != lim)
     return -1;
-
+#endif /* !(HAVE_EVPN) */
   return 0;
 }
 
@@ -192,6 +191,7 @@ bgp_packet_mpattr_route_type_5 (struct stream *s,
                                 struct prefix *p, struct prefix_rd *prd,
                                 u_char *label, struct attr *attr)
 {
+#if defined(HAVE_EVPN)
   int len;
   char temp[16];
   struct evpn_addr *p_evpn_p;
@@ -236,4 +236,5 @@ bgp_packet_mpattr_route_type_5 (struct stream *s,
   else
     stream_put3 (s, 0);
   return;
+#endif /* (HAVE_EVPN) */
 }

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -186,3 +186,54 @@ bgp_nlri_parse_evpn (struct peer *peer, struct attr *attr,
 
   return 0;
 }
+
+void
+bgp_packet_mpattr_route_type_5 (struct stream *s,
+                                struct prefix *p, struct prefix_rd *prd,
+                                u_char *label, struct attr *attr)
+{
+  int len;
+  char temp[16];
+  struct evpn_addr *p_evpn_p;
+
+  memset(&temp, 0, 16);
+  if(p->family != AF_ETHERNET)
+    return;
+  p_evpn_p = &(p->u.prefix_evpn);
+  if (p_evpn_p->flags & IP_PREFIX_V4)
+    len = 8; /* ipv4 */
+  else
+    len = 32; /* ipv6 */
+  stream_putc (s, EVPN_IP_PREFIX);
+  stream_putc (s, 8 /* RD */ + 10 /* ESI */  + 4 /* EthTag */ + 1 + len + 3 /* label */);
+  stream_put (s, prd->val, 8);
+  if(attr && attr->extra)
+    stream_put (s, &(attr->extra->evpn_overlay.eth_s_id), 10);
+  else
+    stream_put (s, &temp, 10);
+  stream_putl (s, p_evpn_p->eth_tag);
+  stream_putc (s, p_evpn_p->ip_prefix_length);
+  if (p_evpn_p->flags & IP_PREFIX_V4)
+    stream_put_ipv4(s, p_evpn_p->ip.v4_addr.s_addr);
+  else
+    stream_put(s, &p_evpn_p->ip.v6_addr, 16);
+  if(attr && attr->extra)
+    {
+      if (p_evpn_p->flags & IP_PREFIX_V4)
+        stream_put_ipv4(s, attr->extra->evpn_overlay.gw_ip.ipv4.s_addr);
+      else
+        stream_put(s, &(attr->extra->evpn_overlay.gw_ip.ipv6), 16);
+    }
+  else
+    {
+      if (p_evpn_p->flags & IP_PREFIX_V4)
+        stream_put_ipv4(s, 0);
+      else
+        stream_put(s, &temp, 16);
+    }
+  if(label)
+    stream_put (s, label, 3);
+  else
+    stream_put3 (s, 0);
+  return;
+}

--- a/bgpd/bgp_evpn.c
+++ b/bgpd/bgp_evpn.c
@@ -1,0 +1,188 @@
+/* Ethernet-VPN Packet and vty Processing File
+   Copyright (C) 2016 6WIND
+
+This file is part of GNU Quagga
+
+GNU Zebra is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation; either version 2, or (at your option) any
+later version.
+
+GNU Zebra is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GNU Zebra; see the file COPYING.  If not, write to the Free
+Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+02111-1307, USA.  */
+
+#include <zebra.h>
+
+#include "command.h"
+#include "filter.h"
+#include "prefix.h"
+#include "log.h"
+#include "memory.h"
+#include "stream.h"
+
+#include "bgpd/bgp_attr_evpn.h"
+#include "bgpd/bgpd.h"
+#include "bgpd/bgp_table.h"
+#include "bgpd/bgp_route.h"
+#include "bgpd/bgp_attr.h"
+#include "bgpd/bgp_mplsvpn.h"
+#include "bgpd/bgp_evpn.h"
+
+int
+bgp_nlri_parse_evpn (struct peer *peer, struct attr *attr,
+                     struct bgp_nlri *packet, int withdraw)
+{
+  u_char *pnt;
+  u_char *lim;
+  struct prefix p;
+  struct prefix_rd prd;
+  struct evpn_addr *p_evpn_p;
+  struct bgp_route_evpn evpn;
+  uint8_t route_type, route_length;
+  u_char *pnt_label;
+  u_int32_t addpath_id = 0;
+
+  /* Check peer status. */
+  if (peer->status != Established)
+    return 0;
+  
+  /* Make prefix_rd */
+  prd.family = AF_UNSPEC;
+  prd.prefixlen = 64;
+
+#if !defined(HAVE_EVPN)
+  return -1;
+#endif /* HAVE_EVPN */
+
+  p_evpn_p = &p.u.prefix_evpn;
+  pnt = packet->nlri;
+  lim = pnt + packet->length;
+  while (pnt < lim)
+    {
+      /* clear evpn structure */
+      memset (&evpn, 0, sizeof (evpn));
+
+      /* Clear prefix structure. */
+      memset (&p, 0, sizeof (struct prefix));
+      memset(&evpn.gw_ip, 0, sizeof(union gw_addr));
+      memset(&evpn.eth_s_id, 0, sizeof(struct eth_segment_id));
+
+      /* Fetch Route Type */ 
+      route_type = *pnt++;
+      route_length = *pnt++;
+      /* simply ignore. goto next route type if any */
+      if(route_type != EVPN_IP_PREFIX)
+	{
+	  if (pnt + route_length > lim)
+	    {
+	      zlog_err ("not enough bytes for New Route Type left in NLRI?");
+	      return -1;
+	    }
+	  pnt += route_length;
+	  continue;
+	}
+
+      /* Fetch RD */
+      if (pnt + 8 > lim)
+        {
+          zlog_err ("not enough bytes for RD left in NLRI?");
+          return -1;
+        }
+
+      /* Copy routing distinguisher to rd. */
+      memcpy (&prd.val, pnt, 8);
+      pnt += 8;
+
+      /* Fetch ESI */
+      if (pnt + 10 > lim)
+        {
+          zlog_err ("not enough bytes for ESI left in NLRI?");
+          return -1;
+        }
+      memcpy(&evpn.eth_s_id.val, pnt, 10);
+      pnt += 10;
+
+      /* Fetch Ethernet Tag */
+      if (pnt + 4 > lim)
+        {
+          zlog_err ("not enough bytes for Eth Tag left in NLRI?");
+          return -1;
+        }
+
+      if (route_type == EVPN_IP_PREFIX)
+        {
+          p_evpn_p->route_type = route_type;
+          memcpy (&(p_evpn_p->eth_tag), pnt, 4);
+          p_evpn_p->eth_tag = ntohl(p_evpn_p->eth_tag);
+          pnt += 4;
+
+           /* Fetch IP prefix length. */
+          p_evpn_p->ip_prefix_length = *pnt++;
+
+          if (p_evpn_p->ip_prefix_length > 128)
+            {
+              zlog_err ("invalid prefixlen %d in EVPN NLRI?", p.prefixlen);
+              return -1;
+            }
+          /* determine IPv4 or IPv6 prefix */
+          if(route_length - 4 - 10 - 8 - 3 /* label to be read */ >= 32)
+            {
+              p_evpn_p->flags = IP_PREFIX_V6;
+              memcpy (&(p_evpn_p->ip.v4_addr), pnt, 16);
+              pnt += 16;
+              memcpy(&evpn.gw_ip.ipv6, pnt, 16);
+              pnt += 16;
+            }
+          else
+            {
+              p_evpn_p->flags = IP_PREFIX_V4;
+              memcpy (&(p_evpn_p->ip.v4_addr), pnt, 4);
+              pnt += 4;
+              memcpy(&evpn.gw_ip.ipv4, pnt, 4);
+              pnt += 4;
+            }
+          p.family = AFI_L2VPN;
+          if (p_evpn_p->flags == IP_PREFIX_V4)
+            p.prefixlen = (u_char)PREFIX_LEN_ROUTE_TYPE_5_IPV4;
+          else
+            p.prefixlen = PREFIX_LEN_ROUTE_TYPE_5_IPV6;
+          p.family = AF_ETHERNET;
+        }
+
+      /* Fetch Label */
+      if (pnt + 3 > lim)
+        {
+          zlog_err ("not enough bytes for Label left in NLRI?");
+          return -1;
+        }
+      pnt_label = pnt;
+      
+      pnt += 3;
+
+      if (!withdraw)
+        {
+          bgp_update (peer, &p, addpath_id, attr, AFI_L2VPN, SAFI_EVPN,
+                      ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd,
+                      pnt_label, 0, &evpn);
+        }
+      else
+        {
+          bgp_withdraw (peer, &p, addpath_id, attr, AFI_L2VPN, SAFI_EVPN,
+                        ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
+                        &prd, pnt_label, &evpn);
+        }
+    }
+
+  /* Packet length consistency check. */
+  if (pnt != lim)
+    return -1;
+
+  return 0;
+}

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -1,0 +1,36 @@
+/* E-VPN header for packet handling
+   Copyright (C) 2016 6WIND
+
+This file is part of GNU Quagga.
+
+GNU Quagga is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation; either version 2, or (at your option) any
+later version.
+
+GNU Quagga is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GNU Quagga; see the file COPYING.  If not, write to the Free
+Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+02111-1307, USA.  */
+
+#ifndef _QUAGGA_BGP_EVPN_H
+#define _QUAGGA_BGP_EVPN_H
+
+extern int bgp_nlri_parse_evpn (struct peer *peer, struct attr *attr,
+                                struct bgp_nlri *packet, int withdraw);
+
+/* EVPN route types as per RFC7432 and
+ * as per draft-ietf-bess-evpn-prefix-advertisement-02
+ */
+#define EVPN_ETHERNET_AUTO_DISCOVERY 1
+#define EVPN_MACIP_ADVERTISEMENT 2
+#define EVPN_INCLUSIVE_MULTICAST_ETHERNET_TAG 3
+#define EVPN_ETHERNET_SEGMENT 4
+#define EVPN_IP_PREFIX 5
+
+#endif /* _QUAGGA_BGP_EVPN_H */

--- a/bgpd/bgp_evpn.h
+++ b/bgpd/bgp_evpn.h
@@ -24,6 +24,10 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 extern int bgp_nlri_parse_evpn (struct peer *peer, struct attr *attr,
                                 struct bgp_nlri *packet, int withdraw);
 
+extern void
+bgp_packet_mpattr_route_type_5 (struct stream *s,
+                                struct prefix *p, struct prefix_rd *prd,
+                                u_char *label, struct attr *attr);
 /* EVPN route types as per RFC7432 and
  * as per draft-ietf-bess-evpn-prefix-advertisement-02
  */

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -30,6 +30,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgpd/bgp_mplsvpn.h"
 #include "bgpd/bgp_vpn.h"
 #include "bgpd/bgp_evpn_vty.h"
+#include "bgpd/bgp_evpn.h"
 
 #define SHOW_DISPLAY_STANDARD 0
 #define SHOW_DISPLAY_TAGS 1
@@ -577,6 +578,71 @@ DEFUN (show_ip_bgp_evpn_rd_overlay,
                                 SHOW_DISPLAY_OVERLAY, use_json (argc, argv));
 }
 
+/* For testing purpose, static route of MPLS-VPN. */
+DEFUN (evpnrt5_network,
+       evpnrt5_network_cmd,
+       "network <A.B.C.D/M|X:X::X:X/M> rd ASN:nn_or_IP-address:nn ethtag WORD label WORD esi WORD gwip <A.B.C.D|X:X::X:X> routermac WORD [route-map WORD]",
+       "Specify a network to announce via BGP\n"
+       "IP prefix\n"
+       "IPv6 prefix\n"
+       "Specify Route Distinguisher\n"
+       "VPN Route Distinguisher\n"
+       "Ethernet Tag\n"
+       "Ethernet Tag Value\n"
+       "BGP label\n"
+       "label value\n"
+       "Ethernet Segment Identifier\n"
+       "ESI value ( 00:11:22:33:44:55:66:77:88:99 format) \n"
+       "Gateway IP\n"
+       "Gateway IP ( A.B.C.D )\n"
+       "Gateway IPv6 ( X:X::X:X )\n"
+       "Router Mac Ext Comm\n"
+       "Router Mac address Value ( aa:bb:cc:dd:ee:ff format)\n")
+{
+  int idx_ipv4_prefixlen = 1;
+  int idx_ext_community = 3;
+  int idx_word = 7;
+  int idx_esi = 9;
+  int idx_gwip = 11;
+  int idx_ethtag = 5;
+  int idx_routermac = 13;
+  int idx_rmap = 15;
+  return bgp_static_set_safi (SAFI_EVPN, vty, argv[idx_ipv4_prefixlen]->arg, argv[idx_ext_community]->arg, 
+                              argv[idx_word]->arg, argv[idx_rmap]?argv[idx_gwip]->arg:NULL,
+                              EVPN_IP_PREFIX, argv[idx_esi]->arg, argv[idx_gwip]->arg,
+                              argv[idx_ethtag]->arg, argv[idx_routermac]->arg);
+}
+
+/* For testing purpose, static route of MPLS-VPN. */
+DEFUN (no_evpnrt5_network,
+       no_evpnrt5_network_cmd,
+       "no network <A.B.C.D/M|X:X::X:X/M> rd ASN:nn_or_IP-address:nn ethtag WORD label WORD esi WORD gwip <A.B.C.D|X:X::X:X>",
+       NO_STR
+       "Specify a network to announce via BGP\n"
+       "IP prefix\n"
+       "IPv6 prefix\n"
+       "Specify Route Distinguisher\n"
+       "VPN Route Distinguisher\n"
+       "Ethernet Tag\n"
+       "Ethernet Tag Value\n"
+       "BGP label\n"
+       "label value\n"
+       "Ethernet Segment Identifier\n"
+       "ESI value ( 00:11:22:33:44:55:66:77:88:99 format) \n"
+       "Gateway IP\n"
+       "Gateway IP ( A.B.C.D )\n"
+       "Gateway IPv6 ( X:X::X:X )\n")
+{
+  int idx_ipv4_prefixlen = 2;
+  int idx_ext_community = 4;
+  int idx_label = 8;
+  int idx_ethtag = 6;
+  int idx_esi = 10;
+  int idx_gwip = 12;
+  return bgp_static_unset_safi (SAFI_EVPN, vty, argv[idx_ipv4_prefixlen]->arg, argv[idx_ext_community]->arg, argv[idx_label]->arg,
+                                EVPN_IP_PREFIX, argv[idx_esi]->arg, argv[idx_gwip]->arg, argv[idx_ethtag]->arg);
+}
+
 
 void
 bgp_ethernetvpn_init (void)
@@ -591,4 +657,6 @@ bgp_ethernetvpn_init (void)
   install_element (VIEW_NODE, &show_ip_bgp_l2vpn_evpn_rd_neighbor_advertised_routes_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_evpn_rd_overlay_cmd);
   install_element (VIEW_NODE, &show_ip_bgp_l2vpn_evpn_all_overlay_cmd);
+  install_element (BGP_EVPN_NODE, &no_evpnrt5_network_cmd);
+  install_element (BGP_EVPN_NODE, &evpnrt5_network_cmd);
 }

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -1,0 +1,597 @@
+/* Ethernet-VPN Packet and vty Processing File
+   Copyright (C) 2017 6WIND
+
+This file is part of Free Range Routing
+
+Free Range Routing is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation; either version 2, or (at your option) any
+later version.
+
+Free Range Routing is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Free Range Routing; see the file COPYING.  If not, write to the Free
+Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+02111-1307, USA.  */
+
+#include <zebra.h>
+#include "command.h"
+#include "prefix.h"
+#include "lib/json.h"
+
+#include "bgpd/bgpd.h"
+#include "bgpd/bgp_table.h"
+#include "bgpd/bgp_attr.h"
+#include "bgpd/bgp_route.h"
+#include "bgpd/bgp_mplsvpn.h"
+#include "bgpd/bgp_vpn.h"
+#include "bgpd/bgp_evpn_vty.h"
+
+#define L2VPN_HELP_STR        "Layer 2 Virtual Private Network\n"
+#define EVPN_HELP_STR        "Ethernet Virtual Private Network\n"
+
+#define SHOW_DISPLAY_STANDARD 0
+#define SHOW_DISPLAY_TAGS 1
+#define SHOW_DISPLAY_OVERLAY 2
+
+static int
+bgp_show_ethernet_vpn (struct vty *vty, struct prefix_rd *prd, enum bgp_show_type type,
+		   void *output_arg, int option, u_char use_json)
+{
+  afi_t afi = AFI_L2VPN;
+  struct bgp *bgp;
+  struct bgp_table *table;
+  struct bgp_node *rn;
+  struct bgp_node *rm;
+  struct bgp_info *ri;
+  int rd_header;
+  int header = 1;
+  char v4_header[] = "   Network          Next Hop            Metric LocPrf Weight Path%s";
+  char v4_header_tag[] = "   Network          Next Hop      In tag/Out tag%s";
+  char v4_header_overlay[] = "   Network          Next Hop      EthTag    Overlay Index   RouterMac%s";
+
+  unsigned long output_count = 0;
+  unsigned long total_count  = 0;
+  json_object *json = NULL;
+  json_object *json_nroute = NULL;
+  json_object *json_array = NULL;
+  json_object *json_scode = NULL;
+  json_object *json_ocode = NULL;
+
+  bgp = bgp_get_default ();
+  if (bgp == NULL)
+    {
+      if (!use_json)
+        vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  if (use_json)
+    {
+      json_scode = json_object_new_object();
+      json_ocode = json_object_new_object();
+      json = json_object_new_object();
+      json_nroute = json_object_new_object();
+
+      json_object_string_add(json_scode, "suppressed", "s");
+      json_object_string_add(json_scode, "damped", "d");
+      json_object_string_add(json_scode, "history", "h");
+      json_object_string_add(json_scode, "valid", "*");
+      json_object_string_add(json_scode, "best", ">");
+      json_object_string_add(json_scode, "internal", "i");
+
+      json_object_string_add(json_ocode, "igp", "i");
+      json_object_string_add(json_ocode, "egp", "e");
+      json_object_string_add(json_ocode, "incomplete", "?");
+    }
+
+  for (rn = bgp_table_top (bgp->rib[afi][SAFI_EVPN]); rn; rn = bgp_route_next (rn))
+    {
+      if (use_json)
+        continue; /* XXX json TODO */
+
+      if (prd && memcmp (rn->p.u.val, prd->val, 8) != 0)
+	continue;
+
+      if ((table = rn->info) != NULL)
+	{
+	  rd_header = 1;
+
+	  for (rm = bgp_table_top (table); rm; rm = bgp_route_next (rm))
+	    for (ri = rm->info; ri; ri = ri->next)
+	      {
+                total_count++;
+		if (type == bgp_show_type_neighbor)
+		  {
+		    union sockunion *su = output_arg;
+
+		    if (ri->peer->su_remote == NULL || ! sockunion_same(ri->peer->su_remote, su))
+		      continue;
+		  }
+                if (header == 0)
+                  {
+                    if (use_json)
+                      {
+                        if (option == SHOW_DISPLAY_TAGS)
+                          {
+                            json_object_int_add(json, "bgpTableVersion", 0);
+                            json_object_string_add(json, "bgpLocalRouterId", inet_ntoa (bgp->router_id));
+                            json_object_object_add(json, "bgpStatusCodes", json_scode);
+                            json_object_object_add(json, "bgpOriginCodes", json_ocode);
+                          }
+                      }
+                    else
+                      {
+                        if (option == SHOW_DISPLAY_TAGS)
+                          vty_out (vty, v4_header_tag, VTY_NEWLINE);
+                        else if (option == SHOW_DISPLAY_OVERLAY)
+                          vty_out (vty, v4_header_overlay, VTY_NEWLINE);
+                        else
+                          {
+                            vty_out (vty, "BGP table version is 0, local router ID is %s%s",
+                                     inet_ntoa (bgp->router_id), VTY_NEWLINE);
+                            vty_out (vty, "Status codes: s suppressed, d damped, h history, * valid, > best, i - internal%s",
+                                     VTY_NEWLINE);
+                            vty_out (vty, "Origin codes: i - IGP, e - EGP, ? - incomplete%s%s",
+                                     VTY_NEWLINE, VTY_NEWLINE);
+                            vty_out (vty, v4_header, VTY_NEWLINE);
+                          }
+                      }
+                    header = 0;
+                  }
+                if (rd_header)
+                  {
+                    u_int16_t type;
+                    struct rd_as rd_as;
+                    struct rd_ip rd_ip;
+                    u_char *pnt;
+
+                    pnt = rn->p.u.val;
+
+                    /* Decode RD type. */
+                    type = decode_rd_type (pnt);
+                    /* Decode RD value. */
+                    if (type == RD_TYPE_AS)
+                      decode_rd_as (pnt + 2, &rd_as);
+                    else if (type == RD_TYPE_AS4)
+                      decode_rd_as4 (pnt + 2, &rd_as);
+                    else if (type == RD_TYPE_IP)
+                      decode_rd_ip (pnt + 2, &rd_ip);
+                    if (use_json)
+                      {
+                        char buffer[BUFSIZ];
+                        if (type == RD_TYPE_AS || type == RD_TYPE_AS4)
+                          sprintf (buffer, "%u:%d", rd_as.as, rd_as.val);
+                        else if (type == RD_TYPE_IP)
+                          sprintf (buffer, "%s:%d", inet_ntoa (rd_ip.ip), rd_ip.val);
+                        json_object_string_add(json_nroute, "routeDistinguisher", buffer);
+                      }
+                    else
+                      {
+                        vty_out (vty, "Route Distinguisher: ");
+                        if (type == RD_TYPE_AS)
+                          vty_out (vty, "as2 %u:%d", rd_as.as, rd_as.val);
+                        else if (type == RD_TYPE_AS4)
+                          vty_out (vty, "as4 %u:%d", rd_as.as, rd_as.val);
+                        else if (type == RD_TYPE_IP)
+                          vty_out (vty, "ip %s:%d", inet_ntoa (rd_ip.ip), rd_ip.val);
+                        vty_out (vty, "%s", VTY_NEWLINE);
+                      }
+                    rd_header = 0;
+                  }
+                if (use_json)
+                  json_array = json_object_new_array();
+                else
+                  json_array = NULL;
+                if (option == SHOW_DISPLAY_TAGS)
+                  route_vty_out_tag (vty, &rm->p, ri, 0, SAFI_EVPN, json_array);
+                else if (option == SHOW_DISPLAY_OVERLAY)
+                  route_vty_out_overlay (vty, &rm->p, ri, 0, json_array);
+                else
+                  route_vty_out (vty, &rm->p, ri, 0, SAFI_EVPN, json_array);
+                output_count++;
+              }
+          /* XXX json */
+        }
+    }
+  if (output_count == 0)
+    vty_out (vty, "No prefixes displayed, %ld exist%s", total_count, VTY_NEWLINE);
+  else
+    vty_out (vty, "%sDisplayed %ld out of %ld total prefixes%s",
+             VTY_NEWLINE, output_count, total_count, VTY_NEWLINE);
+  return CMD_SUCCESS;
+}
+
+DEFUN (show_ip_bgp_l2vpn_evpn,
+       show_ip_bgp_l2vpn_evpn_cmd,
+       "show [ip] bgp l2vpn evpn [json]",
+       SHOW_STR
+       IP_STR
+       BGP_STR
+       L2VPN_HELP_STR
+       EVPN_HELP_STR
+       JSON_STR)
+{
+  return bgp_show_ethernet_vpn (vty, NULL, bgp_show_type_normal, NULL, 0, use_json (argc, argv));
+}
+
+DEFUN (show_ip_bgp_l2vpn_evpn_rd,
+       show_ip_bgp_l2vpn_evpn_rd_cmd,
+       "show [ip] bgp l2vpn evpn rd ASN:nn_or_IP-address:nn [json]",
+       SHOW_STR
+       IP_STR
+       BGP_STR
+       L2VPN_HELP_STR
+       EVPN_HELP_STR
+       "Display information for a route distinguisher\n"
+       "VPN Route Distinguisher\n"
+       JSON_STR)
+{
+  int idx_ext_community = 6;
+  int ret;
+  struct prefix_rd prd;
+
+  ret = str2prefix_rd (argv[idx_ext_community]->arg, &prd);
+  if (! ret)
+    {
+      vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  return bgp_show_ethernet_vpn (vty, &prd, bgp_show_type_normal, NULL, 0, use_json (argc, argv));
+}
+
+DEFUN (show_ip_bgp_l2vpn_evpn_all_tags,
+       show_ip_bgp_l2vpn_evpn_all_tags_cmd,
+       "show [ip] bgp l2vpn evpn all tags",
+       SHOW_STR
+       IP_STR
+       BGP_STR
+       L2VPN_HELP_STR
+       EVPN_HELP_STR
+       "Display information about all EVPN NLRIs\n"
+       "Display BGP tags for prefixes\n")
+{
+  return bgp_show_ethernet_vpn (vty, NULL, bgp_show_type_normal, NULL,  1, 0);
+}
+
+DEFUN (show_ip_bgp_l2vpn_evpn_rd_tags,
+       show_ip_bgp_l2vpn_evpn_rd_tags_cmd,
+       "show [ip] bgp l2vpn evpn rd ASN:nn_or_IP-address:nn tags",
+       SHOW_STR
+       IP_STR
+       BGP_STR
+       L2VPN_HELP_STR
+       EVPN_HELP_STR
+       "Display information for a route distinguisher\n"
+       "VPN Route Distinguisher\n"
+       "Display BGP tags for prefixes\n")
+{
+  int idx_ext_community = 6;
+  int ret;
+  struct prefix_rd prd;
+
+  ret = str2prefix_rd (argv[idx_ext_community]->arg, &prd);
+  if (! ret)
+    {
+      vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  return bgp_show_ethernet_vpn (vty,&prd, bgp_show_type_normal, NULL, 1, 0);
+}
+
+DEFUN (show_ip_bgp_l2vpn_evpn_all_neighbor_routes,
+       show_ip_bgp_l2vpn_evpn_all_neighbor_routes_cmd,
+       "show [ip] bgp l2vpn evpn all neighbors A.B.C.D routes [json]",
+       SHOW_STR
+       IP_STR
+       BGP_STR
+       L2VPN_HELP_STR
+       EVPN_HELP_STR
+       "Display information about all EVPN NLRIs\n"
+       "Detailed information on TCP and BGP neighbor connections\n"
+       "Neighbor to display information about\n"
+       "Display routes learned from neighbor\n"
+       JSON_STR)
+{
+  int idx_ipv4 = 6;
+  union sockunion su;
+  struct peer *peer;
+  int ret;
+  u_char uj = use_json(argc, argv);
+
+  ret = str2sockunion (argv[idx_ipv4]->arg, &su);
+  if (ret < 0)
+    {
+      if (uj)
+        {
+          json_object *json_no = NULL;
+          json_no = json_object_new_object();
+          json_object_string_add(json_no, "warning", "Malformed address");
+          vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+          json_object_free(json_no);
+        }
+      else
+        vty_out (vty, "Malformed address: %s%s", argv[idx_ipv4]->arg, VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  peer = peer_lookup (NULL, &su);
+  if (! peer || ! peer->afc[AFI_L2VPN][SAFI_EVPN])
+    {
+      if (uj)
+        {
+          json_object *json_no = NULL;
+          json_no = json_object_new_object();
+          json_object_string_add(json_no, "warning", "No such neighbor or address family");
+          vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+          json_object_free(json_no);
+        }
+      else
+        vty_out (vty, "%% No such neighbor or address family%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  return bgp_show_ethernet_vpn (vty, NULL, bgp_show_type_neighbor, &su, 0, uj);
+}
+
+DEFUN (show_ip_bgp_l2vpn_evpn_rd_neighbor_routes,
+       show_ip_bgp_l2vpn_evpn_rd_neighbor_routes_cmd,
+       "show [ip] bgp l2vpn evpn rd ASN:nn_or_IP-address:nn neighbors A.B.C.D routes [json]",
+       SHOW_STR
+       IP_STR
+       BGP_STR
+       L2VPN_HELP_STR
+       EVPN_HELP_STR
+       "Display information for a route distinguisher\n"
+       "VPN Route Distinguisher\n"
+       "Detailed information on TCP and BGP neighbor connections\n"
+       "Neighbor to display information about\n"
+       "Display routes learned from neighbor\n"
+       JSON_STR)
+{
+  int idx_ext_community = 6;
+  int idx_ipv4 = 8;
+  int ret;
+  union sockunion su;
+  struct peer *peer;
+  struct prefix_rd prd;
+  u_char uj = use_json(argc, argv);
+
+  ret = str2prefix_rd (argv[idx_ext_community]->arg, &prd);
+  if (! ret)
+    {
+      if (uj)
+        {
+          json_object *json_no = NULL;
+          json_no = json_object_new_object();
+          json_object_string_add(json_no, "warning", "Malformed Route Distinguisher");
+          vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+          json_object_free(json_no);
+        }
+      else
+        vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  ret = str2sockunion (argv[idx_ipv4]->arg, &su);
+  if (ret < 0)
+    {
+      if (uj)
+        {
+          json_object *json_no = NULL;
+          json_no = json_object_new_object();
+          json_object_string_add(json_no, "warning", "Malformed address");
+          vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+          json_object_free(json_no);
+        }
+      else
+        vty_out (vty, "Malformed address: %s%s", argv[idx_ext_community]->arg, VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  peer = peer_lookup (NULL, &su);
+  if (! peer || ! peer->afc[AFI_L2VPN][SAFI_EVPN])
+    {
+      if (uj)
+        {
+          json_object *json_no = NULL;
+          json_no = json_object_new_object();
+          json_object_string_add(json_no, "warning", "No such neighbor or address family");
+          vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+          json_object_free(json_no);
+        }
+      else
+        vty_out (vty, "%% No such neighbor or address family%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  return bgp_show_ethernet_vpn (vty, &prd, bgp_show_type_neighbor, &su, 0, uj);
+}
+
+DEFUN (show_ip_bgp_l2vpn_evpn_all_neighbor_advertised_routes,
+       show_ip_bgp_l2vpn_evpn_all_neighbor_advertised_routes_cmd,
+       "show [ip] bgp l2vpn evpn all neighbors A.B.C.D advertised-routes [json]",
+       SHOW_STR
+       IP_STR
+       BGP_STR
+       L2VPN_HELP_STR
+       EVPN_HELP_STR
+       "Display information about all EVPN NLRIs\n"
+       "Detailed information on TCP and BGP neighbor connections\n"
+       "Neighbor to display information about\n"
+       "Display the routes advertised to a BGP neighbor\n"
+       JSON_STR)
+{
+  int idx_ipv4 = 7;
+  int ret;
+  struct peer *peer;
+  union sockunion su;
+  u_char uj = use_json(argc, argv);
+
+  ret = str2sockunion (argv[idx_ipv4]->arg, &su);
+  if (ret < 0)
+    {
+      if (uj)
+        {
+          json_object *json_no = NULL;
+          json_no = json_object_new_object();
+          json_object_string_add(json_no, "warning", "Malformed address");
+          vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+          json_object_free(json_no);
+        }
+      else
+        vty_out (vty, "Malformed address: %s%s", argv[idx_ipv4]->arg, VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  peer = peer_lookup (NULL, &su);
+  if (! peer || ! peer->afc[AFI_L2VPN][SAFI_EVPN])
+    {
+      if (uj)
+        {
+          json_object *json_no = NULL;
+          json_no = json_object_new_object();
+          json_object_string_add(json_no, "warning", "No such neighbor or address family");
+          vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+          json_object_free(json_no);
+        }
+      else
+        vty_out (vty, "%% No such neighbor or address family%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  return show_adj_route_vpn (vty, peer, NULL, AFI_L2VPN, SAFI_EVPN, uj);
+}
+
+DEFUN (show_ip_bgp_l2vpn_evpn_rd_neighbor_advertised_routes,
+       show_ip_bgp_l2vpn_evpn_rd_neighbor_advertised_routes_cmd,
+       "show [ip] bgp l2vpn evpn rd ASN:nn_or_IP-address:nn neighbors A.B.C.D advertised-routes [json]",
+       SHOW_STR
+       IP_STR
+       BGP_STR
+       L2VPN_HELP_STR
+       EVPN_HELP_STR
+       "Display information for a route distinguisher\n"
+       "VPN Route Distinguisher\n"
+       "Detailed information on TCP and BGP neighbor connections\n"
+       "Neighbor to display information about\n"
+       "Display the routes advertised to a BGP neighbor\n"
+       JSON_STR)
+{
+  int idx_ext_community = 6;
+  int idx_ipv4 = 8;
+  int ret;
+  struct peer *peer;
+  struct prefix_rd prd;
+  union sockunion su;
+  u_char uj = use_json(argc, argv);
+
+  ret = str2sockunion (argv[idx_ipv4]->arg, &su);
+  if (ret < 0)
+    {
+      if (uj)
+        {
+          json_object *json_no = NULL;
+          json_no = json_object_new_object();
+          json_object_string_add(json_no, "warning", "Malformed address");
+          vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+          json_object_free(json_no);
+        }
+      else
+        vty_out (vty, "Malformed address: %s%s", argv[idx_ext_community]->arg, VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  peer = peer_lookup (NULL, &su);
+  if (! peer || ! peer->afc[AFI_L2VPN][SAFI_EVPN])
+    {
+      if (uj)
+        {
+          json_object *json_no = NULL;
+          json_no = json_object_new_object();
+          json_object_string_add(json_no, "warning", "No such neighbor or address family");
+          vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+          json_object_free(json_no);
+        }
+      else
+        vty_out (vty, "%% No such neighbor or address family%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  ret = str2prefix_rd (argv[idx_ext_community]->arg, &prd);
+  if (! ret)
+    {
+      if (uj)
+        {
+          json_object *json_no = NULL;
+          json_no = json_object_new_object();
+          json_object_string_add(json_no, "warning", "Malformed Route Distinguisher");
+          vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
+          json_object_free(json_no);
+        }
+      else
+        vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  return show_adj_route_vpn (vty, peer, &prd, AFI_L2VPN, SAFI_EVPN, uj);
+}
+
+DEFUN (show_ip_bgp_l2vpn_evpn_all_overlay,
+       show_ip_bgp_l2vpn_evpn_all_overlay_cmd,
+       "show [ip] bgp l2vpn evpn all overlay",
+       SHOW_STR
+       IP_STR
+       BGP_STR
+       L2VPN_HELP_STR
+       EVPN_HELP_STR
+       "Display information about all EVPN NLRIs\n"
+       "Display BGP Overlay Information for prefixes\n")
+{
+  return bgp_show_ethernet_vpn (vty, NULL, bgp_show_type_normal, NULL,
+                                SHOW_DISPLAY_OVERLAY, use_json (argc, argv));
+}
+
+DEFUN (show_ip_bgp_evpn_rd_overlay,
+       show_ip_bgp_evpn_rd_overlay_cmd,
+       "show [ip] bgp l2vpn evpn rd ASN:nn_or_IP-address:nn overlay",
+       SHOW_STR
+       IP_STR
+       BGP_STR
+       L2VPN_HELP_STR
+       EVPN_HELP_STR
+       "Display information for a route distinguisher\n"
+       "VPN Route Distinguisher\n"
+       "Display BGP Overlay Information for prefixes\n")
+{
+  int idx_ext_community = 6;
+  int ret;
+  struct prefix_rd prd;
+
+  ret = str2prefix_rd (argv[idx_ext_community]->arg, &prd);
+  if (! ret)
+    {
+      vty_out (vty, "%% Malformed Route Distinguisher%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+  return bgp_show_ethernet_vpn (vty, &prd, bgp_show_type_normal, NULL,
+                                SHOW_DISPLAY_OVERLAY, use_json (argc, argv));
+}
+
+
+void
+bgp_ethernetvpn_init (void)
+{
+  install_element (VIEW_NODE, &show_ip_bgp_l2vpn_evpn_cmd);
+  install_element (VIEW_NODE, &show_ip_bgp_l2vpn_evpn_rd_cmd);
+  install_element (VIEW_NODE, &show_ip_bgp_l2vpn_evpn_all_tags_cmd);
+  install_element (VIEW_NODE, &show_ip_bgp_l2vpn_evpn_rd_tags_cmd);
+  install_element (VIEW_NODE, &show_ip_bgp_l2vpn_evpn_all_neighbor_routes_cmd);
+  install_element (VIEW_NODE, &show_ip_bgp_l2vpn_evpn_rd_neighbor_routes_cmd);
+  install_element (VIEW_NODE, &show_ip_bgp_l2vpn_evpn_all_neighbor_advertised_routes_cmd);
+  install_element (VIEW_NODE, &show_ip_bgp_l2vpn_evpn_rd_neighbor_advertised_routes_cmd);
+  install_element (VIEW_NODE, &show_ip_bgp_evpn_rd_overlay_cmd);
+  install_element (VIEW_NODE, &show_ip_bgp_l2vpn_evpn_all_overlay_cmd);
+}

--- a/bgpd/bgp_evpn_vty.c
+++ b/bgpd/bgp_evpn_vty.c
@@ -31,9 +31,6 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgpd/bgp_vpn.h"
 #include "bgpd/bgp_evpn_vty.h"
 
-#define L2VPN_HELP_STR        "Layer 2 Virtual Private Network\n"
-#define EVPN_HELP_STR        "Ethernet Virtual Private Network\n"
-
 #define SHOW_DISPLAY_STANDARD 0
 #define SHOW_DISPLAY_TAGS 1
 #define SHOW_DISPLAY_OVERLAY 2

--- a/bgpd/bgp_evpn_vty.h
+++ b/bgpd/bgp_evpn_vty.h
@@ -1,0 +1,27 @@
+/* EVPN VTY functions to EVPN
+   Copyright (C) 2017 6WIND
+
+This file is part of Free Range Routing.
+
+Free Range Routing is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation; either version 2, or (at your option) any
+later version.
+
+Free Range Routing is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Free Range Routing; see the file COPYING.  If not, write to the Free
+Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+02111-1307, USA.  */
+
+#ifndef _FRR_BGP_EVPN_VTY_H
+#define _FRR_BGP_EVPN_VTY_H
+
+extern void
+bgp_ethernetvpn_init (void);
+
+#endif /* _QUAGGA_BGP_EVPN_VTY_H */

--- a/bgpd/bgp_evpn_vty.h
+++ b/bgpd/bgp_evpn_vty.h
@@ -24,4 +24,8 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 extern void
 bgp_ethernetvpn_init (void);
 
+#define L2VPN_HELP_STR        "Layer 2 Virtual Private Network\n"
+#define EVPN_HELP_STR        "Ethernet Virtual Private Network\n"
+
+
 #endif /* _QUAGGA_BGP_EVPN_VTY_H */

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -295,7 +295,7 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
       if (attr)
         {
 	bgp_update (peer, &p, addpath_id, attr, packet->afi, SAFI_MPLS_VPN,
-		    ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, tagpnt, 0);
+		    ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, tagpnt, 0, NULL);
 #if ENABLE_BGP_VNC
           rfapiProcessUpdate(peer, NULL, &p, &prd, attr, packet->afi, 
                              SAFI_MPLS_VPN, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
@@ -309,8 +309,8 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
                                SAFI_MPLS_VPN, ZEBRA_ROUTE_BGP, 0);
 #endif
 	bgp_withdraw (peer, &p, addpath_id, attr, packet->afi, SAFI_MPLS_VPN,
-		      ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, tagpnt);
-    }
+		      ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, tagpnt, NULL);
+        }
     }
   /* Packet length consistency check. */
   if (pnt != lim)

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -487,7 +487,8 @@ DEFUN (vpnv4_network,
   int idx_ipv4_prefixlen = 1;
   int idx_ext_community = 3;
   int idx_word = 5;
-  return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv4_prefixlen]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, NULL);
+  return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv4_prefixlen]->arg, argv[idx_ext_community]->arg,
+                              argv[idx_word]->arg, NULL, 0, NULL, NULL, NULL, NULL);
 }
 
 DEFUN (vpnv4_network_route_map,
@@ -506,7 +507,8 @@ DEFUN (vpnv4_network_route_map,
   int idx_ext_community = 3;
   int idx_word = 5;
   int idx_word_2 = 7;
-  return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv4_prefixlen]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, argv[idx_word_2]->arg);
+  return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv4_prefixlen]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg,
+                              argv[idx_word_2]->arg, 0, NULL, NULL, NULL, NULL);
 }
 
 /* For testing purpose, static route of MPLS-VPN. */
@@ -524,7 +526,9 @@ DEFUN (no_vpnv4_network,
   int idx_ipv4_prefixlen = 2;
   int idx_ext_community = 4;
   int idx_word = 6;
-  return bgp_static_unset_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv4_prefixlen]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg);
+  return bgp_static_unset_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv4_prefixlen]->arg,
+                                argv[idx_ext_community]->arg, argv[idx_word]->arg,
+                                0, NULL, NULL, NULL);
 }
 
 DEFUN (vpnv6_network,
@@ -544,9 +548,9 @@ DEFUN (vpnv6_network,
   int idx_word = 5;
   int idx_word_2 = 7;
   if (argv[idx_word_2])
-    return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, argv[idx_word_2]->arg);
+    return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, argv[idx_word_2]->arg, 0, NULL, NULL, NULL, NULL);
   else
-    return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, NULL);
+    return bgp_static_set_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, NULL, 0, NULL, NULL, NULL, NULL);
 }
 
 /* For testing purpose, static route of MPLS-VPN. */
@@ -564,7 +568,7 @@ DEFUN (no_vpnv6_network,
   int idx_ipv6_prefix = 2;
   int idx_ext_community = 4;
   int idx_word = 6;
-  return bgp_static_unset_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg);
+  return bgp_static_unset_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg, 0, NULL, NULL, NULL);
 }
 
 static int

--- a/bgpd/bgp_mplsvpn.h
+++ b/bgpd/bgp_mplsvpn.h
@@ -92,7 +92,8 @@ extern void decode_rd_as (u_char *, struct rd_as *);
 extern void decode_rd_as4 (u_char *, struct rd_as *);
 extern void decode_rd_ip (u_char *, struct rd_ip *);
 #if ENABLE_BGP_VNC
-extern void decode_vnc_eth (u_char *, struct rd_vnc_eth *);
+extern void
+decode_rd_vnc_eth (u_char *pnt, struct rd_vnc_eth *rd_vnc_eth);
 #endif
 extern int str2prefix_rd (const char *, struct prefix_rd *);
 extern int str2tag (const char *, u_char *);

--- a/bgpd/bgp_open.c
+++ b/bgpd/bgp_open.c
@@ -93,6 +93,9 @@ bgp_capability_vty_out (struct vty *vty, struct peer *peer, u_char use_json, jso
                   case AFI_IP6:
                     json_object_string_add(json_cap, "capabilityErrorMultiProtocolAfi", "IPv6");
                   break;
+                  case AFI_L2VPN:
+                    json_object_string_add(json_cap, "capabilityErrorMultiProtocolAfi", "L2VPN");
+                  break;
                   default:
                     json_object_int_add(json_cap, "capabilityErrorMultiProtocolAfiUnknown", ntohs (mpc.afi));
                   break;
@@ -111,6 +114,9 @@ bgp_capability_vty_out (struct vty *vty, struct peer *peer, u_char use_json, jso
                   case SAFI_ENCAP:
                     json_object_string_add(json_cap, "capabilityErrorMultiProtocolSafi", "encap");
                   break;
+                  case SAFI_EVPN:
+                    json_object_string_add(json_cap, "capabilityErrorMultiProtocolSafi", "EVPN");
+                  break;
                   default:
                     json_object_int_add(json_cap, "capabilityErrorMultiProtocolSafiUnknown", mpc.safi);
                   break;
@@ -126,6 +132,9 @@ bgp_capability_vty_out (struct vty *vty, struct peer *peer, u_char use_json, jso
                   break;
                   case AFI_IP6:
                     vty_out (vty, "AFI IPv6, ");
+                  break;
+                  case AFI_L2VPN:
+                    vty_out (vty, "AFI L2VPN, ");
                   break;
                   default:
                     vty_out (vty, "AFI Unknown %d, ", ntohs (mpc.afi));
@@ -144,6 +153,9 @@ bgp_capability_vty_out (struct vty *vty, struct peer *peer, u_char use_json, jso
                   break;
                   case SAFI_ENCAP:
                     vty_out (vty, "SAFI ENCAP");
+                  break;
+                  case SAFI_EVPN:
+                    vty_out (vty, "SAFI EVPN");
                   break;
                   default:
                     vty_out (vty, "SAFI Unknown %d ", mpc.safi);
@@ -1131,7 +1143,8 @@ bgp_open_option_parse (struct peer *peer, u_char length, int *mp_capability)
 	  && ! peer->afc_nego[AFI_IP6][SAFI_UNICAST]
 	  && ! peer->afc_nego[AFI_IP6][SAFI_MULTICAST]
 	  && ! peer->afc_nego[AFI_IP6][SAFI_MPLS_VPN]
-	  && ! peer->afc_nego[AFI_IP6][SAFI_ENCAP])
+	  && ! peer->afc_nego[AFI_IP6][SAFI_ENCAP]
+	  && ! peer->afc_nego[AFI_L2VPN][SAFI_EVPN])
 	{
 	  zlog_err ("%s [Error] Configured AFI/SAFIs do not "
 		    "overlap with received MP capabilities",

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -50,6 +50,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgpd/bgp_mplsvpn.h"
 #include "bgpd/bgp_evpn.h"
 #include "bgpd/bgp_encap.h"
+#include "bgpd/bgp_evpn.h"
 #include "bgpd/bgp_advertise.h"
 #include "bgpd/bgp_vty.h"
 #include "bgpd/bgp_updgrp.h"

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -48,6 +48,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgpd/bgp_ecommunity.h"
 #include "bgpd/bgp_network.h"
 #include "bgpd/bgp_mplsvpn.h"
+#include "bgpd/bgp_evpn.h"
 #include "bgpd/bgp_encap.h"
 #include "bgpd/bgp_advertise.h"
 #include "bgpd/bgp_vty.h"
@@ -1530,11 +1531,17 @@ bgp_update_receive (struct peer *peer, bgp_size_t size)
         {
           case NLRI_UPDATE:
           case NLRI_MP_UPDATE:
-            nlri_ret = bgp_nlri_parse (peer, NLRI_ATTR_ARG, &nlris[i]);
+            if (nlris[i].afi == AFI_L2VPN && nlris[i].safi == SAFI_EVPN)
+              nlri_ret = bgp_nlri_parse_evpn (peer, NLRI_ATTR_ARG, &nlris[i], 0);
+            else
+              nlri_ret = bgp_nlri_parse (peer, NLRI_ATTR_ARG, &nlris[i]);
             break;
           case NLRI_WITHDRAW:
           case NLRI_MP_WITHDRAW:
-            nlri_ret = bgp_nlri_parse (peer, NULL, &nlris[i]);
+            if (nlris[i].afi == AFI_L2VPN && nlris[i].safi == SAFI_EVPN)
+              nlri_ret = bgp_nlri_parse_evpn (peer, &attr, &nlris[i], 1);
+            else
+              nlri_ret = bgp_nlri_parse (peer, NULL, &nlris[i]);
             break;
           default:
             nlri_ret = -1;

--- a/bgpd/bgp_packet.c
+++ b/bgpd/bgp_packet.c
@@ -245,13 +245,13 @@ bgp_write_packet (struct peer *peer)
 		if (!(PAF_SUBGRP(paf))->t_coalesce &&
 		    peer->afc_nego[afi][safi] && peer->synctime
 		    && ! CHECK_FLAG (peer->af_sflags[afi][safi],
-				     PEER_STATUS_EOR_SEND))
+				     PEER_STATUS_EOR_SEND)
+                    && safi != SAFI_EVPN)
 		  {
 		    SET_FLAG (peer->af_sflags[afi][safi],
 			      PEER_STATUS_EOR_SEND);
 		    return bgp_update_packet_eor (peer, afi, safi);
 		  }
-
 	      }
 	    continue;
 	  }

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3952,6 +3952,14 @@ bgp_static_update_safi (struct bgp *bgp, struct prefix *p,
   attr.med = bgp_static->igpmetric;
   attr.flag |= ATTR_FLAG_BIT (BGP_ATTR_MULTI_EXIT_DISC);
 
+  if ((safi == SAFI_EVPN) || (safi == SAFI_MPLS_VPN) || (safi == SAFI_ENCAP))
+    {
+      if (bgp_static->igpnexthop.s_addr)
+        {
+          bgp_attr_extra_get (&attr)->mp_nexthop_global_in = bgp_static->igpnexthop;
+          bgp_attr_extra_get (&attr)->mp_nexthop_len = IPV4_MAX_BYTELEN;
+        }
+    }
   if(afi == AFI_L2VPN)
     {
       if (bgp_static->gatewayIp.family == AF_INET)

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -4083,7 +4083,6 @@ bgp_static_update_safi (struct bgp *bgp, struct prefix *p,
 
   /* Register new BGP information. */
   bgp_info_add (rn, new);
-
   /* route_node_get lock */
   bgp_unlock_node (rn);
 
@@ -6425,8 +6424,9 @@ route_vty_out_tag (struct vty *vty, struct prefix *p,
   attr = binfo->attr;
   if (attr) 
     {
-      if (p->family == AF_INET
-          && (safi == SAFI_MPLS_VPN || !BGP_ATTR_NEXTHOP_AFI_IP6(attr)))
+      if (((p->family == AF_INET) && ((safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP)))
+          || (safi == SAFI_EVPN && p->family == AF_ETHERNET && !BGP_ATTR_NEXTHOP_AFI_IP6(attr))
+          || (!BGP_ATTR_NEXTHOP_AFI_IP6(attr)))
 	{
 	  if (safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP || safi == SAFI_EVPN)
             {
@@ -6443,7 +6443,9 @@ route_vty_out_tag (struct vty *vty, struct prefix *p,
                 vty_out (vty, "%-16s", inet_ntoa (attr->nexthop));
             }
 	}
-      else if (p->family == AF_INET6 || BGP_ATTR_NEXTHOP_AFI_IP6(attr))
+      else if (((p->family == AF_INET6) && ((safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP)))
+               || (safi == SAFI_EVPN && p->family == AF_ETHERNET && BGP_ATTR_NEXTHOP_AFI_IP6(attr))
+               || (BGP_ATTR_NEXTHOP_AFI_IP6(attr)))
 	{
 	  assert (attr->extra);
 	  char buf_a[BUFSIZ];

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -9365,7 +9365,27 @@ DEFUN (show_ip_bgp_vpn_all_route_prefix,
 }
 #endif /* KEEP_OLD_VPN_COMMANDS */
 
-static void
+DEFUN (show_ip_bgp_l2vpn_evpn_all_route_prefix,
+       show_ip_bgp_l2vpn_evpn_all_route_prefix_cmd,
+       "show [ip] bgp l2vpn evpn all <A.B.C.D|A.B.C.D/M> [json]",
+       SHOW_STR
+       IP_STR
+       BGP_STR
+       L2VPN_HELP_STR
+       EVPN_HELP_STR
+       "Display information about all EVPN NLRIs\n"
+       "Network in the BGP routing table to display\n"
+       "Network in the BGP routing table to display\n"
+       JSON_STR)
+{
+  int idx = 0;
+  char *network = NULL;
+  network = argv_find (argv, argc, "A.B.C.D", &idx) ? argv[idx]->arg : NULL;
+  network = argv_find (argv, argc, "A.B.C.D/M", &idx) ? argv[idx]->arg : NULL;
+  return bgp_show_route (vty, NULL, network, AFI_L2VPN, SAFI_EVPN, NULL, 0, BGP_PATH_ALL, use_json(argc, argv));
+}
+
+ static void
 show_adj_route (struct vty *vty, struct peer *peer, afi_t afi, safi_t safi,
                 int in, const char *rmap_name, u_char use_json, json_object *json)
 {
@@ -10704,7 +10724,8 @@ bgp_route_init (void)
 #ifdef KEEP_OLD_VPN_COMMANDS
   install_element (VIEW_NODE, &show_ip_bgp_vpn_all_route_prefix_cmd);
 #endif /* KEEP_OLD_VPN_COMMANDS */
-
+  install_element (VIEW_NODE, &show_ip_bgp_l2vpn_evpn_all_route_prefix_cmd);
+  
  /* BGP dampening clear commands */
   install_element (ENABLE_NODE, &clear_ip_bgp_dampening_cmd);
   install_element (ENABLE_NODE, &clear_ip_bgp_dampening_prefix_cmd);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -7304,27 +7304,6 @@ route_vty_out_detail (struct vty *vty, struct bgp *bgp, struct prefix *p,
 #define BGP_SHOW_DAMP_HEADER "   Network          From             Reuse    Path%s"
 #define BGP_SHOW_FLAP_HEADER "   Network          From            Flaps Duration Reuse    Path%s"
 
-enum bgp_show_type
-{
-  bgp_show_type_normal,
-  bgp_show_type_regexp,
-  bgp_show_type_prefix_list,
-  bgp_show_type_filter_list,
-  bgp_show_type_route_map,
-  bgp_show_type_neighbor,
-  bgp_show_type_cidr_only,
-  bgp_show_type_prefix_longer,
-  bgp_show_type_community_all,
-  bgp_show_type_community,
-  bgp_show_type_community_exact,
-  bgp_show_type_community_list,
-  bgp_show_type_community_list_exact,
-  bgp_show_type_flap_statistics,
-  bgp_show_type_flap_neighbor,
-  bgp_show_type_dampend_paths,
-  bgp_show_type_damp_neighbor
-};
-
 static int
 bgp_show_prefix_list (struct vty *vty, const char *name,
                       const char *prefix_list_str, afi_t afi,

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2338,7 +2338,7 @@ int
 bgp_update (struct peer *peer, struct prefix *p, u_int32_t addpath_id,
             struct attr *attr, afi_t afi, safi_t safi, int type,
             int sub_type, struct prefix_rd *prd, u_char *tag,
-            int soft_reconfig)
+            int soft_reconfig, struct bgp_route_evpn* evpn)
 {
   int ret;
   int aspath_loop_count = 0;
@@ -2807,7 +2807,7 @@ bgp_update (struct peer *peer, struct prefix *p, u_int32_t addpath_id,
 int
 bgp_withdraw (struct peer *peer, struct prefix *p, u_int32_t addpath_id,
               struct attr *attr, afi_t afi, safi_t safi, int type, int sub_type,
-	      struct prefix_rd *prd, u_char *tag)
+	      struct prefix_rd *prd, u_char *tag, struct bgp_route_evpn *evpn)
 {
   struct bgp *bgp;
   char buf[SU_ADDRSTRLEN];
@@ -2998,7 +2998,7 @@ bgp_soft_reconfig_table (struct peer *peer, afi_t afi, safi_t safi,
 
 	    ret = bgp_update (peer, &rn->p, ain->addpath_rx_id, ain->attr,
                               afi, safi, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
-			      prd, tag, 1);
+			      prd, tag, 1, NULL);
 
 	    if (ret < 0)
 	      {
@@ -3564,10 +3564,10 @@ bgp_nlri_parse_ip (struct peer *peer, struct attr *attr,
       /* Normal process. */
       if (attr)
 	ret = bgp_update (peer, &p, addpath_id, attr, afi, safi,
-			  ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, NULL, NULL, 0);
+			  ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, NULL, NULL, 0, NULL);
       else
 	ret = bgp_withdraw (peer, &p, addpath_id, attr, afi, safi,
-			    ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, NULL, NULL);
+			    ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, NULL, NULL, NULL);
 
       /* Address family configuration mismatch or maximum-prefix count
          overflow. */

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -65,7 +65,10 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgpd/rfapi/vnc_import_bgp.h"
 #include "bgpd/rfapi/vnc_export_bgp.h"
 #endif
+#include "bgpd/bgp_encap_types.h"
+#include "bgpd/bgp_encap_tlv.h"
 #include "bgpd/bgp_evpn.h"
+
 
 /* Extern from bgp_dump.c */
 extern const char *bgp_origin_str[];
@@ -3948,7 +3951,16 @@ bgp_static_update_safi (struct bgp *bgp, struct prefix *p,
   attr.flag |= ATTR_FLAG_BIT (BGP_ATTR_MULTI_EXIT_DISC);
 
   if(afi == AFI_L2VPN)
+    {
       overlay_index_update(&attr, bgp_static->eth_s_id, NULL);
+      if (bgp_static->encap_tunneltype == BGP_ENCAP_TYPE_VXLAN)
+        {
+          struct bgp_encap_type_vxlan bet;
+          memset(&bet, 0, sizeof(struct bgp_encap_type_vxlan));
+          bet.vnid = p->u.prefix_evpn.eth_tag;
+          bgp_encap_type_vxlan_to_tlv(&bet, &attr);
+        }
+    }
   /* Apply route-map. */
   if (bgp_static->rmap.name)
     {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3965,6 +3965,10 @@ bgp_static_update_safi (struct bgp *bgp, struct prefix *p,
           bet.vnid = p->u.prefix_evpn.eth_tag;
           bgp_encap_type_vxlan_to_tlv(&bet, &attr);
         }
+      if (bgp_static->router_mac)
+        {
+          bgp_add_routermac_ecom (&attr, bgp_static->router_mac);
+        }
     }
   /* Apply route-map. */
   if (bgp_static->rmap.name)

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3939,6 +3939,7 @@ bgp_static_update_safi (struct bgp *bgp, struct prefix *p,
 #if ENABLE_BGP_VNC
   u_int32_t        label = 0;
 #endif
+  union gw_addr add;
 
   assert (bgp_static);
 
@@ -3952,7 +3953,11 @@ bgp_static_update_safi (struct bgp *bgp, struct prefix *p,
 
   if(afi == AFI_L2VPN)
     {
-      overlay_index_update(&attr, bgp_static->eth_s_id, NULL);
+      if (bgp_static->gatewayIp.family == AF_INET)
+        add.ipv4.s_addr = bgp_static->gatewayIp.u.prefix4.s_addr;
+      else if (bgp_static->gatewayIp.family == AF_INET6)
+        memcpy( &(add.ipv6), &(bgp_static->gatewayIp.u.prefix6), sizeof (struct in6_addr));
+      overlay_index_update(&attr, bgp_static->eth_s_id, &add);
       if (bgp_static->encap_tunneltype == BGP_ENCAP_TYPE_VXLAN)
         {
           struct bgp_encap_type_vxlan bet;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5832,6 +5832,11 @@ route_vty_out_route (struct prefix *p, struct vty *vty)
       else
         len += vty_out (vty, "/%d", p->prefixlen);
     }
+  else if (p->family == AF_ETHERNET)
+    {
+      prefix2str(p, buf, PREFIX_STRLEN);
+      len = vty_out (vty, "%s", buf);
+    }
   else
     len = vty_out (vty, "%s/%d", inet_ntop (p->family, &p->u.prefix, buf, BUFSIZ),
 		   p->prefixlen);
@@ -7743,11 +7748,15 @@ route_vty_out_detail_header (struct vty *vty, struct bgp *bgp,
     }
   else
     {
+      if (p->family == AF_ETHERNET)
+        prefix2str (p, buf2, INET6_ADDRSTRLEN);
+      else
+        inet_ntop (p->family, &p->u.prefix, buf2, INET6_ADDRSTRLEN);
       vty_out (vty, "BGP routing table entry for %s%s%s/%d%s",
 	       ((safi == SAFI_MPLS_VPN || safi == SAFI_ENCAP || safi == SAFI_EVPN) ?
 	       prefix_rd2str (prd, buf1, RD_ADDRSTRLEN) : ""),
 	       ((safi == SAFI_MPLS_VPN) || (safi == SAFI_EVPN)) ? ":" : "",
-	       inet_ntop (p->family, &p->u.prefix, buf2, INET6_ADDRSTRLEN),
+	       buf2,
 	       p->prefixlen, VTY_NEWLINE);
     }
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -3940,7 +3940,9 @@ bgp_static_update_safi (struct bgp *bgp, struct prefix *p,
 #if ENABLE_BGP_VNC
   u_int32_t        label = 0;
 #endif
+#if defined(HAVE_EVPN)
   union gw_addr add;
+#endif /* (HAVE_EVPN) */
 
   assert (bgp_static);
 
@@ -3960,6 +3962,7 @@ bgp_static_update_safi (struct bgp *bgp, struct prefix *p,
           bgp_attr_extra_get (&attr)->mp_nexthop_len = IPV4_MAX_BYTELEN;
         }
     }
+#if defined(HAVE_EVPN)
   if(afi == AFI_L2VPN)
     {
       if (bgp_static->gatewayIp.family == AF_INET)
@@ -3979,6 +3982,7 @@ bgp_static_update_safi (struct bgp *bgp, struct prefix *p,
           bgp_add_routermac_ecom (&attr, bgp_static->router_mac);
         }
     }
+#endif /* (HAVE_EVPN) */
   /* Apply route-map. */
   if (bgp_static->rmap.name)
     {
@@ -4441,6 +4445,7 @@ bgp_static_set_safi (safi_t safi, struct vty *vty, const char *ip_str,
     {
       encode_label (0, tag);
     }
+#if defined (HAVE_EVPN)
   if (safi == SAFI_EVPN)
     {
       if( esi && str2esi (esi, NULL) == 0)
@@ -4470,6 +4475,7 @@ bgp_static_set_safi (safi_t safi, struct vty *vty, const char *ip_str,
             }
         }
     }
+#endif /* (HAVE_EVPN) */
   prn = bgp_node_get (bgp->route[afi][safi],
 			(struct prefix *)&prd);
   if (prn->info == NULL)
@@ -6553,6 +6559,7 @@ route_vty_out_overlay (struct vty *vty, struct prefix *p,
 
   if(attr->extra)
     {
+#if defined (HAVE_EVPN)
       struct eth_segment_id *id = &(attr->extra->evpn_overlay.eth_s_id);
       char *str = esi2str(id);
       vty_out (vty, "%s", str);
@@ -6567,6 +6574,7 @@ route_vty_out_overlay (struct vty *vty, struct prefix *p,
                    inet_ntop (AF_INET6, &(attr->extra->evpn_overlay.gw_ip.ipv6),
                               buf, BUFSIZ));
 	}
+#endif /* (HAVE_EVPN) */
       if(attr->extra->ecommunity)
         {
           char *mac = NULL;
@@ -10626,9 +10634,11 @@ bgp_config_write_network_evpn (struct vty *vty, struct bgp *bgp,
             inet_ntop (AF_INET, &bgp_static->igpnexthop, buf2, SU_ADDRSTRLEN);
 
             prefix2str (p, buf, sizeof (buf)),
+#if defined (HAVE_EVPN)
 	    vty_out (vty, " network %s rd %s ethtag %u tag %u esi %s gwip %s routermac %s",
 		     buf, rdbuf, p->u.prefix_evpn.eth_tag,
                      decode_label (bgp_static->tag), esi, buf2 , macrouter);
+#endif /*(HAVE_EVPN)*/
 	    vty_out (vty, "%s", VTY_NEWLINE);
 	  }
   return 0;

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6319,7 +6319,7 @@ route_vty_out_tag (struct vty *vty, struct prefix *p,
   json_object *json_out = NULL;
   struct attr *attr;
   u_int32_t label = 0;
-  
+
   if (!binfo->extra)
     return;
 
@@ -6409,9 +6409,96 @@ route_vty_out_tag (struct vty *vty, struct prefix *p,
   else
     {
       vty_out (vty, "notag/%d", label);
+
       vty_out (vty, "%s", VTY_NEWLINE);
     }
 }  
+
+void
+route_vty_out_overlay (struct vty *vty, struct prefix *p,
+                       struct bgp_info *binfo, int display, json_object *json_paths)
+{
+  struct attr *attr;
+  char buf[BUFSIZ];
+  json_object *json_path = NULL;
+
+  if (json_paths)
+    json_path = json_object_new_object();
+
+  if (!binfo->extra)
+    return;
+
+  /* short status lead text */
+  route_vty_short_status_out (vty, binfo, json_path);
+
+  /* print prefix and mask */
+  if (! display)
+    route_vty_out_route (p, vty);
+  else
+    vty_out (vty, "%*s", 17, " ");
+
+  /* Print attribute */
+  attr = binfo->attr;
+  if (attr)
+    {
+      if (attr->extra)
+        {
+          char	buf1[BUFSIZ];
+          int af = NEXTHOP_FAMILY(attr->extra->mp_nexthop_len);
+
+          switch (af) {
+          case AF_INET:
+            vty_out (vty, "%-16s", inet_ntop(af,
+                                             &attr->extra->mp_nexthop_global_in, buf, BUFSIZ));
+            break;
+          case AF_INET6:
+            vty_out (vty, "%s(%s)",
+                     inet_ntop (af,
+                                &attr->extra->mp_nexthop_global, buf, BUFSIZ),
+                     inet_ntop (af,
+                                &attr->extra->mp_nexthop_local, buf1, BUFSIZ));
+            break;
+          default:
+            vty_out(vty, "?");
+          }
+        } else {
+        vty_out(vty, "?");
+      }
+    }
+
+  if(attr->extra)
+    {
+      struct eth_segment_id *id = &(attr->extra->evpn_overlay.eth_s_id);
+      char *str = esi2str(id);
+      vty_out (vty, "%s", str);
+      free(str);
+      if (p->u.prefix_evpn.flags & IP_PREFIX_V4)
+	{
+          vty_out (vty, "/%s", inet_ntoa (attr->extra->evpn_overlay.gw_ip.ipv4));
+	}
+      else if (p->u.prefix_evpn.flags & IP_PREFIX_V6)
+	{
+          vty_out (vty, "/%s",
+                   inet_ntop (AF_INET6, &(attr->extra->evpn_overlay.gw_ip.ipv6),
+                              buf, BUFSIZ));
+	}
+      if(attr->extra->ecommunity)
+        {
+          char *mac = NULL;
+          struct ecommunity_val *routermac = ecommunity_lookup (attr->extra->ecommunity,
+                                                                ECOMMUNITY_ENCODE_EVPN,
+                                                                ECOMMUNITY_EVPN_SUBTYPE_ROUTERMAC);
+          if(routermac)
+            mac = ecom_mac2str((char *)routermac->val);
+          if(mac)
+            {
+              vty_out (vty, "/%s",(char *)mac);
+              free(mac);
+            }
+        }
+    }
+  vty_out (vty, "%s", VTY_NEWLINE);
+}
 
 /* dampening route */
 static void

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -183,6 +183,7 @@ struct bgp_static
   struct eth_segment_id *eth_s_id;
   char *router_mac;
   uint16_t   encap_tunneltype;
+  struct prefix gatewayIp;
 };
 
 #define BGP_NEXTHOP_AFI_FROM_NHLEN(nhlen) \

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -355,6 +355,9 @@ extern safi_t bgp_node_safi (struct vty *);
 extern void route_vty_out (struct vty *, struct prefix *, struct bgp_info *, int, safi_t, json_object *);
 extern void route_vty_out_tag (struct vty *, struct prefix *, struct bgp_info *, int, safi_t, json_object *);
 extern void route_vty_out_tmp (struct vty *, struct prefix *, struct attr *, safi_t, u_char, json_object *);
+extern void
+route_vty_out_overlay (struct vty *vty, struct prefix *p,
+                       struct bgp_info *binfo, int display, json_object *json);
 
 extern int
 subgroup_process_announce_selected (struct update_subgroup *subgrp,

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -316,10 +316,12 @@ extern void bgp_static_update (struct bgp *, struct prefix *, struct bgp_static 
 extern void bgp_static_withdraw (struct bgp *, struct prefix *, afi_t, safi_t);
                      
 extern int bgp_static_set_safi (safi_t safi, struct vty *vty, const char *,
-                          const char *, const char *, const char *);
+                                const char *, const char *, const char *,
+                                int, const char *, const char *, const char *, const char *);
 
 extern int bgp_static_unset_safi (safi_t safi, struct vty *, const char *,
-                            const char *, const char *);
+                                  const char *, const char *,
+                                  int, const char *, const char *, const char *);
 
 /* this is primarily for MPLS-VPN */
 extern int bgp_update (struct peer *, struct prefix *, u_int32_t, struct attr *,

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -182,6 +182,7 @@ struct bgp_static
   /* EVPN */
   struct eth_segment_id *eth_s_id;
   char *router_mac;
+  uint16_t   encap_tunneltype;
 };
 
 #define BGP_NEXTHOP_AFI_FROM_NHLEN(nhlen) \

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -178,6 +178,10 @@ struct bgp_static
 
   /* MPLS label.  */
   u_char tag[3];
+
+  /* EVPN */
+  struct eth_segment_id *eth_s_id;
+  char *router_mac;
 };
 
 #define BGP_NEXTHOP_AFI_FROM_NHLEN(nhlen) \

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -25,6 +25,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgp_table.h"
 
 struct bgp_nexthop_cache;
+struct bgp_route_evpn;
 
 #define BGP_SHOW_SCODE_HEADER "Status codes: s suppressed, d damped, "\
                               "h history, * valid, > best, = multipath,%s"\
@@ -294,10 +295,11 @@ extern int bgp_static_unset_safi (safi_t safi, struct vty *, const char *,
 
 /* this is primarily for MPLS-VPN */
 extern int bgp_update (struct peer *, struct prefix *, u_int32_t, struct attr *,
-		       afi_t, safi_t, int, int, struct prefix_rd *, 
-		       u_char *, int);
+		       afi_t, safi_t, int, int, struct prefix_rd *,
+		       u_char *, int, struct bgp_route_evpn *);
 extern int bgp_withdraw (struct peer *, struct prefix *, u_int32_t, struct attr *,
-			 afi_t, safi_t, int, int, struct prefix_rd *, u_char *);
+			 afi_t, safi_t, int, int, struct prefix_rd *, u_char *, 
+                         struct bgp_route_evpn *);
 
 /* for bgp_nexthop and bgp_damp */
 extern void bgp_process (struct bgp *, struct bgp_node *, afi_t, safi_t);

--- a/bgpd/bgp_route.h
+++ b/bgpd/bgp_route.h
@@ -27,6 +27,28 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 struct bgp_nexthop_cache;
 struct bgp_route_evpn;
 
+enum bgp_show_type
+{
+  bgp_show_type_normal,
+  bgp_show_type_regexp,
+  bgp_show_type_prefix_list,
+  bgp_show_type_filter_list,
+  bgp_show_type_route_map,
+  bgp_show_type_neighbor,
+  bgp_show_type_cidr_only,
+  bgp_show_type_prefix_longer,
+  bgp_show_type_community_all,
+  bgp_show_type_community,
+  bgp_show_type_community_exact,
+  bgp_show_type_community_list,
+  bgp_show_type_community_list_exact,
+  bgp_show_type_flap_statistics,
+  bgp_show_type_flap_neighbor,
+  bgp_show_type_dampend_paths,
+  bgp_show_type_damp_neighbor
+};
+
+
 #define BGP_SHOW_SCODE_HEADER "Status codes: s suppressed, d damped, "\
                               "h history, * valid, > best, = multipath,%s"\
                 "              i internal, r RIB-failure, S Stale, R Removed%s"

--- a/bgpd/bgp_updgrp_adv.c
+++ b/bgpd/bgp_updgrp_adv.c
@@ -605,6 +605,7 @@ subgroup_announce_table (struct update_subgroup *subgrp,
 
   if (safi != SAFI_MPLS_VPN
       && safi != SAFI_ENCAP
+      && safi != SAFI_EVPN
       && CHECK_FLAG (peer->af_flags[afi][safi], PEER_FLAG_DEFAULT_ORIGINATE))
     subgroup_default_originate (subgrp, 0);
 
@@ -668,7 +669,8 @@ subgroup_announce_route (struct update_subgroup *subgrp)
     return;
 
   if (SUBGRP_SAFI (subgrp) != SAFI_MPLS_VPN &&
-      SUBGRP_SAFI (subgrp) != SAFI_ENCAP)
+      SUBGRP_SAFI (subgrp) != SAFI_ENCAP &&
+      SUBGRP_SAFI (subgrp) != SAFI_EVPN)
     subgroup_announce_table (subgrp, NULL);
   else
     for (rn = bgp_table_top (update_subgroup_rib (subgrp)); rn;

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -53,6 +53,7 @@
 #include "bgpd/bgp_updgrp.h"
 #include "bgpd/bgp_nexthop.h"
 #include "bgpd/bgp_nht.h"
+#include "bgpd/bgp_mplsvpn.h"
 
 /********************
  * PRIVATE FUNCTIONS
@@ -617,6 +618,7 @@ static void
 bgp_info_addpath_tx_str (int addpath_encode, u_int32_t addpath_tx_id,
                          char *buf)
 {
+  buf[0] = '\0';
   if (addpath_encode)
     sprintf(buf, " with addpath ID %d", addpath_tx_id);
 }
@@ -648,6 +650,7 @@ subgroup_update_packet (struct update_subgroup *subgrp)
   int num_pfx = 0;
   int addpath_encode = 0;
   u_int32_t addpath_tx_id = 0;
+  struct prefix_rd *prd = NULL;
 
   if (!subgrp)
     return NULL;
@@ -751,7 +754,6 @@ subgroup_update_packet (struct update_subgroup *subgrp)
       else
 	{
 	  /* Encode the prefix in MP_REACH_NLRI attribute */
-	  struct prefix_rd *prd = NULL;
 	  u_char *tag = NULL;
 
 	  if (rn->prn)
@@ -772,8 +774,7 @@ subgroup_update_packet (struct update_subgroup *subgrp)
 
       if (bgp_debug_update(NULL, &rn->p, subgrp->update_group, 0))
 	{
-          char buf[INET6_BUFSIZ];
-          char tx_id_buf[30];
+          char pfx_buf[BGP_PRD_PATH_STRLEN];
 
           if (!send_attr_printed)
             {
@@ -782,11 +783,11 @@ subgroup_update_packet (struct update_subgroup *subgrp)
               send_attr_printed = 1;
             }
 
-          bgp_info_addpath_tx_str (addpath_encode, addpath_tx_id, tx_id_buf);
-          zlog_debug ("u%" PRIu64 ":s%" PRIu64 " send UPDATE %s/%d%s",
+          zlog_debug ("u%" PRIu64 ":s%" PRIu64 " send UPDATE %s",
                       subgrp->update_group->id, subgrp->id,
-                      inet_ntop (rn->p.family, &(rn->p.u.prefix), buf, INET6_BUFSIZ),
-                      rn->p.prefixlen, tx_id_buf);
+                      bgp_debug_rdpfxpath2str (prd, &rn->p, addpath_encode,
+                                               addpath_tx_id,
+                                               pfx_buf, sizeof (pfx_buf)));
 	}
 
       /* Synchnorize attribute.  */
@@ -863,6 +864,8 @@ subgroup_withdraw_packet (struct update_subgroup *subgrp)
   int num_pfx = 0;
   int addpath_encode = 0;
   u_int32_t addpath_tx_id = 0;
+  struct prefix_rd *prd = NULL;
+
 
   if (!subgrp)
     return NULL;
@@ -905,8 +908,6 @@ subgroup_withdraw_packet (struct update_subgroup *subgrp)
 	stream_put_prefix_addpath (s, &rn->p, addpath_encode, addpath_tx_id);
       else
 	{
-	  struct prefix_rd *prd = NULL;
-
 	  if (rn->prn)
 	    prd = (struct prefix_rd *) &rn->prn->p;
 
@@ -928,13 +929,13 @@ subgroup_withdraw_packet (struct update_subgroup *subgrp)
 
       if (bgp_debug_update(NULL, &rn->p, subgrp->update_group, 0))
 	{
-          char buf[INET6_BUFSIZ];
-          char tx_id_buf[30];
-          bgp_info_addpath_tx_str (addpath_encode, addpath_tx_id, tx_id_buf);
-	  zlog_debug ("u%" PRIu64 ":s%" PRIu64 " send UPDATE %s/%d%s -- unreachable",
+          char pfx_buf[BGP_PRD_PATH_STRLEN];
+
+	  zlog_debug ("u%" PRIu64 ":s%" PRIu64 " send UPDATE %s -- unreachable",
                       subgrp->update_group->id, subgrp->id,
-                      inet_ntop (rn->p.family, &(rn->p.u.prefix), buf, INET6_BUFSIZ),
-                      rn->p.prefixlen, tx_id_buf);
+                      bgp_debug_rdpfxpath2str (prd, &rn->p,
+                                               addpath_encode, addpath_tx_id,
+                                               pfx_buf, sizeof (pfx_buf)));
 	}
 
       subgrp->scount--;
@@ -1010,16 +1011,16 @@ subgroup_default_update_packet (struct update_subgroup *subgrp,
   if (bgp_debug_update(NULL, &p, subgrp->update_group, 0))
     {
       char attrstr[BUFSIZ];
-      char buf[INET6_BUFSIZ];
+      char buf[PREFIX_STRLEN];
       char tx_id_buf[30];
       attrstr[0] = '\0';
 
       bgp_dump_attr (peer, attr, attrstr, BUFSIZ);
       bgp_info_addpath_tx_str (addpath_encode, BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE, tx_id_buf);
-      zlog_debug ("u%" PRIu64 ":s%" PRIu64 " send UPDATE %s/%d%s %s",
+      zlog_debug ("u%" PRIu64 ":s%" PRIu64 " send UPDATE %s%s %s",
                   (SUBGRP_UPDGRP (subgrp))->id, subgrp->id,
-                  inet_ntop (p.family, &(p.u.prefix), buf, INET6_BUFSIZ),
-                  p.prefixlen, tx_id_buf, attrstr);
+                  prefix2str (&p, buf, sizeof (buf)),
+                  tx_id_buf, attrstr);
     }
 
   s = stream_new (BGP_MAX_PACKET_SIZE);
@@ -1084,14 +1085,13 @@ subgroup_default_withdraw_packet (struct update_subgroup *subgrp)
 
   if (bgp_debug_update(NULL, &p, subgrp->update_group, 0))
     {
-      char buf[INET6_BUFSIZ];
+      char buf[PREFIX_STRLEN];
       char tx_id_buf[INET6_BUFSIZ];
 
       bgp_info_addpath_tx_str (addpath_encode, BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE, tx_id_buf);
-      zlog_debug ("u%" PRIu64 ":s%" PRIu64 " send UPDATE %s/%d%s -- unreachable",
+      zlog_debug ("u%" PRIu64 ":s%" PRIu64 " send UPDATE %s%s -- unreachable",
                   (SUBGRP_UPDGRP (subgrp))->id, subgrp->id,
-                  inet_ntop (p.family, &(p.u.prefix), buf, INET6_BUFSIZ),
-                  p.prefixlen, tx_id_buf);
+                  prefix2str (&p, buf, sizeof (buf)), tx_id_buf);
     }
 
   s = stream_new (BGP_MAX_PACKET_SIZE);

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -766,8 +766,9 @@ subgroup_update_packet (struct update_subgroup *subgrp)
                                          (peer_cap_enhe(peer) ? AFI_IP6 :
                                           AFI_MAX), /* get from NH */
 				          &vecarr, adv->baa->attr);
-          bgp_packet_mpattr_prefix (snlri, afi, safi, &rn->p, prd, tag,
-                                    addpath_encode, addpath_tx_id);
+
+          bgp_packet_mpattr_prefix (snlri, afi, safi, &rn->p, prd,
+                                    tag, addpath_encode, addpath_tx_id, adv->baa->attr);
 	}
 
       num_pfx++;
@@ -922,7 +923,7 @@ subgroup_withdraw_packet (struct update_subgroup *subgrp)
 	    }
 
 	  bgp_packet_mpunreach_prefix (s, &rn->p, afi, safi, prd, NULL,
-                                       addpath_encode, addpath_tx_id);
+                                       addpath_encode, addpath_tx_id, NULL);
 	}
 
       num_pfx++;
@@ -1126,7 +1127,7 @@ subgroup_default_withdraw_packet (struct update_subgroup *subgrp)
       mplen_pos = bgp_packet_mpunreach_start (s, afi, safi);
       bgp_packet_mpunreach_prefix (s, &p, afi, safi, NULL, NULL,
                                    addpath_encode,
-                                   BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE);
+                                   BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE, NULL);
 
       /* Set the mp_unreach attr's length */
       bgp_packet_mpunreach_end (s, mplen_pos);

--- a/bgpd/bgp_vpn.c
+++ b/bgpd/bgp_vpn.c
@@ -1,0 +1,199 @@
+/* VPN Related functions
+   Copyright (C) 2017 6WIND
+
+This file is part of Free Range Routing
+
+Free Range Routing is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation; either version 2, or (at your option) any
+later version.
+
+Free Range Routing is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Free Range Routing; see the file COPYING.  If not, write to the Free
+Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+02111-1307, USA.  */
+
+#include <zebra.h>
+#include "command.h"
+#include "prefix.h"
+#include "lib/json.h"
+
+#include "bgpd/bgpd.h"
+#include "bgpd/bgp_route.h"
+#include "bgpd/bgp_table.h"
+#include "bgpd/bgp_attr.h"
+#include "bgpd/bgp_mplsvpn.h"
+#include "bgpd/bgp_vpn.h"
+
+int
+show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd,
+                    afi_t afi, safi_t safi, u_char use_json)
+{
+  struct bgp *bgp;
+  struct bgp_table *table;
+  struct bgp_node *rn;
+  struct bgp_node *rm;
+  struct attr *attr;
+  int rd_header;
+  int header = 1;
+  char v4_header[] = "   Network          Next Hop            Metric LocPrf Weight Path%s";
+  json_object *json = NULL;
+  json_object *json_scode = NULL;
+  json_object *json_ocode = NULL;
+  json_object *json_routes = NULL;
+  json_object *json_array = NULL;
+
+  bgp = bgp_get_default ();
+  if (bgp == NULL)
+    {
+      if (!use_json)
+        vty_out (vty, "No BGP process is configured%s", VTY_NEWLINE);
+      return CMD_WARNING;
+    }
+
+  if (use_json)
+    {
+      json_scode = json_object_new_object();
+      json_ocode = json_object_new_object();
+      json_routes = json_object_new_object();
+      json = json_object_new_object();
+
+      json_object_string_add(json_scode, "suppressed", "s");
+      json_object_string_add(json_scode, "damped", "d");
+      json_object_string_add(json_scode, "history", "h");
+      json_object_string_add(json_scode, "valid", "*");
+      json_object_string_add(json_scode, "best", ">");
+      json_object_string_add(json_scode, "internal", "i");
+
+      json_object_string_add(json_ocode, "igp", "i");
+      json_object_string_add(json_ocode, "egp", "e");
+      json_object_string_add(json_ocode, "incomplete", "?");
+    }
+
+  for (rn = bgp_table_top (bgp->rib[afi][safi]); rn;
+       rn = bgp_route_next (rn))
+    {
+      if (prd && memcmp (rn->p.u.val, prd->val, 8) != 0)
+        continue;
+
+      if ((table = rn->info) != NULL)
+        {
+          if (use_json)
+            json_array = json_object_new_array();
+          else
+            json_array = NULL;
+
+          rd_header = 1;
+
+          for (rm = bgp_table_top (table); rm; rm = bgp_route_next (rm))
+            {
+              if ((attr = rm->info) != NULL)
+                {
+                  if (header)
+                    {
+                      if (use_json)
+                        {
+                          json_object_int_add(json, "bgpTableVersion", 0);
+                          json_object_string_add(json, "bgpLocalRouterId", inet_ntoa (bgp->router_id));
+                          json_object_object_add(json, "bgpStatusCodes", json_scode);
+                          json_object_object_add(json, "bgpOriginCodes", json_ocode);
+                        }
+                      else
+                        {
+                          vty_out (vty, "BGP table version is 0, local router ID is %s%s",
+                                   inet_ntoa (bgp->router_id), VTY_NEWLINE);
+                          vty_out (vty, "Status codes: s suppressed, d damped, h history, * valid, > best, i - internal%s",
+                                   VTY_NEWLINE);
+                          vty_out (vty, "Origin codes: i - IGP, e - EGP, ? - incomplete%s%s",
+                                   VTY_NEWLINE, VTY_NEWLINE);
+                          vty_out (vty, v4_header, VTY_NEWLINE);
+                        }
+                      header = 0;
+                    }
+
+                  if (rd_header)
+                    {
+                      u_int16_t type;
+                      struct rd_as rd_as;
+                      struct rd_ip rd_ip = {0};
+#if ENABLE_BGP_VNC
+                      struct rd_vnc_eth rd_vnc_eth;
+#endif
+                      u_char *pnt;
+
+                      pnt = rn->p.u.val;
+
+                      /* Decode RD type. */
+                      type = decode_rd_type (pnt);
+                      /* Decode RD value. */
+                      if (type == RD_TYPE_AS)
+                        decode_rd_as (pnt + 2, &rd_as);
+                      else if (type == RD_TYPE_AS4)
+                        decode_rd_as4 (pnt + 2, &rd_as);
+                      else if (type == RD_TYPE_IP)
+                        decode_rd_ip (pnt + 2, &rd_ip);
+#if ENABLE_BGP_VNC
+                      else if (type == RD_TYPE_VNC_ETH)
+                        decode_rd_vnc_eth (pnt, &rd_vnc_eth);
+#endif
+
+                      if (use_json)
+                        {
+                          char buffer[BUFSIZ];
+                          if (type == RD_TYPE_AS || type == RD_TYPE_AS4)
+                            sprintf (buffer, "%u:%d", rd_as.as, rd_as.val);
+                          else if (type == RD_TYPE_IP)
+                            sprintf (buffer, "%s:%d", inet_ntoa (rd_ip.ip), rd_ip.val);
+                          json_object_string_add(json_routes, "routeDistinguisher", buffer);
+                        }
+                      else
+                        {
+                          vty_out (vty, "Route Distinguisher: ");
+
+                          if (type == RD_TYPE_AS || type == RD_TYPE_AS4)
+                            vty_out (vty, "%u:%d", rd_as.as, rd_as.val);
+                          else if (type == RD_TYPE_IP)
+                            vty_out (vty, "%s:%d", inet_ntoa (rd_ip.ip), rd_ip.val);
+#if ENABLE_BGP_VNC
+                          else if (type == RD_TYPE_VNC_ETH)
+                            vty_out (vty, "%u:%02x:%02x:%02x:%02x:%02x:%02x", 
+                                     rd_vnc_eth.local_nve_id, 
+                                     rd_vnc_eth.macaddr.octet[0],
+                                     rd_vnc_eth.macaddr.octet[1],
+                                     rd_vnc_eth.macaddr.octet[2],
+                                     rd_vnc_eth.macaddr.octet[3],
+                                     rd_vnc_eth.macaddr.octet[4],
+                                     rd_vnc_eth.macaddr.octet[5]);
+#endif
+
+                          vty_out (vty, "%s", VTY_NEWLINE);
+                        }
+                      rd_header = 0;
+                    }
+                  route_vty_out_tmp (vty, &rm->p, attr, safi, use_json, json_array);
+                }
+            }
+          if (use_json)
+            {
+              struct prefix *p;
+              char buf_a[BUFSIZ];
+              char buf_b[BUFSIZ];
+              p = &rm->p;
+              sprintf(buf_a, "%s/%d", inet_ntop (p->family, &p->u.prefix, buf_b, BUFSIZ), p->prefixlen);
+              json_object_object_add(json_routes, buf_a, json_array);
+            }
+        }
+    }
+  if (use_json)
+    {
+      json_object_object_add(json, "routes", json_routes);
+      vty_out (vty, "%s%s", json_object_to_json_string_ext(json, JSON_C_TO_STRING_PRETTY), VTY_NEWLINE);
+      json_object_free(json);
+    }
+  return CMD_SUCCESS;
+}

--- a/bgpd/bgp_vpn.h
+++ b/bgpd/bgp_vpn.h
@@ -1,0 +1,30 @@
+/* VPN common functions to MP-BGP
+   Copyright (C) 2017 6WIND
+
+This file is part of Free Range Routing.
+
+Free Range Routing is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation; either version 2, or (at your option) any
+later version.
+
+Free Range Routing is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Free Range Routing; see the file COPYING.  If not, write to the Free
+Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
+02111-1307, USA.  */
+
+#ifndef _FRR_BGP_VPN_H
+#define _FRR_BGP_VPN_H
+
+#include <zebra.h>
+
+extern int
+show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd,
+                    afi_t afi, safi_t safi, u_char use_json);
+
+#endif /* _QUAGGA_BGP_VPN_H */

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5649,7 +5649,7 @@ DEFUN (address_family_encapv6,
 
 DEFUN (address_family_evpn,
        address_family_evpn_cmd,
-       "address-family <evpn|l2vpn evpn>",
+       "address-family <l2vpn evpn>",
        "Enter Address Family command mode\n"
        "EVPN Address family\n"
        "Layer2 VPN Address family\n"

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -6765,6 +6765,8 @@ afi_safi_print (afi_t afi, safi_t safi)
     return "IPv6 VPN";
   else if (afi == AFI_IP6 && safi == SAFI_ENCAP)
     return "IPv6 Encap";
+  else if (afi == AFI_L2VPN && safi == SAFI_EVPN)
+    return "L2VPN EVPN";
   else
     return "Unknown";
 }
@@ -6788,6 +6790,8 @@ afi_safi_json (afi_t afi, safi_t safi)
     return "IPv6VPN";
   else if (afi == AFI_IP6 && safi == SAFI_ENCAP)
     return "IPv6Encap";
+  else if (afi == AFI_L2VPN && safi == SAFI_EVPN)
+    return "L2VPN EVPN";
   else
     return "Unknown";
 }

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -73,6 +73,9 @@ bgp_node_afi (struct vty *vty)
     case BGP_ENCAPV6_NODE:
       afi = AFI_IP6;
       break;
+    case BGP_EVPN_NODE:
+      afi = AFI_L2VPN;
+      break;
     default:
       afi = AFI_IP;
       break;
@@ -100,6 +103,9 @@ bgp_node_safi (struct vty *vty)
     case BGP_IPV6M_NODE:
       safi = SAFI_MULTICAST;
       break;
+    case BGP_EVPN_NODE:
+      safi = SAFI_EVPN;
+      break;
     default:
       safi = SAFI_UNICAST;
       break;
@@ -117,6 +123,9 @@ bgp_vty_afi_from_arg(const char *afi_str)
     }
   else if (!strcmp(afi_str, "ipv6")) {
     afi = AFI_IP6;
+  }
+  else if (!strcmp(afi_str, "l2vpn")) {
+    afi = AFI_L2VPN;
   }
   return afi;
 }
@@ -203,6 +212,12 @@ argv_find_and_parse_safi(struct cmd_token **argv, int argc, int *index, safi_t *
       ret = 1;
       if (safi)
         *safi = SAFI_ENCAP;
+    }
+  else if (argv_find (argv, argc, "evpn", index))
+    {
+      ret = 1;
+      if (safi)
+        *safi = SAFI_EVPN;
     }
   return ret;
 }
@@ -5632,6 +5647,18 @@ DEFUN (address_family_encapv6,
   return CMD_SUCCESS;
 }
 
+DEFUN (address_family_evpn,
+       address_family_evpn_cmd,
+       "address-family evpn",
+       "Enter Address Family command mode\n"
+       "Address family\n")
+{
+#if defined(HAVE_EVPN)
+  vty->node = BGP_EVPN_NODE;
+#endif /* HAVE_EVPN */
+  return CMD_SUCCESS;
+}
+
 DEFUN (exit_address_family,
        exit_address_family_cmd,
        "exit-address-family",
@@ -5644,7 +5671,8 @@ DEFUN (exit_address_family,
       || vty->node == BGP_IPV6M_NODE
       || vty->node == BGP_VPNV6_NODE
       || vty->node == BGP_ENCAP_NODE
-      || vty->node == BGP_ENCAPV6_NODE)
+      || vty->node == BGP_ENCAPV6_NODE
+      || vty->node == BGP_EVPN_NODE)
     vty->node = BGP_NODE;
   return CMD_SUCCESS;
 }
@@ -9852,6 +9880,13 @@ static struct cmd_node bgp_encapv6_node =
   1
 };
 
+static struct cmd_node bgp_evpn_node =
+{
+  BGP_EVPN_NODE,
+  "%s(config-router-evpn)# ",
+  1
+};
+
 static void community_list_vty (void);
 
 void
@@ -9867,6 +9902,7 @@ bgp_vty_init (void)
   install_node (&bgp_vpnv6_node, NULL);
   install_node (&bgp_encap_node, NULL);
   install_node (&bgp_encapv6_node, NULL);
+  install_node (&bgp_evpn_node, NULL);
 
   /* Install default VTY commands to new nodes.  */
   install_default (BGP_NODE);
@@ -9878,6 +9914,7 @@ bgp_vty_init (void)
   install_default (BGP_VPNV6_NODE);
   install_default (BGP_ENCAP_NODE);
   install_default (BGP_ENCAPV6_NODE);
+  install_default (BGP_EVPN_NODE);
 
   /* "bgp multiple-instance" commands. */
   install_element (CONFIG_NODE, &bgp_multiple_instance_cmd);
@@ -10091,6 +10128,7 @@ bgp_vty_init (void)
   install_element (BGP_VPNV6_NODE, &neighbor_activate_cmd);
   install_element (BGP_ENCAP_NODE, &neighbor_activate_cmd);
   install_element (BGP_ENCAPV6_NODE, &neighbor_activate_cmd);
+  install_element (BGP_EVPN_NODE, &neighbor_activate_cmd);
 
   /* "no neighbor activate" commands. */
   install_element (BGP_NODE, &no_neighbor_activate_cmd);
@@ -10102,6 +10140,7 @@ bgp_vty_init (void)
   install_element (BGP_VPNV6_NODE, &no_neighbor_activate_cmd);
   install_element (BGP_ENCAP_NODE, &no_neighbor_activate_cmd);
   install_element (BGP_ENCAPV6_NODE, &no_neighbor_activate_cmd);
+  install_element (BGP_EVPN_NODE, &no_neighbor_activate_cmd);
 
   /* "neighbor peer-group" set commands.
    * Long term we should only accept this command under BGP_NODE and not all of
@@ -10171,6 +10210,9 @@ bgp_vty_init (void)
 
   install_element (BGP_ENCAPV6_NODE, &neighbor_attr_unchanged_cmd);
   install_element (BGP_ENCAPV6_NODE, &no_neighbor_attr_unchanged_cmd);
+
+  install_element (BGP_EVPN_NODE, &neighbor_attr_unchanged_cmd);
+  install_element (BGP_EVPN_NODE, &no_neighbor_attr_unchanged_cmd);
 
   /* "nexthop-local unchanged" commands */
   install_element (BGP_IPV6_NODE, &neighbor_nexthop_local_unchanged_cmd);
@@ -10718,6 +10760,8 @@ bgp_vty_init (void)
   install_element (BGP_NODE, &address_family_encap_cmd);
   install_element (BGP_NODE, &address_family_encapv6_cmd);
 
+  install_element (BGP_NODE, &address_family_evpn_cmd);
+
   /* "exit-address-family" command. */
   install_element (BGP_IPV4_NODE, &exit_address_family_cmd);
   install_element (BGP_IPV4M_NODE, &exit_address_family_cmd);
@@ -10727,6 +10771,7 @@ bgp_vty_init (void)
   install_element (BGP_VPNV6_NODE, &exit_address_family_cmd);
   install_element (BGP_ENCAP_NODE, &exit_address_family_cmd);
   install_element (BGP_ENCAPV6_NODE, &exit_address_family_cmd);
+  install_element (BGP_EVPN_NODE, &exit_address_family_cmd);
 
   /* "clear ip bgp commands" */
   install_element (ENABLE_NODE, &clear_ip_bgp_all_cmd);

--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5649,9 +5649,11 @@ DEFUN (address_family_encapv6,
 
 DEFUN (address_family_evpn,
        address_family_evpn_cmd,
-       "address-family evpn",
+       "address-family <evpn|l2vpn evpn>",
        "Enter Address Family command mode\n"
-       "Address family\n")
+       "EVPN Address family\n"
+       "Layer2 VPN Address family\n"
+       "Ethernet Virtual Private Network Subsequent Address Family\n")
 {
 #if defined(HAVE_EVPN)
   vty->node = BGP_EVPN_NODE;

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -78,6 +78,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgpd/bgp_updgrp.h"
 #include "bgpd/bgp_bfd.h"
 #include "bgpd/bgp_memory.h"
+#include "bgpd/bgp_evpn_vty.h"
 
 DEFINE_QOBJ_TYPE(bgp_master)
 DEFINE_QOBJ_TYPE(bgp)
@@ -7605,6 +7606,7 @@ bgp_init (void)
 #if ENABLE_BGP_VNC
   rfapi_init ();
 #endif
+  bgp_ethernetvpn_init ();
 
   /* Access list initialize. */
   access_list_init ();

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -66,6 +66,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "bgpd/rfapi/bgp_rfapi_cfg.h"
 #include "bgpd/rfapi/rfapi_backend.h"
 #endif
+#include "bgpd/bgp_evpn.h"
 #include "bgpd/bgp_advertise.h"
 #include "bgpd/bgp_network.h"
 #include "bgpd/bgp_vty.h"

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -1641,6 +1641,8 @@ peer_as_change (struct peer *peer, as_t as, int as_specified)
 		  PEER_FLAG_REFLECTOR_CLIENT);
       UNSET_FLAG (peer->af_flags[AFI_IP6][SAFI_ENCAP],
 		  PEER_FLAG_REFLECTOR_CLIENT);
+      UNSET_FLAG (peer->af_flags[AFI_L2VPN][SAFI_EVPN],
+		  PEER_FLAG_REFLECTOR_CLIENT);
     }
 
   /* local-as reset */
@@ -7197,7 +7199,11 @@ bgp_config_write_family_header (struct vty *vty, afi_t afi, safi_t safi,
       else if (safi == SAFI_ENCAP)
         vty_out (vty, "ipv6 encap");
     }
-
+  else if (afi == AFI_L2VPN)
+    {
+      if (safi == SAFI_EVPN)
+	vty_out (vty, "evpn");
+    }
   vty_out (vty, "%s", VTY_NEWLINE);
 
   *write = 1;
@@ -7497,6 +7503,9 @@ bgp_config_write (struct vty *vty)
 
       /* ENCAPv6 configuration.  */
       write += bgp_config_write_family (vty, bgp, AFI_IP6, SAFI_ENCAP);
+
+      /* EVPN configuration.  */
+      write += bgp_config_write_family (vty, bgp, AFI_L2VPN, SAFI_EVPN);
 
 #if ENABLE_BGP_VNC
       write += bgp_rfapi_cfg_write(vty, bgp);

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -73,6 +73,7 @@ enum bgp_af_index
   BGP_AF_IPV6_VPN,
   BGP_AF_IPV4_ENCAP,
   BGP_AF_IPV6_ENCAP,
+  BGP_AF_L2VPN_EVPN,
   BGP_AF_MAX
 };
 
@@ -1412,6 +1413,16 @@ afindex (afi_t afi, safi_t safi)
 	  break;
 	}
       break;
+    case AFI_L2VPN:
+      switch (safi)
+        {
+        case SAFI_EVPN:
+          return BGP_AF_L2VPN_EVPN;
+          break;
+        default:
+          return BGP_AF_MAX;
+          break;
+        }
     default:
       return BGP_AF_MAX;
       break;

--- a/bgpd/rfapi/bgp_rfapi_cfg.c
+++ b/bgpd/rfapi/bgp_rfapi_cfg.c
@@ -3782,7 +3782,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                 ecommunity_cmp (rfg->rt_import_list, rfg->rt_export_list))
               {
                 char *b = ecommunity_ecom2str (rfg->rt_import_list,
-                                               ECOMMUNITY_FORMAT_ROUTE_MAP);
+                                               ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
                 vty_out (vty, "   rt both %s%s", b, VTY_NEWLINE);
                 XFREE (MTYPE_ECOMMUNITY_STR, b);
               }
@@ -3791,14 +3791,14 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                 if (rfg->rt_import_list)
                   {
                     char *b = ecommunity_ecom2str (rfg->rt_import_list,
-                                                   ECOMMUNITY_FORMAT_ROUTE_MAP);
+                                                   ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
                     vty_out (vty, "  rt import %s%s", b, VTY_NEWLINE);
                     XFREE (MTYPE_ECOMMUNITY_STR, b);
                   }
                 if (rfg->rt_export_list)
                   {
                     char *b = ecommunity_ecom2str (rfg->rt_export_list,
-                                                   ECOMMUNITY_FORMAT_ROUTE_MAP);
+                                                   ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
                     vty_out (vty, "  rt export %s%s", b, VTY_NEWLINE);
                     XFREE (MTYPE_ECOMMUNITY_STR, b);
                   }
@@ -3869,7 +3869,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
                             hc->default_rt_export_list))
           {
             char *b = ecommunity_ecom2str (hc->default_rt_import_list,
-                                           ECOMMUNITY_FORMAT_ROUTE_MAP);
+                                           ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
             vty_out (vty, "  rt both %s%s", b, VTY_NEWLINE);
             XFREE (MTYPE_ECOMMUNITY_STR, b);
           }
@@ -3878,14 +3878,14 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
             if (hc->default_rt_import_list)
               {
                 char *b = ecommunity_ecom2str (hc->default_rt_import_list,
-                                               ECOMMUNITY_FORMAT_ROUTE_MAP);
+                                               ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
                 vty_out (vty, "  rt import %s%s", b, VTY_NEWLINE);
                 XFREE (MTYPE_ECOMMUNITY_STR, b);
               }
             if (hc->default_rt_export_list)
               {
                 char *b = ecommunity_ecom2str (hc->default_rt_export_list,
-                                               ECOMMUNITY_FORMAT_ROUTE_MAP);
+                                               ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
                 vty_out (vty, "  rt export %s%s", b, VTY_NEWLINE);
                 XFREE (MTYPE_ECOMMUNITY_STR, b);
               }
@@ -3983,7 +3983,7 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
             ecommunity_cmp (rfg->rt_import_list, rfg->rt_export_list))
           {
             char *b = ecommunity_ecom2str (rfg->rt_import_list,
-                                           ECOMMUNITY_FORMAT_ROUTE_MAP);
+                                           ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
             vty_out (vty, "  rt both %s%s", b, VTY_NEWLINE);
             XFREE (MTYPE_ECOMMUNITY_STR, b);
           }
@@ -3992,14 +3992,14 @@ bgp_rfapi_cfg_write (struct vty *vty, struct bgp *bgp)
             if (rfg->rt_import_list)
               {
                 char *b = ecommunity_ecom2str (rfg->rt_import_list,
-                                               ECOMMUNITY_FORMAT_ROUTE_MAP);
+                                               ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
                 vty_out (vty, "  rt import %s%s", b, VTY_NEWLINE);
                 XFREE (MTYPE_ECOMMUNITY_STR, b);
               }
             if (rfg->rt_export_list)
               {
                 char *b = ecommunity_ecom2str (rfg->rt_export_list,
-                                               ECOMMUNITY_FORMAT_ROUTE_MAP);
+                                               ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
                 vty_out (vty, "  rt export %s%s", b, VTY_NEWLINE);
                 XFREE (MTYPE_ECOMMUNITY_STR, b);
               }

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -3782,7 +3782,7 @@ DEFUN (debug_rfapi_show_import,
   for (it = h->imports; it; it = it->next)
     {
       s = ecommunity_ecom2str (it->rt_import_list,
-                               ECOMMUNITY_FORMAT_ROUTE_MAP);
+                               ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
       vty_out (vty, "Import Table %p, RTs: %s%s", it, s, VTY_NEWLINE);
       XFREE (MTYPE_ECOMMUNITY_STR, s);
 

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -1084,8 +1084,8 @@ rfapiEcommunitiesIntersect (struct ecommunity *e1, struct ecommunity *e2)
 
   {
     char *s1, *s2;
-    s1 = ecommunity_ecom2str (e1, ECOMMUNITY_FORMAT_DISPLAY);
-    s2 = ecommunity_ecom2str (e2, ECOMMUNITY_FORMAT_DISPLAY);
+    s1 = ecommunity_ecom2str (e1, ECOMMUNITY_FORMAT_DISPLAY, ECOMMUNITY_ROUTE_TARGET);
+    s2 = ecommunity_ecom2str (e2, ECOMMUNITY_FORMAT_DISPLAY, ECOMMUNITY_ROUTE_TARGET);
     vnc_zlog_debug_verbose ("%s: e1[%s], e2[%s]", __func__, s1, s2);
     XFREE (MTYPE_ECOMMUNITY_STR, s1);
     XFREE (MTYPE_ECOMMUNITY_STR, s2);

--- a/bgpd/rfapi/rfapi_vty.c
+++ b/bgpd/rfapi/rfapi_vty.c
@@ -482,7 +482,7 @@ rfapi_vty_out_vncinfo (
   if (bi->attr && bi->attr->extra && bi->attr->extra->ecommunity)
     {
       s = ecommunity_ecom2str (bi->attr->extra->ecommunity,
-                               ECOMMUNITY_FORMAT_ROUTE_MAP);
+                               ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
       vty_out (vty, " EC{%s}", s);
       XFREE (MTYPE_ECOMMUNITY_STR, s);
     }
@@ -686,7 +686,7 @@ rfapiPrintBi (void *stream, struct bgp_info *bi)
       if (bi->attr->extra->ecommunity)
         {
           s = ecommunity_ecom2str (bi->attr->extra->ecommunity,
-                                   ECOMMUNITY_FORMAT_ROUTE_MAP);
+                                   ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
           r = snprintf (p, REMAIN, " %s", s);
           INCP;
           XFREE (MTYPE_ECOMMUNITY_STR, s);
@@ -1442,7 +1442,7 @@ rfapiShowRemoteRegistrationsIt (
                     }
 
                   s = ecommunity_ecom2str (it->rt_import_list,
-                                           ECOMMUNITY_FORMAT_ROUTE_MAP);
+                                           ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
 
                   if (pLni)
                     {
@@ -1806,7 +1806,7 @@ rfapiPrintDescriptor (struct vty *vty, struct rfapi_descriptor *rfd)
     {
       s =
         ecommunity_ecom2str (rfd->rt_export_list,
-                             ECOMMUNITY_FORMAT_ROUTE_MAP);
+                             ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
       vty_out (vty, " Export %s%s", s, HVTY_NEWLINE);
       XFREE (MTYPE_ECOMMUNITY_STR, s);
     }
@@ -1819,7 +1819,7 @@ rfapiPrintDescriptor (struct vty *vty, struct rfapi_descriptor *rfd)
   if (rfd->import_table)
     {
       s = ecommunity_ecom2str (rfd->import_table->rt_import_list,
-                               ECOMMUNITY_FORMAT_ROUTE_MAP);
+                               ECOMMUNITY_FORMAT_ROUTE_MAP, ECOMMUNITY_ROUTE_TARGET);
       vty_out (vty, " Import %s%s", s, HVTY_NEWLINE);
       XFREE (MTYPE_ECOMMUNITY_STR, s);
     }

--- a/bgpd/rfapi/vnc_export_bgp.c
+++ b/bgpd/rfapi/vnc_export_bgp.c
@@ -340,7 +340,7 @@ vnc_direct_bgp_add_route_ce (
               iattr,      /* bgp_update copies this attr */
               afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT, BGP_ROUTE_REDISTRIBUTE, NULL,  /* RD not used for unicast */
               NULL,             /* tag not used for unicast */
-              0);
+              0, NULL);         /* EVPN not used */
   bgp_attr_unintern (&iattr);
 }
 
@@ -425,7 +425,7 @@ vnc_direct_bgp_del_route_ce (
                 0,                /* addpath_id */
                 NULL, /* attr, ignored */
                 afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT, BGP_ROUTE_REDISTRIBUTE, NULL,        /* RD not used for unicast */
-                NULL);          /* tag not used for unicast */
+                NULL, NULL);          /* tag not used for unicast */
 
 }
 
@@ -534,7 +534,7 @@ vnc_direct_bgp_vpn_disable_ce (struct bgp *bgp, afi_t afi)
                             0,                /* addpath_id */
                             NULL,       /* ignored */
                             AFI_IP, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT, BGP_ROUTE_REDISTRIBUTE, NULL, /* RD not used for unicast */
-                            NULL);      /* tag not used for unicast */
+                            NULL, NULL);      /* tag not used for unicast */
             }
         }
     }
@@ -911,7 +911,7 @@ vnc_direct_bgp_add_prefix (
                       iattr,    /* bgp_update copies it */
                       afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT, BGP_ROUTE_REDISTRIBUTE, NULL,  /* RD not used for unicast */
                       NULL,     /* tag not used for unicast */
-                      0);
+                      0, NULL); /* EVPN not used */
 
           bgp_attr_unintern (&iattr);
         }
@@ -1011,7 +1011,7 @@ vnc_direct_bgp_del_prefix (
                         0,                /* addpath_id */
                         NULL,   /* attr, ignored */
                         afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT, BGP_ROUTE_REDISTRIBUTE, NULL,        /* RD not used for unicast */
-                        NULL);  /* tag not used for unicast */
+                        NULL, NULL);  /* tag not used for unicast */
         }
     }
 }
@@ -1150,7 +1150,7 @@ vnc_direct_bgp_add_nve (struct bgp *bgp, struct rfapi_descriptor *rfd)
                               iattr,    /* bgp_update copies it */
                               afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT, BGP_ROUTE_REDISTRIBUTE, NULL,  /* RD not used for unicast */
                               NULL,     /* tag not used for unicast */
-                              0);
+                              0, NULL); /* EVPN not used */
 
                   bgp_attr_unintern (&iattr);
 
@@ -1250,7 +1250,7 @@ vnc_direct_bgp_del_nve (struct bgp *bgp, struct rfapi_descriptor *rfd)
                                 0,                      /* addpath_id */
                                 NULL,   /* attr, ignored */
                                 afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT, BGP_ROUTE_REDISTRIBUTE, NULL,        /* RD not used for unicast */
-                                NULL);  /* tag not used for unicast */
+                                NULL, NULL);  /* tag not used for unicast */
 
                 }
             }
@@ -1377,7 +1377,7 @@ vnc_direct_bgp_add_group_afi (
                           iattr,        /* bgp_update copies it */
                           afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT, BGP_ROUTE_REDISTRIBUTE, NULL,      /* RD not used for unicast */
                           NULL, /* tag not used for unicast */
-                          0);
+                          0, NULL); /* EVPN not used */
 
               bgp_attr_unintern (&iattr);
             }
@@ -1462,7 +1462,7 @@ vnc_direct_bgp_del_group_afi (
                             0,                  /* addpath_id */
                             NULL,       /* attr, ignored */
                             afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT, BGP_ROUTE_REDISTRIBUTE, NULL,    /* RD not used for unicast */
-                            NULL);      /* tag not used for unicast */
+                            NULL, NULL);      /* tag not used for unicast */
 
             }
         }
@@ -1540,7 +1540,7 @@ vnc_direct_bgp_unexport_table (
                                 0,                      /* addpath_id */
                                 NULL,   /* attr, ignored */
                                 afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT, BGP_ROUTE_REDISTRIBUTE, NULL,        /* RD not used for unicast */
-                                NULL);  /* tag not used for unicast */
+                                NULL, NULL);  /* tag not used for unicast, EVPN neither */
 
                 }
             }
@@ -1777,8 +1777,8 @@ vnc_direct_bgp_rh_add_route (
               0,                /* addpath_id */
               iattr,            /* bgp_update copies this attr */
               afi, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT_RH, BGP_ROUTE_REDISTRIBUTE, NULL,       /* RD not used for unicast */
-              NULL,             /* tag not used for unicast */
-              0);
+              NULL,             /* tag not used for unicast, EVPN neither */
+              0, NULL);         /* EVPN not used */
   bgp_attr_unintern (&iattr);
 
 }
@@ -1801,7 +1801,7 @@ vncExportWithdrawTimer (struct thread *t)
     eti->type,
     eti->subtype,
     NULL,				/* RD not used for unicast */
-    NULL);				/* tag not used for unicast */
+    NULL, NULL);			/* tag not used for unicast, EVPN neither */
 
   /*
    * Free the eti
@@ -2019,8 +2019,8 @@ vnc_direct_bgp_rh_vpn_enable (struct bgp *bgp, afi_t afi)
                               0,                /* addpath_id */
                               iattr,    /* bgp_update copies it */
                               AFI_IP, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT_RH, BGP_ROUTE_REDISTRIBUTE, NULL,    /* RD not used for unicast */
-                              NULL,     /* tag not used for unicast */
-                              0);
+                              NULL,     /* tag not used for unicast, EVPN neither */
+                              0, NULL); /* EVPN not used */
                   bgp_attr_unintern (&iattr);
                 }
             }
@@ -2085,7 +2085,7 @@ vnc_direct_bgp_rh_vpn_disable (struct bgp *bgp, afi_t afi)
                             0,                  /* addpath_id */
                             NULL,       /* ignored */
                             AFI_IP, SAFI_UNICAST, ZEBRA_ROUTE_VNC_DIRECT_RH, BGP_ROUTE_REDISTRIBUTE, NULL,      /* RD not used for unicast */
-                            NULL);      /* tag not used for unicast */
+                            NULL, NULL);      /* tag not used for unicast, EVPN neither */
             }
         }
     }

--- a/configure.ac
+++ b/configure.ac
@@ -285,6 +285,8 @@ AC_ARG_ENABLE([protobuf],
   AS_HELP_STRING([--enable-protobuf], [Enable experimental protobuf support]))
 AC_ARG_ENABLE([oldvpn_commands],
   AS_HELP_STRING([--enable-old-vpn-commands], [Keep old vpn commands]))
+AC_ARG_ENABLE(evpn,
+  AS_HELP_STRING([--enable-evpn], [enable EVPN support)]))
 
 AC_CHECK_HEADERS(json-c/json.h)
 AC_CHECK_LIB(json-c, json_object_get, LIBS="$LIBS -ljson-c")
@@ -395,6 +397,13 @@ fi
 #
 if test "$enable_old_vpn_commands" = "yes"; then
    AC_DEFINE(KEEP_OLD_VPN_COMMANDS,, [Define for compiling with old vpn commands])
+fi
+
+# Logic for evpn support.
+#
+if test "$enable_evpn" = "yes"; then
+   have_evpn=yes
+   AC_DEFINE(HAVE_EVPN,, [Define for compiling with EVPN])
 fi
 
 # Fail if the user explicity enabled protobuf support and we couldn't

--- a/lib/command.c
+++ b/lib/command.c
@@ -748,6 +748,7 @@ node_parent ( enum node_type node )
     case BGP_IPV4M_NODE:
     case BGP_IPV6_NODE:
     case BGP_IPV6M_NODE:
+    case BGP_EVPN_NODE:
       ret = BGP_NODE;
       break;
     case KEYCHAIN_KEY_NODE:
@@ -1111,6 +1112,7 @@ cmd_exit (struct vty *vty)
     case BGP_VNC_L2_GROUP_NODE:
     case BGP_IPV6_NODE:
     case BGP_IPV6M_NODE:
+    case BGP_EVPN_NODE:
       vty->node = BGP_NODE;
       break;
     case LDP_IPV4_NODE:
@@ -1178,6 +1180,7 @@ DEFUN (config_end,
     case BGP_IPV4M_NODE:
     case BGP_IPV6_NODE:
     case BGP_IPV6M_NODE:
+    case BGP_EVPN_NODE:
     case RMAP_NODE:
     case OSPF_NODE:
     case OSPF6_NODE:

--- a/lib/command.h
+++ b/lib/command.h
@@ -103,6 +103,7 @@ enum node_type
   BGP_VNC_NVE_GROUP_NODE,	/* BGP VNC nve group */
   BGP_VNC_L2_GROUP_NODE,	/* BGP VNC L2 group */
   RFP_DEFAULTS_NODE,	/* RFP defaults node */
+  BGP_EVPN_NODE,	        /* BGP EVPN node. */
   OSPF_NODE,                    /* OSPF protocol mode */
   OSPF6_NODE,                   /* OSPF protocol for IPv6 mode */
   LDP_NODE,			/* LDP protocol mode */

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -236,6 +236,8 @@ afi2str(afi_t afi)
 	return "IPv6";
     case AFI_ETHER:
 	return "ethernet";
+    case AFI_L2VPN:
+	return "l2vpn";
     case AFI_MAX:
         return "bad-value";
     default:
@@ -256,6 +258,8 @@ safi2str(safi_t safi)
 	return "encap";
     case SAFI_MPLS_VPN:
 	return "vpn";
+    case SAFI_EVPN:
+	return "evpn";
   }
   return NULL;
 }

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -873,23 +873,39 @@ str2prefix (const char *str, struct prefix *p)
 }
 
 const char *
-prefix2str (union prefix46constptr pu, char *str, int size)
+prefix2str (union prefixconstptr pu, char *str, int size)
 {
   const struct prefix *p = pu.p;
+  char buf[PREFIX2STR_BUFFER];
 
-  if (p->family == AF_ETHERNET)
+  switch (p->family)
     {
-      snprintf(str, size, "%02x:%02x:%02x:%02x:%02x:%02x/%d",
-               p->u.prefix_eth.octet[0], p->u.prefix_eth.octet[1],
-               p->u.prefix_eth.octet[2], p->u.prefix_eth.octet[3],
-               p->u.prefix_eth.octet[4], p->u.prefix_eth.octet[5],
-               p->prefixlen);
-    }
-  else
-    {
-      char buf[PREFIX2STR_BUFFER];
-      inet_ntop(p->family, &p->u.prefix, buf, sizeof(buf));
-      snprintf(str, size, "%s/%d", buf, p->prefixlen);
+      u_char family;
+
+      case AF_INET:
+      case AF_INET6:
+        snprintf (str, size, "%s/%d",
+                  inet_ntop (p->family, &p->u.prefix, buf, PREFIX2STR_BUFFER),
+                  p->prefixlen);
+        break;
+
+      case AF_ETHERNET:
+        if (p->u.prefix_evpn.route_type == 5)
+          {
+            family = (p->u.prefix_evpn.flags & (IP_ADDR_V4 | IP_PREFIX_V4)) ?
+              AF_INET : AF_INET6;
+            snprintf (str, size, "[%d]:[%u][%s]/%d",
+                      p->u.prefix_evpn.route_type,
+                      p->u.prefix_evpn.eth_tag,
+                      inet_ntop (family, &p->u.prefix_evpn.ip.addr,
+                                 buf, PREFIX2STR_BUFFER),
+                      p->prefixlen);
+          }
+        break;
+
+      default:
+        sprintf (str, "UNK prefix");
+        break;
     }
 
   return str;

--- a/lib/prefix.c
+++ b/lib/prefix.c
@@ -304,18 +304,16 @@ prefix_copy (struct prefix *dest, const struct prefix *src)
     dest->u.prefix4 = src->u.prefix4;
   else if (src->family == AF_INET6)
     dest->u.prefix6 = src->u.prefix6;
+#if defined(HAVE_EVPN)
   else if (src->family == AF_ETHERNET)
     {
       memcpy (&dest->u.prefix_evpn, &src->u.prefix_evpn, sizeof (struct evpn_addr));
     }
+#endif /* (HAVE_EVPN) */
   else if (src->family == AF_UNSPEC)
     {
       dest->u.lp.id = src->u.lp.id;
       dest->u.lp.adv_router = src->u.lp.adv_router;
-    }
-  else if (src->family == AF_ETHERNET)
-    {
-      dest->u.prefix_eth = src->u.prefix_eth;
     }
   else
     {
@@ -350,9 +348,11 @@ prefix_same (const struct prefix *p1, const struct prefix *p2)
       if (p1->family == AF_INET6 )
 	if (IPV6_ADDR_SAME (&p1->u.prefix6.s6_addr, &p2->u.prefix6.s6_addr))
 	  return 1;
+#if defined(HAVE_EVPN)
       if (p1->family == AF_ETHERNET )
         if (!memcmp (&p1->u.prefix_evpn, &p2->u.prefix_evpn, sizeof (struct evpn_addr)))
           return 1;
+#endif /* (HAVE_EVPN) */
     }
   return 0;
 }
@@ -880,8 +880,6 @@ prefix2str (union prefixconstptr pu, char *str, int size)
 
   switch (p->family)
     {
-      u_char family;
-
       case AF_INET:
       case AF_INET6:
         snprintf (str, size, "%s/%d",
@@ -889,9 +887,11 @@ prefix2str (union prefixconstptr pu, char *str, int size)
                   p->prefixlen);
         break;
 
+#if defined(HAVE_EVPN)
       case AF_ETHERNET:
         if (p->u.prefix_evpn.route_type == 5)
           {
+            u_char family;
             family = (p->u.prefix_evpn.flags & (IP_ADDR_V4 | IP_PREFIX_V4)) ?
               AF_INET : AF_INET6;
             snprintf (str, size, "[%d]:[%u][%s]/%d",
@@ -902,7 +902,7 @@ prefix2str (union prefixconstptr pu, char *str, int size)
                       p->prefixlen);
           }
         break;
-
+#endif /* (HAVE_EVPN) */
       default:
         sprintf (str, "UNK prefix");
         break;

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -62,6 +62,8 @@ struct evpn_addr
 #define IP_ADDR_NONE      0x0
 #define IP_ADDR_V4        0x1
 #define IP_ADDR_V6        0x2
+#define IP_PREFIX_V4      0x4
+#define IP_PREFIX_V6      0x8
   struct ethaddr mac;
   uint32_t eth_tag;
   u_char ip_prefix_length;

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -47,6 +47,39 @@ struct ethaddr {
 } __packed;
 
 
+/* length is the number of valuable bits of prefix structure 
+* 18 bytes is current length in structure, if address is ipv4
+* 30 bytes is in case of ipv6
+*/
+#define PREFIX_LEN_ROUTE_TYPE_5_IPV4 (18*8)
+#define PREFIX_LEN_ROUTE_TYPE_5_IPV6 (30*8)
+
+/* EVPN address (RFC 7432) */
+struct evpn_addr
+{
+  u_char route_type;
+  u_char flags;
+#define IP_ADDR_NONE      0x0
+#define IP_ADDR_V4        0x1
+#define IP_ADDR_V6        0x2
+  struct ethaddr mac;
+  uint32_t eth_tag;
+  u_char ip_prefix_length;
+  union
+  {
+    struct in_addr v4_addr;
+    struct in6_addr v6_addr;
+  } ip;
+};
+
+/* EVPN prefix structure. */
+struct prefix_evpn
+{
+  u_char family;
+  u_char prefixlen;
+  struct evpn_addr prefix __attribute__ ((aligned (8)));
+};
+
 /*
  * A struct prefix contains an address family, a prefix length, and an
  * address.  This can represent either a 'network prefix' as defined
@@ -83,6 +116,9 @@ struct prefix
     struct ethaddr prefix_eth;	/* AF_ETHERNET */
     u_char val[8];
     uintptr_t ptr;
+#if defined(HAVE_EVPN)
+    struct evpn_addr prefix_evpn;
+#endif
   } u __attribute__ ((aligned (8)));
 };
 

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -69,6 +69,7 @@ struct evpn_addr
   u_char ip_prefix_length;
   union
   {
+    u_char addr;
     struct in_addr v4_addr;
     struct in6_addr v6_addr;
   } ip;
@@ -192,11 +193,12 @@ union prefix46ptr
   struct prefix_ipv6 *p6;
 } __attribute__ ((transparent_union));
 
-union prefix46constptr
+union prefixconstptr
 {
   const struct prefix *p;
   const struct prefix_ipv4 *p4;
   const struct prefix_ipv6 *p6;
+  const struct prefix_evpn *evp;
 } __attribute__ ((transparent_union));
 
 #ifndef INET_ADDRSTRLEN
@@ -270,7 +272,7 @@ extern int str2prefix (const char *, struct prefix *);
 
 #define PREFIX2STR_BUFFER  PREFIX_STRLEN
 
-extern const char *prefix2str (union prefix46constptr, char *, int);
+extern const char *prefix2str (union prefixconstptr, char *, int);
 extern int prefix_match (const struct prefix *, const struct prefix *);
 extern int prefix_same (const struct prefix *, const struct prefix *);
 extern int prefix_cmp (const struct prefix *, const struct prefix *);

--- a/lib/prefix.h
+++ b/lib/prefix.h
@@ -44,7 +44,7 @@
  */
 struct ethaddr {
     u_char octet[ETHER_ADDR_LEN];
-} __packed;
+} __attribute__ ((packed));
 
 
 /* length is the number of valuable bits of prefix structure 

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -749,6 +749,7 @@ vty_end_config (struct vty *vty)
     case BGP_IPV4M_NODE:
     case BGP_IPV6_NODE:
     case BGP_IPV6M_NODE:
+    case BGP_EVPN_NODE:
     case RMAP_NODE:
     case OSPF_NODE:
     case OSPF6_NODE:

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -465,7 +465,8 @@ typedef enum {
   AFI_IP  = 1,
   AFI_IP6 = 2,
   AFI_ETHER = 3,                /* RFC 1700 has "6" for 802.* */
-  AFI_MAX = 4
+  AFI_L2VPN = 4,
+  AFI_MAX = 5
 } afi_t;
 
 /* Subsequent Address Family Identifier. */
@@ -475,7 +476,8 @@ typedef enum {
 #define SAFI_RESERVED_4           4
 #define SAFI_ENCAP		  5
 #define SAFI_RESERVED_5           5
-#define SAFI_MAX                  6
+#define SAFI_EVPN                 6
+#define SAFI_MAX                  7
 
 /*
  * The above AFI and SAFI definitions are for internal use. The protocol
@@ -497,6 +499,7 @@ typedef enum {
 #define IANA_SAFI_UNICAST             1
 #define IANA_SAFI_MULTICAST           2
 #define IANA_SAFI_ENCAP               7
+#define IANA_SAFI_EVPN                70
 #define IANA_SAFI_MPLS_VPN            128
 
 /* Default Administrative Distance of each protocol. */
@@ -537,6 +540,8 @@ static inline afi_t afi_iana2int (afi_t afi)
     return AFI_IP;
   if (afi == IANA_AFI_IPV6)
     return AFI_IP6;
+  if (afi == IANA_AFI_L2VPN)
+    return AFI_L2VPN;
   return AFI_MAX;
 }
 
@@ -546,6 +551,8 @@ static inline afi_t afi_int2iana (afi_t afi)
     return IANA_AFI_IPV4;
   if (afi == AFI_IP6)
     return IANA_AFI_IPV6;
+  if (afi == AFI_L2VPN)
+    return IANA_AFI_L2VPN;
   return IANA_AFI_RESERVED;
 }
 
@@ -559,6 +566,8 @@ static inline safi_t safi_iana2int (safi_t safi)
     return SAFI_MPLS_VPN;
   if (safi == IANA_SAFI_ENCAP)
     return SAFI_ENCAP;
+  if (safi == IANA_SAFI_EVPN)
+    return SAFI_EVPN;
   return SAFI_MAX;
 }
 
@@ -572,6 +581,8 @@ static inline safi_t safi_int2iana (safi_t safi)
     return IANA_SAFI_MPLS_VPN;
   if (safi == SAFI_ENCAP)
     return IANA_SAFI_ENCAP;
+  if (safi == SAFI_EVPN)
+    return IANA_SAFI_EVPN;
   return IANA_SAFI_RESERVED;
 }
 

--- a/tests/ecommunity_test.c
+++ b/tests/ecommunity_test.c
@@ -97,10 +97,10 @@ validate (struct ecommunity *ecom, const struct test_spec *sp)
   char *str1, *str2;
     
   printf ("got:\n  %s\n", ecommunity_str (ecom));
-  str1 = ecommunity_ecom2str (ecom, ECOMMUNITY_FORMAT_COMMUNITY_LIST);
+  str1 = ecommunity_ecom2str (ecom, ECOMMUNITY_FORMAT_COMMUNITY_LIST, 0);
   etmp = ecommunity_str2com (str1, 0, 1);
   if (etmp)
-    str2 = ecommunity_ecom2str (etmp, ECOMMUNITY_FORMAT_COMMUNITY_LIST);
+    str2 = ecommunity_ecom2str (etmp, ECOMMUNITY_FORMAT_COMMUNITY_LIST, 0);
   else
     str2 = NULL;
   

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1195,7 +1195,7 @@ DEFUNSH (VTYSH_BGPD,
 DEFUNSH (VTYSH_BGPD,
 	 address_family_evpn,
 	 address_family_evpn_cmd,
-	 "address-family <evpn|l2vpn evpn>",
+	 "address-family <l2vpn evpn>",
          "Enter Address Family command mode\n"
          "EVPN Address family\n"
          "Layer2 VPN Address family\n"

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -307,7 +307,7 @@ vtysh_execute_func (const char *line, int pager)
 	   || saved_node == BGP_ENCAP_NODE || saved_node == BGP_ENCAPV6_NODE
            || saved_node == BGP_IPV4_NODE
 	   || saved_node == BGP_IPV6_NODE || saved_node == BGP_IPV4M_NODE
-	   || saved_node == BGP_IPV6M_NODE)
+	   || saved_node == BGP_IPV6M_NODE || saved_node == BGP_EVPN_NODE)
 	  && (tried == 1))
 	{
 	  vtysh_execute("exit-address-family");
@@ -557,7 +557,8 @@ vtysh_mark_file (const char *filename)
 	{
 	  if ((prev_node == BGP_VPNV4_NODE || prev_node == BGP_IPV4_NODE
 	       || prev_node == BGP_IPV6_NODE || prev_node == BGP_IPV4M_NODE
-	       || prev_node == BGP_IPV6M_NODE || prev_node == BGP_VPNV6_NODE)
+	       || prev_node == BGP_IPV6M_NODE || prev_node == BGP_VPNV6_NODE
+               || prev_node == BGP_EVPN_NODE)
 	      && (tried == 1))
 	    {
 	      fprintf(stdout, "exit-address-family\n");
@@ -951,6 +952,12 @@ static struct cmd_node bgp_ipv6m_node =
   "%s(config-router-af)# "
 };
 
+static struct cmd_node bgp_evpn_node =
+{
+  BGP_EVPN_NODE,
+  "%s(config-router-af)# "
+};
+
 static struct cmd_node bgp_vnc_defaults_node =
 {
   BGP_VNC_DEFAULTS_NODE,
@@ -1182,6 +1189,20 @@ DEFUNSH (VTYSH_BGPD,
 	 "Address Family Modifier\n")
 {
   vty->node = BGP_IPV6M_NODE;
+  return CMD_SUCCESS;
+}
+
+DEFUNSH (VTYSH_BGPD,
+	 address_family_evpn,
+	 address_family_evpn_cmd,
+	 "address-family evpn",
+	 "Enter Address Family command mode\n"
+         "Enter Address Family command mode\n"
+         "Address family\n")
+{
+#if defined(HAVE_EVPN)
+  vty->node = BGP_EVPN_NODE;
+#endif /* HAVE_EVPN */
   return CMD_SUCCESS;
 }
 
@@ -1481,6 +1502,7 @@ vtysh_exit (struct vty *vty)
     case BGP_IPV4M_NODE:
     case BGP_IPV6_NODE:
     case BGP_IPV6M_NODE:
+    case BGP_EVPN_NODE:
     case BGP_VNC_DEFAULTS_NODE:
     case BGP_VNC_NVE_GROUP_NODE:
     case BGP_VNC_L2_GROUP_NODE:
@@ -3042,6 +3064,7 @@ vtysh_init_vty (void)
   install_node (&bgp_ipv4m_node, NULL);
   install_node (&bgp_ipv6_node, NULL);
   install_node (&bgp_ipv6m_node, NULL);
+  install_node (&bgp_evpn_node, NULL);
   install_node (&bgp_vnc_defaults_node, NULL);
   install_node (&bgp_vnc_nve_group_node, NULL);
   install_node (&bgp_vnc_l2_group_node, NULL);
@@ -3078,6 +3101,7 @@ vtysh_init_vty (void)
   vtysh_install_default (BGP_IPV4M_NODE);
   vtysh_install_default (BGP_IPV6_NODE);
   vtysh_install_default (BGP_IPV6M_NODE);
+  vtysh_install_default (BGP_EVPN_NODE);
 #if ENABLE_BGP_VNC
   vtysh_install_default (BGP_VNC_DEFAULTS_NODE);
   vtysh_install_default (BGP_VNC_NVE_GROUP_NODE);
@@ -3149,6 +3173,7 @@ vtysh_init_vty (void)
   install_element (BGP_IPV6_NODE, &vtysh_quit_bgpd_cmd);
   install_element (BGP_IPV6M_NODE, &vtysh_exit_bgpd_cmd);
   install_element (BGP_IPV6M_NODE, &vtysh_quit_bgpd_cmd);
+  install_element (BGP_EVPN_NODE, &vtysh_quit_bgpd_cmd);
 #if defined (ENABLE_BGP_VNC)
   install_element (BGP_VNC_DEFAULTS_NODE, &vtysh_exit_bgpd_cmd);
   install_element (BGP_VNC_DEFAULTS_NODE, &vtysh_quit_bgpd_cmd);
@@ -3191,6 +3216,7 @@ vtysh_init_vty (void)
   install_element (BGP_ENCAPV6_NODE, &vtysh_end_all_cmd);
   install_element (BGP_IPV6_NODE, &vtysh_end_all_cmd);
   install_element (BGP_IPV6M_NODE, &vtysh_end_all_cmd);
+  install_element (BGP_EVPN_NODE, &vtysh_end_all_cmd);
   install_element (BGP_VNC_DEFAULTS_NODE, &vtysh_end_all_cmd);
   install_element (BGP_VNC_NVE_GROUP_NODE, &vtysh_end_all_cmd);
   install_element (BGP_VNC_L2_GROUP_NODE, &vtysh_end_all_cmd);
@@ -3247,6 +3273,7 @@ vtysh_init_vty (void)
   install_element (BGP_NODE, &address_family_ipv4_multicast_cmd);
   install_element (BGP_NODE, &address_family_ipv6_cmd);
   install_element (BGP_NODE, &address_family_ipv6_multicast_cmd);
+  install_element (BGP_NODE, &address_family_evpn_cmd);
   install_element (BGP_VPNV4_NODE, &exit_address_family_cmd);
   install_element (BGP_VPNV6_NODE, &exit_address_family_cmd);
   install_element (BGP_ENCAP_NODE, &exit_address_family_cmd);
@@ -3255,6 +3282,7 @@ vtysh_init_vty (void)
   install_element (BGP_IPV4M_NODE, &exit_address_family_cmd);
   install_element (BGP_IPV6_NODE, &exit_address_family_cmd);
   install_element (BGP_IPV6M_NODE, &exit_address_family_cmd);
+  install_element (BGP_EVPN_NODE, &exit_address_family_cmd);
 
   install_element (BGP_VNC_DEFAULTS_NODE, &exit_vnc_config_cmd);
   install_element (BGP_VNC_NVE_GROUP_NODE, &exit_vnc_config_cmd);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1195,10 +1195,11 @@ DEFUNSH (VTYSH_BGPD,
 DEFUNSH (VTYSH_BGPD,
 	 address_family_evpn,
 	 address_family_evpn_cmd,
-	 "address-family evpn",
-	 "Enter Address Family command mode\n"
+	 "address-family <evpn|l2vpn evpn>",
          "Enter Address Family command mode\n"
-         "Address family\n")
+         "EVPN Address family\n"
+         "Layer2 VPN Address family\n"
+         "Ethernet Virtual Private Network Subsequent Address Family\n")
 {
 #if defined(HAVE_EVPN)
   vty->node = BGP_EVPN_NODE;

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -313,7 +313,7 @@ extern void rib_lookup_and_dump (struct prefix_ipv4 *, vrf_id_t);
 extern void rib_lookup_and_pushup (struct prefix_ipv4 *, vrf_id_t);
 #define rib_dump(prefix ,rib) _rib_dump(__func__, prefix, rib)
 extern void _rib_dump (const char *,
-		       union prefix46constptr, const struct rib *);
+		       union prefixconstptr, const struct rib *);
 extern int rib_lookup_ipv4_route (struct prefix_ipv4 *, union sockunion *,
                                   vrf_id_t);
 #define ZEBRA_RIB_LOOKUP_ERROR -1

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -2428,7 +2428,7 @@ rib_delnode (struct route_node *rn, struct rib *rib)
  */
 
 void _rib_dump (const char * func,
-		union prefix46constptr pp, const struct rib * rib)
+		union prefixconstptr pp, const struct rib * rib)
 {
   const struct prefix *p = pp.p;
   char straddr[PREFIX_STRLEN];


### PR DESCRIPTION
This series of commit is supposed to respond to the following issue previously entered on github frr:
https://github.com/freerangerouting/frr/issues/79

This series of commit proposes:
- a set of new files for handling EVPN.
The defines and structures are inherited from rfc7432 specification.
- a define in order to compile with or without EVPN support.
The fact is introduction of evpn prefixes has great consequences on memory.
- the handling of a specific route type 5 message as specified in https://tools.ietf.org/html/draft-ietf-bess-evpn-prefix-advertisement-03.
It handles both ipv4 and ipv6 evpn messages.
- a set of vty commands to configure and monitor evpn entries.

This series of commits does not propose:
- changes related to evpn import processing
- handling of route type 2, type 1

Best Regards,

Philippe