### PR TITLE
debian: Fix changelog so sbuild will work

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ frr (2.0) Released; urgency=medium
 
   * Switchover to FRR
 
+ -- frr <frr@lists.nox.tf> Mon, 23 Jan 2017 16:30:22 -0400
+
 quagga (0.99.24+cl3u5) RELEASED; urgency=medium
 
   * Closes: CM-12846 - Resolve Memory leaks in 'show ip bgp neighbor json'


### PR DESCRIPTION
Fix the changelog so a sbuild issued for the
creation of a .deb works.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>