### PR TITLE
bgpd: remove duplicated vty command to enter in vpn address family node

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -5588,28 +5588,6 @@ DEFUN (address_family_vpnv6,
 }
 #endif /* KEEP_OLD_VPN_COMMANDS */
 
-DEFUN (address_family_ipv4_vpn,
-       address_family_ipv4_vpn_cmd,
-       "address-family ipv4 vpn",
-       "Enter Address Family command mode\n"
-       "Address Family\n"
-       "Subsequent Address Family modifier\n")
-{
-  vty->node = BGP_VPNV4_NODE;
-  return CMD_SUCCESS;
-}
-
-DEFUN (address_family_ipv6_vpn,
-       address_family_ipv6_vpn_cmd,
-       "address-family ipv6 vpn",
-       "Enter Address Family command mode\n"
-       "Address Family\n"
-       "Subsequent Address Family modifier\n")
-{
-  vty->node = BGP_VPNV6_NODE;
-  return CMD_SUCCESS;
-}
-
 DEFUN (address_family_encap,
        address_family_encap_cmd,
        "address-family <encap|encapv4>",
@@ -10717,9 +10695,6 @@ bgp_vty_init (void)
   install_element (BGP_NODE, &address_family_vpnv4_cmd);
   install_element (BGP_NODE, &address_family_vpnv6_cmd);
 #endif /* KEEP_OLD_VPN_COMMANDS */
-  install_element (BGP_NODE, &address_family_ipv4_vpn_cmd);
-  install_element (BGP_NODE, &address_family_ipv6_vpn_cmd);
-
   install_element (BGP_NODE, &address_family_encap_cmd);
   install_element (BGP_NODE, &address_family_encapv6_cmd);
 


### PR DESCRIPTION
Because the vpn configuration command was duplicate, there was an
ambiguity to raise. This is a fix that permits configuring vpnv4 or
vpnv6 address-families on bgp.

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>