### PR TITLE
2.0, Issue #91 FIx VPN/ENCAP safi handoff to rfapi

### DIFF
--- a/bgpd/bgp_encap.c
+++ b/bgpd/bgp_encap.c
@@ -188,15 +188,7 @@ bgp_nlri_parse_encap(
       if (attr) {
 	bgp_update (peer, &p, 0, attr, afi, SAFI_ENCAP,
 		    ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, NULL, 0);
-#if ENABLE_BGP_VNC
-	rfapiProcessUpdate(peer, NULL, &p, &prd, attr, afi, SAFI_ENCAP,
-                           ZEBRA_ROUTE_BGP,  BGP_ROUTE_NORMAL, NULL);
-#endif
       } else {
-#if ENABLE_BGP_VNC
-	rfapiProcessWithdraw(peer, NULL, &p, &prd, attr, afi, SAFI_ENCAP,
-                             ZEBRA_ROUTE_BGP, 0);
-#endif
 	bgp_withdraw (peer, &p, 0, attr, afi, SAFI_ENCAP,
 		      ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, NULL);
       }

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -154,9 +154,6 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
   safi_t safi;
   int addpath_encoded;
   u_int32_t addpath_id;
-#if ENABLE_BGP_VNC
-  u_int32_t label = 0;
-#endif
 
   /* Check peer status. */
   if (peer->status != Established)
@@ -232,10 +229,6 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
           return -1;
         }
       
-#if ENABLE_BGP_VNC
-      label = decode_label (pnt);
-#endif
-
       /* Copyr label to prefix. */
       tagpnt = pnt;
 
@@ -277,18 +270,9 @@ bgp_nlri_parse_vpn (struct peer *peer, struct attr *attr,
         {
           bgp_update (peer, &p, addpath_id, attr, packet->afi, SAFI_MPLS_VPN,
                       ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, tagpnt, 0);
-#if ENABLE_BGP_VNC
-          rfapiProcessUpdate(peer, NULL, &p, &prd, attr, packet->afi, 
-                             SAFI_MPLS_VPN, ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL,
-                             &label);
-#endif
         }
       else
         {
-#if ENABLE_BGP_VNC
-          rfapiProcessWithdraw(peer, NULL, &p, &prd, attr, packet->afi, 
-                               SAFI_MPLS_VPN, ZEBRA_ROUTE_BGP, 0);
-#endif
           bgp_withdraw (peer, &p, addpath_id, attr, packet->afi, SAFI_MPLS_VPN,
                         ZEBRA_ROUTE_BGP, BGP_ROUTE_NORMAL, &prd, tagpnt);
         }
@@ -588,7 +572,7 @@ show_adj_route_vpn (struct vty *vty, struct peer *peer, afi_t afi, struct prefix
                       struct rd_as rd_as;
                       struct rd_ip rd_ip = {0};
 #if ENABLE_BGP_VNC
-                      struct rd_vnc_eth rd_vnc_eth;
+                      struct rd_vnc_eth rd_vnc_eth = {0};
 #endif
                       u_char *pnt;
 
@@ -798,7 +782,7 @@ bgp_show_mpls_vpn (struct vty *vty, afi_t afi, struct prefix_rd *prd,
 		      struct rd_as rd_as;
 		      struct rd_ip rd_ip = {0};
 #if ENABLE_BGP_VNC
-                      struct rd_vnc_eth rd_vnc_eth;
+                      struct rd_vnc_eth rd_vnc_eth = {0};
 #endif
 		      u_char *pnt;
 

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2686,6 +2686,21 @@ bgp_update (struct peer *peer, struct prefix *p, u_int32_t addpath_id,
       bgp_process (bgp, rn, afi, safi);
       bgp_unlock_node (rn);
 
+#if ENABLE_BGP_VNC
+  if (SAFI_MPLS_VPN == safi)
+    {
+      uint32_t    label = decode_label(tag);
+
+      rfapiProcessUpdate(peer, NULL, p, prd, attr, afi, safi, type, sub_type,
+        &label);
+    }
+  if (SAFI_ENCAP == safi)
+    {
+      rfapiProcessUpdate(peer, NULL, p, prd, attr, afi, safi, type, sub_type,
+        NULL);
+    }
+#endif
+
       return 0;
     } // End of implicit withdraw
 
@@ -2780,6 +2795,21 @@ bgp_update (struct peer *peer, struct prefix *p, u_int32_t addpath_id,
   /* Process change. */
   bgp_process (bgp, rn, afi, safi);
 
+#if ENABLE_BGP_VNC
+  if (SAFI_MPLS_VPN == safi)
+    {
+      uint32_t    label = decode_label(tag);
+
+      rfapiProcessUpdate(peer, NULL, p, prd, attr, afi, safi, type, sub_type,
+        &label);
+    }
+  if (SAFI_ENCAP == safi)
+    {
+      rfapiProcessUpdate(peer, NULL, p, prd, attr, afi, safi, type, sub_type,
+        NULL);
+    }
+#endif
+
   return 0;
 
   /* This BGP update is filtered.  Log the reason then update BGP
@@ -2818,6 +2848,13 @@ bgp_withdraw (struct peer *peer, struct prefix *p, u_int32_t addpath_id,
   char buf2[30];
   struct bgp_node *rn;
   struct bgp_info *ri;
+
+#if ENABLE_BGP_VNC
+  if ((SAFI_MPLS_VPN == safi) || (SAFI_ENCAP == safi))
+    {
+      rfapiProcessWithdraw(peer, NULL, p, prd, NULL, afi, safi, type, 0);
+    }
+#endif
 
   bgp = peer->bgp;
 

--- a/bgpd/rfapi/rfapi.c
+++ b/bgpd/rfapi/rfapi.c
@@ -417,9 +417,10 @@ del_vnc_route (
     {
 
       vnc_zlog_debug_verbose
-        ("%s: trying bi=%p, bi->peer=%p, bi->type=%d, bi->sub_type=%d, bi->extra->vnc.export.rfapi_handle=%p",
+        ("%s: trying bi=%p, bi->peer=%p, bi->type=%d, bi->sub_type=%d, bi->extra->vnc.export.rfapi_handle=%p, local_pref=%u",
          __func__, bi, bi->peer, bi->type, bi->sub_type,
-         (bi->extra ? bi->extra->vnc.export.rfapi_handle : NULL));
+         (bi->extra ? bi->extra->vnc.export.rfapi_handle : NULL),
+	 ((bi->attr && CHECK_FLAG(bi->attr->flag, ATTR_FLAG_BIT (BGP_ATTR_LOCAL_PREF)))? bi->attr->local_pref: 0));
 
       if (bi->peer == peer &&
           bi->type == type &&

--- a/bgpd/rfapi/rfapi_import.c
+++ b/bgpd/rfapi/rfapi_import.c
@@ -3724,6 +3724,12 @@ rfapiBgpInfoFilteredImportVPN (
       if (rn->info)
         original_had_routes = 1;
 
+      if (VNC_DEBUG(VERBOSE))
+        {
+          vnc_zlog_debug_verbose ("%s: showing IT node on entry", __func__);
+          rfapiShowItNode (NULL, rn);   /* debug */
+        }
+
       /*
        * Look for same route (will have same RD and peer)
        */


### PR DESCRIPTION
bgpd rfapi: Shift rfapi receive hooks for vpn and encap safis into
     bgp_update/bgp_withdraw (Issue #91)
