### PR TITLE
bgpd: build failed due to show_adj_route_vpn() not being used

### DIFF
--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -566,6 +566,7 @@ DEFUN (no_vpnv6_network,
   return bgp_static_unset_safi (SAFI_MPLS_VPN, vty, argv[idx_ipv6_prefix]->arg, argv[idx_ext_community]->arg, argv[idx_word]->arg);
 }
 
+#ifdef KEEP_OLD_VPN_COMMANDS
 static int
 show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd, u_char use_json, afi_t afi)
 {
@@ -732,6 +733,7 @@ show_adj_route_vpn (struct vty *vty, struct peer *peer, struct prefix_rd *prd, u
     }
   return CMD_SUCCESS;
 }
+#endif /* KEEP_OLD_VPN_COMMANDS */
 
 enum bgp_show_type
 {


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>

 CC       bgp_snmp.o
  CC       bgp_ecommunity.o
  CC       bgp_mplsvpn.o
  CC       bgp_nexthop.o
bgp_mplsvpn.c:570:1: error: ‘show_adj_route_vpn’ defined but not used
[-Werror=unused-function]
 show_adj_route_vpn (struct vty *vty, struct peer *peer, struct
prefix_rd *prd, u_char use_json, afi_t afi)
 ^
  CC       bgp_damp.o
cc1: all warnings being treated as errors