### PR TITLE
frr: Allow configure to actually disable snmp

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1287,7 +1287,7 @@ AC_SUBST(HAVE_LIBPCREPOSIX)
 dnl ------------------
 dnl check Net-SNMP library
 dnl ------------------
-if test "${enable_snmp}" != ""; then
+if test "${enable_snmp}" != "no"; then
    AC_PATH_TOOL([NETSNMP_CONFIG], [net-snmp-config], [no])
    if test x"$NETSNMP_CONFIG" = x"no"; then
       AC_MSG_ERROR([--enable-snmp given but unable to find net-snmp-config])


### PR DESCRIPTION
If you do not have any snmp libraries installed on your system
and you happen to run configure ... '--disable-snmp'
the configure script would still test for the snmp libraries
and attempt to configure with them.

This allows you to intentionally disable snmp

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>