### PR TITLE
bgpd: add multipath command for ip[v4/v6] vpn address-family

### DIFF
--- a/bgpd/bgp_vty.c
+++ b/bgpd/bgp_vty.c
@@ -10055,6 +10055,16 @@ bgp_vty_init (void)
   install_element(BGP_IPV6_NODE, &bgp_maxpaths_ibgp_cluster_cmd);
   install_element (BGP_IPV6_NODE, &no_bgp_maxpaths_ibgp_cmd);
 
+  install_element (BGP_VPNV4_NODE, &bgp_maxpaths_cmd);
+  install_element (BGP_VPNV4_NODE, &no_bgp_maxpaths_cmd);
+  install_element (BGP_VPNV4_NODE, &bgp_maxpaths_ibgp_cmd);
+  install_element (BGP_VPNV4_NODE, &no_bgp_maxpaths_ibgp_cmd);
+  install_element (BGP_VPNV6_NODE, &bgp_maxpaths_cmd);
+  install_element (BGP_VPNV6_NODE, &no_bgp_maxpaths_cmd);
+  install_element (BGP_VPNV6_NODE, &bgp_maxpaths_ibgp_cmd);
+  install_element (BGP_VPNV6_NODE, &no_bgp_maxpaths_ibgp_cmd);
+
+
   /* "timers bgp" commands. */
   install_element (BGP_NODE, &bgp_timers_cmd);
   install_element (BGP_NODE, &no_bgp_timers_cmd);


### PR DESCRIPTION
It is possible to enable multipath command into ipv4 vpn and ipv6 vpn
address-family subnode. The following commands are available through vty
interface:

[no] maximum-paths [ibgp] <1-64>

Signed-off-by: Philippe Guibert <philippe.guibert@6wind.com>