### PR TITLE
isisd: parse TE-IP reachability and IPv6 reachability subtlvs

### DIFF
--- a/isisd/isis_tlv.h
+++ b/isisd/isis_tlv.h
@@ -223,7 +223,7 @@ struct te_ipv4_reachability
   u_char prefix_start;		/* since this is variable length by nature it only */
 };				/* points to an approximate location */
 
-
+#define TE_IPV4_HAS_SUBTLV (0x40)
 
 struct idrp_info
 {


### PR DESCRIPTION
Without this patch, isisd will screw up parsing of reachabilities if subtlvs are present. It might be nice to have this included in the 2.0 release.