### PR TITLE
Fix debian package build.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ frr (2.1) Released; urgency=medium
 
   * Switchover to FRR
 
+ -- Donald Sharp <sharpd@cumulusnetworks.com>  Sun, 29 Jan 2017 19:06:11 -0500
+
 quagga (0.99.24+cl3u5) RELEASED; urgency=medium
 
   * Closes: CM-12846 - Resolve Memory leaks in 'show ip bgp neighbor json'


### PR DESCRIPTION
Debian build tools refuse to work if changelog is malformed, so I fixed it to be well-formed.

Also, looks like the debian/control was copied from the debian quagga package? I suppose the maintainer address should be updated too, and the description... Does anyone really remember what routed was? ;)