### PR TITLE
2.0: complete Issue#91 fix (regression now clean)

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2835,6 +2835,17 @@ bgp_update (struct peer *peer, struct prefix *p, u_int32_t addpath_id,
 
   bgp_unlock_node (rn);
 
+#if ENABLE_BGP_VNC
+  /*
+   * Filtered update is treated as an implicit withdrawal (see bgp_rib_remove()
+   * a few lines above)
+   */
+  if ((SAFI_MPLS_VPN == safi) || (SAFI_ENCAP == safi))
+    {
+      rfapiProcessWithdraw(peer, NULL, p, prd, NULL, afi, safi, type, 0);
+    }
+#endif
+
   return 0;
 }
 


### PR DESCRIPTION
 bgpd rfapi: RR replated (Issue #91) treat filtered update
    as implicit withdraw for rfapi

