### PR TITLE
vty: fix uninitialized variable in vty_close

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2230,7 +2230,7 @@ void
 vty_close (struct vty *vty)
 {
   int i;
-  bool was_stdio;
+  bool was_stdio = false;
 
   /* Cancel threads.*/
   if (vty->t_read)


### PR DESCRIPTION
Per https://github.com/freerangerouting/frr/issues/160