### PR TITLE
Pim vrf

### DIFF
--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -389,15 +389,15 @@ static void pim_sock_read_on(struct interface *ifp)
 		 pim_ifp->pim_sock_fd);
 }
 
-static int pim_sock_open(struct in_addr ifaddr, ifindex_t ifindex)
+static int pim_sock_open(struct in_addr ifaddr, struct interface *ifp)
 {
   int fd;
 
-  fd = pim_socket_mcast(IPPROTO_PIM, ifaddr, ifindex, 0 /* loop=false */);
+  fd = pim_socket_mcast(IPPROTO_PIM, ifaddr, ifp, 0 /* loop=false */);
   if (fd < 0)
     return -1;
 
-  if (pim_socket_join(fd, qpim_all_pim_routers_addr, ifaddr, ifindex)) {
+  if (pim_socket_join(fd, qpim_all_pim_routers_addr, ifaddr, ifp->ifindex)) {
     close(fd);
     return -2;
   }
@@ -808,7 +808,7 @@ int pim_sock_add(struct interface *ifp)
 
   ifaddr = pim_ifp->primary_address;
 
-  pim_ifp->pim_sock_fd = pim_sock_open(ifaddr, ifp->ifindex);
+  pim_ifp->pim_sock_fd = pim_sock_open(ifaddr, ifp);
   if (pim_ifp->pim_sock_fd < 0) {
     if (PIM_DEBUG_PIM_PACKETS)
       zlog_debug("Could not open PIM socket on interface %s",

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -389,15 +389,16 @@ static void pim_sock_read_on(struct interface *ifp)
 		 pim_ifp->pim_sock_fd);
 }
 
-static int pim_sock_open(struct in_addr ifaddr, struct interface *ifp)
+static int pim_sock_open(struct interface *ifp)
 {
   int fd;
+  struct pim_interface *pim_ifp = ifp->info;
 
-  fd = pim_socket_mcast(IPPROTO_PIM, ifaddr, ifp, 0 /* loop=false */);
+  fd = pim_socket_mcast(IPPROTO_PIM, pim_ifp->primary_address, ifp, 0 /* loop=false */);
   if (fd < 0)
     return -1;
 
-  if (pim_socket_join(fd, qpim_all_pim_routers_addr, ifaddr, ifp->ifindex)) {
+  if (pim_socket_join(fd, qpim_all_pim_routers_addr, pim_ifp->primary_address, ifp->ifindex)) {
     close(fd);
     return -2;
   }
@@ -793,7 +794,6 @@ void pim_hello_restart_triggered(struct interface *ifp)
 int pim_sock_add(struct interface *ifp)
 {
   struct pim_interface *pim_ifp;
-  struct in_addr ifaddr;
   uint32_t old_genid;
 
   pim_ifp = ifp->info;
@@ -806,9 +806,7 @@ int pim_sock_add(struct interface *ifp)
     return -1;
   }
 
-  ifaddr = pim_ifp->primary_address;
-
-  pim_ifp->pim_sock_fd = pim_sock_open(ifaddr, ifp);
+  pim_ifp->pim_sock_fd = pim_sock_open(ifp);
   if (pim_ifp->pim_sock_fd < 0) {
     if (PIM_DEBUG_PIM_PACKETS)
       zlog_debug("Could not open PIM socket on interface %s",

--- a/pimd/pim_sock.c
+++ b/pimd/pim_sock.c
@@ -111,7 +111,7 @@ pim_socket_bind (int fd, struct interface *ifp)
   return ret;
 }
 
-int pim_socket_mcast(int protocol, struct in_addr ifaddr, int ifindex, u_char loop)
+int pim_socket_mcast(int protocol, struct in_addr ifaddr, struct interface *ifp, u_char loop)
 {
   int rcvbuf = 1024 * 1024 * 8;
 #ifdef HAVE_STRUCT_IP_MREQN_IMR_IFINDEX
@@ -132,9 +132,6 @@ int pim_socket_mcast(int protocol, struct in_addr ifaddr, int ifindex, u_char lo
   if (protocol == IPPROTO_PIM)
     {
       int ret;
-      struct interface *ifp = NULL;
-
-      ifp = if_lookup_by_index_vrf (ifindex, VRF_DEFAULT);
 
       ret = pim_socket_bind (fd, ifp);
       if (ret)
@@ -222,7 +219,7 @@ int pim_socket_mcast(int protocol, struct in_addr ifaddr, int ifindex, u_char lo
 
   memset (&mreq, 0, sizeof (mreq));
 #ifdef HAVE_STRUCT_IP_MREQN_IMR_IFINDEX
-  mreq.imr_ifindex = ifindex;
+  mreq.imr_ifindex = ifp->ifindex;
 #else
   /*
    * I am not sure what to do here yet for *BSD

--- a/pimd/pim_sock.h
+++ b/pimd/pim_sock.h
@@ -39,7 +39,7 @@
 int pim_socket_bind (int fd, struct interface *ifp);
 int pim_socket_ip_hdr (int fd);
 int pim_socket_raw(int protocol);
-int pim_socket_mcast(int protocol, struct in_addr ifaddr, int ifindex, u_char loop);
+int pim_socket_mcast(int protocol, struct in_addr ifaddr, struct interface *ifp, u_char loop);
 int pim_socket_join(int fd, struct in_addr group,
 		    struct in_addr ifaddr, ifindex_t ifindex);
 int pim_socket_join_source(int fd, ifindex_t ifindex,


### PR DESCRIPTION
When you attempted to configure a interface that is inside of a vrf with pim commands, it would crash pim.  These two commits fix this issue.