### PR TITLE
lib: Don't use malloc!

### DIFF
--- a/lib/thread.c
+++ b/lib/thread.c
@@ -489,8 +489,8 @@ thread_master_create (void)
 #if defined(HAVE_POLL)
   rv->handler.pfdsize = rv->fd_limit;
   rv->handler.pfdcount = 0;
-  rv->handler.pfds = (struct pollfd *) malloc (sizeof (struct pollfd) * rv->handler.pfdsize);
-  memset (rv->handler.pfds, 0, sizeof (struct pollfd) * rv->handler.pfdsize);
+  rv->handler.pfds = (struct pollfd *) XCALLOC (MTYPE_THREAD_MASTER,
+                                                sizeof (struct pollfd) * rv->handler.pfdsize);
 #endif
   return rv;
 }

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -489,8 +489,8 @@ thread_master_create (void)
 #if defined(HAVE_POLL)
   rv->handler.pfdsize = rv->fd_limit;
   rv->handler.pfdcount = 0;
-  rv->handler.pfds = (struct pollfd *) XCALLOC (MTYPE_THREAD_MASTER,
-                                                sizeof (struct pollfd) * rv->handler.pfdsize);
+  rv->handler.pfds = XCALLOC (MTYPE_THREAD_MASTER,
+                              sizeof (struct pollfd) * rv->handler.pfdsize);
 #endif
   return rv;
 }


### PR DESCRIPTION
thread.c was using malloc.  This was found by the
assert added to memory.c.

Fixes issues #170

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>