### PR TITLE
2.0: Fix encap attribute on wire, protect against broken object.

### DIFF
--- a/bgpd/rfapi/vnc_import_bgp.c
+++ b/bgpd/rfapi/vnc_import_bgp.c
@@ -513,7 +513,8 @@ vnc_import_bgp_add_route_mode_resolve_nve_one_bi (
   if (bi->attr && bi->attr->extra)
     {
       encaptlvs = bi->attr->extra->vnc_subtlvs;
-      if (bi->attr->extra->encap_tunneltype != BGP_ENCAP_TYPE_MPLS)
+      if (bi->attr->extra->encap_tunneltype != BGP_ENCAP_TYPE_RESERVED &&
+          bi->attr->extra->encap_tunneltype != BGP_ENCAP_TYPE_MPLS)
         {
           if (opt != NULL)
             opt->next = &optary[cur_opt];


### PR DESCRIPTION
Issue #172 
bgpd rfapi: advertise encap attribute when TT is valid and not MPLS.
     Ensure tunnel type set based on rx'ed
     Ignore bad/mpls encap types.

