### PR TITLE
ldpd: fix issues reported by coverity scan

### DIFF
--- a/ldpd/ldp_vty_conf.c
+++ b/ldpd/ldp_vty_conf.c
@@ -487,8 +487,10 @@ ldp_vty_address_family(struct vty *vty, struct vty_arg *args[])
 	} else if (strcmp(af_str, "ipv6") == 0) {
 		af = AF_INET6;
 		af_conf = &vty_conf->ipv6;
-	} else
+	} else {
+		ldp_clear_config(vty_conf);
 		return (CMD_WARNING);
+	}
 
 	if (disable) {
 		af_conf->flags &= ~F_LDPD_AF_ENABLED;
@@ -919,7 +921,8 @@ ldp_vty_interface(struct vty *vty, struct vty_arg *args[])
 		if (!ia->enabled) {
 			ia->enabled = 1;
 			ldp_reload_ref(vty_conf, (void **)&iface);
-		}
+		} else
+			ldp_clear_config(vty_conf);
 	}
 
 	switch (af) {

--- a/ldpd/packet.c
+++ b/ldpd/packet.c
@@ -686,8 +686,8 @@ struct tcp_conn *
 tcp_new(int fd, struct nbr *nbr)
 {
 	struct tcp_conn		*tcp;
-	struct sockaddr_storage	 src;
-	socklen_t		 len = sizeof(src);
+	struct sockaddr_storage	 ss;
+	socklen_t		 len = sizeof(ss);
 
 	if ((tcp = calloc(1, sizeof(*tcp))) == NULL)
 		fatal(__func__);
@@ -703,10 +703,14 @@ tcp_new(int fd, struct nbr *nbr)
 		tcp->nbr = nbr;
 	}
 
-	getsockname(fd, (struct sockaddr *)&src, &len);
-	sa2addr((struct sockaddr *)&src, NULL, NULL, &tcp->lport);
-	getpeername(fd, (struct sockaddr *)&src, &len);
-	sa2addr((struct sockaddr *)&src, NULL, NULL, &tcp->rport);
+	if (getsockname(fd, (struct sockaddr *)&ss, &len) != 0)
+		log_warn("%s: getsockname", __func__);
+	else
+		sa2addr((struct sockaddr *)&ss, NULL, NULL, &tcp->lport);
+	if (getpeername(fd, (struct sockaddr *)&ss, &len) != 0)
+		log_warn("%s: getpeername", __func__);
+	else
+		sa2addr((struct sockaddr *)&ss, NULL, NULL, &tcp->rport);
 
 	return (tcp);
 }


### PR DESCRIPTION
Fix two small memleaks in the CLI code and check the return values of
getsockname() and getpeername().

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>