### PR TITLE
Add support for draft-ietf-rtgwg-backoff-algo for IS-IS

### DIFF
--- a/isisd/Makefile.am
+++ b/isisd/Makefile.am
@@ -16,7 +16,7 @@ libisis_a_SOURCES = \
 	isis_tlv.c isisd.c isis_misc.c isis_zebra.c isis_dr.c \
 	isis_flags.c isis_dynhn.c iso_checksum.c isis_csm.c isis_events.c \
 	isis_spf.c isis_redist.c isis_route.c isis_routemap.c isis_te.c \
-	isis_vty.c
+	isis_vty.c isis_spf_delay.c
 
 
 noinst_HEADERS = \
@@ -25,7 +25,7 @@ noinst_HEADERS = \
 	isis_lsp.h dict.h isis_circuit.h isis_misc.h isis_network.h \
 	isis_zebra.h isis_dr.h isis_flags.h isis_dynhn.h isis_common.h \
 	iso_checksum.h isis_csm.h isis_events.h isis_spf.h isis_redist.h \
-	isis_route.h isis_routemap.h isis_te.h
+	isis_route.h isis_routemap.h isis_te.h isis_spf_delay.h
 
 isisd_SOURCES = \
 	isis_main.c $(libisis_a_SOURCES) \

--- a/isisd/isis_constants.h
+++ b/isisd/isis_constants.h
@@ -104,6 +104,10 @@
 
 #define ISIS_MAX_PATH_SPLITS          64
 
+/* Default values for IETF SPF delay */
+#define MIN_SPFD_TIMER                    100
+#define MAX_SPFD_TIMER                    60000
+
 /*
  * NLPID values
  */

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -156,7 +156,6 @@ lsp_destroy (struct isis_lsp *lsp)
     }
 
   isis_spf_schedule (lsp->area, lsp->level);
-  isis_spf_schedule6 (lsp->area, lsp->level);
 
   if (lsp->pdu)
     stream_free (lsp->pdu);
@@ -425,7 +424,6 @@ lsp_inc_seqnum (struct isis_lsp *lsp, u_int32_t seq_num)
                     ntohs (lsp->lsp_header->pdu_len) - 12, 12);
 
   isis_spf_schedule (lsp->area, lsp->level);
-  isis_spf_schedule6 (lsp->area, lsp->level);
 
   return;
 }
@@ -640,7 +638,6 @@ lsp_insert (struct isis_lsp *lsp, dict_t * lspdb)
   if (lsp->lsp_header->seq_num != 0)
     {
       isis_spf_schedule (lsp->area, lsp->level);
-      isis_spf_schedule6 (lsp->area, lsp->level);
     }
 }
 

--- a/isisd/isis_spf.c
+++ b/isisd/isis_spf.c
@@ -1252,10 +1252,8 @@ out:
 
   if (area->spf_delay_ietf[level-1]) {
     if (family == AF_INET) {
-      timerclear(&area->spf_delay_ietf[level-1]->family[0]->next_spf);
       area->spf_delay_ietf[level-1]->family[0]->pending = 0;
     } else if (family == AF_INET6) {
-      timerclear(&area->spf_delay_ietf[level-1]->family[1]->next_spf);
       area->spf_delay_ietf[level-1]->family[1]->pending = 0;
     }
   }
@@ -1274,7 +1272,6 @@ isis_run_spf_l1 (struct thread *thread)
   assert (area);
 
   if (area->spf_delay_ietf[0]) {
-    area->spf_delay_ietf[0]->family[0]->t_spf = NULL;
     area->spf_delay_ietf[0]->family[0]->t_spf = NULL;
   }
 
@@ -1308,7 +1305,6 @@ isis_run_spf_l2 (struct thread *thread)
   assert (area);
 
   if (area->spf_delay_ietf[1]) {
-    area->spf_delay_ietf[1]->family[0]->t_spf = NULL;
     area->spf_delay_ietf[1]->family[0]->t_spf = NULL;
   }
 
@@ -1385,7 +1381,6 @@ isis_run_spf6_l1 (struct thread *thread)
 
   if (area->spf_delay_ietf[0]) {
     area->spf_delay_ietf[0]->family[1]->t_spf = NULL;
-    area->spf_delay_ietf[0]->family[1]->t_spf = NULL;
   }
 
   area->spftree6[0]->t_spf = NULL;
@@ -1417,7 +1412,6 @@ isis_run_spf6_l2 (struct thread *thread)
   assert (area);
 
   if (area->spf_delay_ietf[1]) {
-    area->spf_delay_ietf[1]->family[1]->t_spf = NULL;
     area->spf_delay_ietf[1]->family[1]->t_spf = NULL;
   }
 

--- a/isisd/isis_spf.h
+++ b/isisd/isis_spf.h
@@ -60,14 +60,18 @@ struct isis_vertex
 
 struct isis_spftree
 {
-  struct thread *t_spf;		/* spf threads */
   struct list *paths;		/* the SPT */
   struct list *tents;		/* TENT */
   struct isis_area *area;       /* back pointer to area */
-  int pending;			/* already scheduled */
   unsigned int runcount;        /* number of runs since uptime */
   time_t last_run_timestamp;    /* last run timestamp for scheduling */
   time_t last_run_duration;     /* last run duration in msec */
+};
+
+struct isis_spfstate
+{
+  struct thread *t_spf;		/* SPF threads */
+  int pending;			/* Set when SPF is already scheduled */
 };
 
 struct isis_spftree * isis_spftree_new (struct isis_area *area);
@@ -78,11 +82,14 @@ void spftree_area_init (struct isis_area *area);
 void spftree_area_del (struct isis_area *area);
 void spftree_area_adj_del (struct isis_area *area,
                            struct isis_adjacency *adj);
+
+struct isis_spfstate * isis_spfstate_new (struct isis_area *area);
+void isis_spfstate_del (struct isis_spfstate *spftree);
+void spfstate_area_init (struct isis_area *area);
+void spfstate_area_del (struct isis_area *area);
+
 int isis_spf_schedule (struct isis_area *area, int level);
 void isis_spf_cmds_init (void);
-int isis_spf_schedule6 (struct isis_area *area, int level);
-int isis_run_spf6_l1 (struct thread *thread);
-int isis_run_spf6_l2 (struct thread *thread);
 int isis_run_spf_l1 (struct thread *thread);
 int isis_run_spf_l2 (struct thread *thread);
 

--- a/isisd/isis_spf.h
+++ b/isisd/isis_spf.h
@@ -81,4 +81,9 @@ void spftree_area_adj_del (struct isis_area *area,
 int isis_spf_schedule (struct isis_area *area, int level);
 void isis_spf_cmds_init (void);
 int isis_spf_schedule6 (struct isis_area *area, int level);
+int isis_run_spf6_l1 (struct thread *thread);
+int isis_run_spf6_l2 (struct thread *thread);
+int isis_run_spf_l1 (struct thread *thread);
+int isis_run_spf_l2 (struct thread *thread);
+
 #endif /* _ZEBRA_ISIS_SPF_H */

--- a/isisd/isis_spf_delay.c
+++ b/isisd/isis_spf_delay.c
@@ -1,0 +1,432 @@
+/*
+ * This is an implementation of the IETF SPF delay algorithm 
+ * as explain in draft-ietf-rtgwg-backoff-algo
+ *
+ * Module name: isis_spf_delay.c
+ * Version:     0.1
+ * Created:     25-01-2017 by S. Litkowski 
+ * Copyright (C) 2017 Orange Labs http://www.orange.com/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+ * MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+#include <sys/time.h>
+#include <stdlib.h>
+
+#include "thread.h"
+#include "memory.h"
+#include "prefix.h"
+
+#include "isisd/isis_constants.h"
+#include "isisd/isisd.h"
+#include "isisd/isis_adjacency.h"
+#include "isisd/isis_spf.h"
+#include "isisd/isis_spf_delay.h"
+
+const char       *isis_spf_delay_states[3] = { "QUIET", 
+					       "SHORT_WAIT", 
+					       "LONG_WAIT"};
+
+DEFINE_MTYPE_STATIC(ISISD, ISIS_SPF_DELAY_REINIT, "ISIS spf delay reinit")
+DEFINE_MTYPE_STATIC(ISISD, ISIS_SPF_DELAY_AF, "ISIS spf delay af")
+DEFINE_MTYPE_STATIC(ISISD, ISIS_SPF_DELAY, "ISIS spf delay")
+
+
+int
+isis_spf_delay_event_ttl_expires(struct thread *thread) {
+
+  int level = 0;
+  struct isis_spf_delay_reinit    *reinit;
+  struct isis_area        *area;
+  int family = 0;
+
+  reinit = THREAD_ARG(thread);
+  
+  area = reinit->area;
+  level = reinit->level;
+  family = reinit->family;
+
+  if (family == AF_INET) {
+    family = 0;
+  } else if (family == AF_INET6) {
+    family = 1; 
+  }
+  
+  area->spf_delay_ietf[level-1]->family[family]->state = ISIS_SPF_DELAY_STATE_LONG_WAIT;
+  timerclear(&area->spf_delay_ietf[level-1]->family[family]->ttl_time);	
+  area->spf_delay_ietf[level-1]->family[family]->t_timetolearn = NULL;	
+  if (isis->debugs & DEBUG_SPF_IETF) {
+    zlog_debug ("ISIS-Spf (%s) L%d IETF SPF delay TIMETOLEARN expired moved to state %d (%s) family %d\n",
+                area->area_tag, 
+		level, 
+		area->spf_delay_ietf[level-1]->family[family]->state,
+                isis_spf_delay_states[area->spf_delay_ietf[level-1]->family[family]->state],
+		family);
+  }
+
+  return 1;
+}
+
+
+int
+isis_spf_delay_event_holddown_expires(struct thread *thread) {
+
+  int level = 0; 
+  struct isis_spf_delay_reinit	*reinit;	
+  struct isis_area	*area;
+  int family = 0;
+
+  reinit = THREAD_ARG(thread);
+  
+  area = reinit->area;
+  level = reinit->level;	
+  family = reinit->family;
+	
+  if (family == AF_INET) {
+    family = 0;
+  } else if (family == AF_INET6) {
+    family = 1;
+  }
+
+  if (isis->debugs & DEBUG_SPF_IETF)
+    zlog_debug ("ISIS-Spf (%s) L%d F%d IETF SPF delay : disabling timetolearn (thread %p)",
+                area->area_tag, 
+		level, 
+		family, 
+		area->spf_delay_ietf[level-1]->family[family]->t_timetolearn);
+
+  THREAD_TIMER_OFF(area->spf_delay_ietf[level-1]->family[family]->t_timetolearn);
+  area->spf_delay_ietf[level-1]->family[family]->t_holddown = NULL;
+  area->spf_delay_ietf[level-1]->family[family]->t_timetolearn = NULL;
+  timerclear(&area->spf_delay_ietf[level-1]->family[family]->first_event_time);
+  timerclear(&area->spf_delay_ietf[level-1]->family[family]->resettime);
+  timerclear(&area->spf_delay_ietf[level-1]->family[family]->ttl_time);
+  area->spf_delay_ietf[level-1]->family[family]->state = ISIS_SPF_DELAY_STATE_QUIET;
+
+  if (isis->debugs & DEBUG_SPF_IETF) {
+    zlog_debug ("ISIS-Spf (%s) L%d IETF SPF delay HOLDDOWN expired moved to state %d (%s) family %d\n",
+		area->area_tag, 
+		level, 
+		area->spf_delay_ietf[level-1]->family[family]->state,
+		isis_spf_delay_states[area->spf_delay_ietf[level-1]->family[family]->state],
+		family);
+  }
+	
+  return 1;
+}
+
+int
+isis_spf_delay_ietf_schedule(struct isis_area *area, int level, int family) {
+  struct timeval time_now, time_now_rt;
+  long current_wait_time;
+  struct isis_spf_delay_reinit  *reinit;
+  unsigned char old_spf_state;
+
+  reinit = XMALLOC(MTYPE_ISIS_SPF_DELAY_REINIT, sizeof(struct isis_spf_delay_reinit));
+  old_spf_state = area->spf_delay_ietf[level-1]->family[family]->state;
+ 
+  if (family != 0) 
+   return ISIS_OK; 
+  
+  reinit->area = area;
+  reinit->level = level;
+  reinit->family = AF_INET;
+
+  gettimeofday(&time_now_rt, NULL);
+  monotime(&time_now);
+
+  if (isis->debugs & DEBUG_SPF_EVENTS)
+    zlog_debug ("ISIS-Spf (%s) L%d SPF F%d schedule called using IETF algorithm, ttl thread : %p, holddown thread : %p",
+                area->area_tag, 
+		level, 
+		family, 
+		area->spf_delay_ietf[level-1]->family[family]->t_timetolearn,
+		area->spf_delay_ietf[level-1]->family[family]->t_holddown);
+
+
+  // If first event equals 0, we init first event to current time
+  area->spf_delay_ietf[level-1]->family[family]->last_event_time = time_now_rt;
+ 
+  if (area->spf_delay_ietf[level-1]->family[family]->first_event_time.tv_sec == 0)
+    area->spf_delay_ietf[level-1]->family[family]->first_event_time = time_now_rt;
+
+  // We compute the appropriate wait time and new state
+  if (area->spf_delay_ietf[level-1]->family[family]->state == ISIS_SPF_DELAY_STATE_QUIET) {
+    // QUIET state behavior
+    
+    current_wait_time = area->spf_delay_ietf[level-1]->init_delay;
+    area->spf_delay_ietf[level-1]->family[family]->state = ISIS_SPF_DELAY_STATE_SHORT_WAIT;
+
+    // We disable Time to learn timer
+    if (isis->debugs & DEBUG_SPF_IETF)
+      zlog_debug ("ISIS-Spf (%s) L%d F%d IETF SPF delay : disabling timetolearn (thread %p)",
+                  area->area_tag,
+		  level,
+		  family,
+		  area->spf_delay_ietf[level-1]->family[family]->t_timetolearn);
+
+    THREAD_TIMER_OFF(area->spf_delay_ietf[level-1]->family[family]->t_timetolearn);
+ 
+    // Start timetolearn timer 
+    if (isis->debugs & DEBUG_SPF_IETF)
+      zlog_debug ("ISIS-Spf (%s) L%d F%d IETF SPF delay launch TIMETOLEARN timer\n",
+                  area->area_tag,
+		  level,
+		  family);
+      area->spf_delay_ietf[level-1]->family[family]->ttl_time = timeval_add_msec(time_now,area->spf_delay_ietf[level-1]->timetolearn); 
+      THREAD_TIMER_MSEC_ON(master,
+                           area->spf_delay_ietf[level-1]->family[family]->t_timetolearn,
+                           isis_spf_delay_event_ttl_expires,
+                           reinit,
+                           area->spf_delay_ietf[level-1]->timetolearn);
+
+    // We disable Holddown timer
+    if (isis->debugs & DEBUG_SPF_IETF)
+      zlog_debug ("ISIS-Spf (%s) L%d F%d IETF SPF delay : disabling holddown (thread %p)",
+                  area->area_tag,
+		  level,
+		  family,
+		  area->spf_delay_ietf[level-1]->family[family]->t_holddown);
+
+    THREAD_TIMER_OFF(area->spf_delay_ietf[level-1]->family[family]->t_holddown);
+	 
+    // Start Holddown timer  
+    if (isis->debugs & DEBUG_SPF_IETF)
+      zlog_debug ("ISIS-Spf (%s) L%d F%d IETF SPF delay launch HOLDDOWN timer\n",
+                  area->area_tag,
+		  level,
+		  family);
+      area->spf_delay_ietf[level-1]->family[family]->resettime = timeval_add_msec(time_now,
+										  area->spf_delay_ietf[level-1]->holddown);
+      THREAD_TIMER_MSEC_ON (master, area->spf_delay_ietf[level-1]->family[family]->t_holddown, 
+      isis_spf_delay_event_holddown_expires,reinit,area->spf_delay_ietf[level-1]->holddown);
+  
+  } else if (area->spf_delay_ietf[level-1]->family[family]->state == ISIS_SPF_DELAY_STATE_SHORT_WAIT) {
+    // SHORT WAIT state behavior
+    
+    current_wait_time = area->spf_delay_ietf[level-1]->short_delay;
+
+    // We disable Holddown timer
+    if (isis->debugs & DEBUG_SPF_IETF)
+      zlog_debug ("ISIS-Spf (%s) L%d F%d IETF SPF delay : disabling holddown (thread %p)",
+                  area->area_tag,
+                  level,
+		  family,
+		  area->spf_delay_ietf[level-1]->family[family]->t_holddown);
+
+      THREAD_TIMER_OFF(area->spf_delay_ietf[level-1]->family[family]->t_holddown);
+  
+      // Start Holddown timer
+      if (isis->debugs & DEBUG_SPF_IETF)
+        zlog_debug ("ISIS-Spf (%s) L%d F%d IETF SPF delay launch HOLDDOWN timer\n",
+                    area->area_tag,
+		    level,
+		    family);
+      area->spf_delay_ietf[level-1]->family[family]->resettime = timeval_add_msec(time_now,
+										  area->spf_delay_ietf[level-1]->holddown);
+      THREAD_TIMER_MSEC_ON (master,
+			    area->spf_delay_ietf[level-1]->family[family]->t_holddown,
+                            isis_spf_delay_event_holddown_expires,
+			    reinit,
+			    area->spf_delay_ietf[level-1]->holddown);
+  } else {
+    // LONG WAIT state behavior
+    
+    current_wait_time = area->spf_delay_ietf[level-1]->long_delay;
+    // We disable Holddown timer
+    if (isis->debugs & DEBUG_SPF_IETF)
+      zlog_debug ("ISIS-Spf (%s) L%d F%d IETF SPF delay : disabling holddown (thread %p)",
+                  area->area_tag,
+		  level,
+		  family,
+		  area->spf_delay_ietf[level-1]->family[family]->t_holddown);
+
+    THREAD_TIMER_OFF(area->spf_delay_ietf[level-1]->family[family]->t_holddown);
+	 
+    // Start Holddown timer
+    if (isis->debugs & DEBUG_SPF_IETF)
+      zlog_debug ("ISIS-Spf (%s) L%d F%d IETF SPF delay launch HOLDDOWN timer\n",
+                  area->area_tag,
+		  level,
+		  family);
+    area->spf_delay_ietf[level-1]->family[family]->resettime = timeval_add_msec(time_now,
+										area->spf_delay_ietf[level-1]->holddown);
+    THREAD_TIMER_MSEC_ON (master,
+			  area->spf_delay_ietf[level-1]->family[family]->t_holddown,
+			  isis_spf_delay_event_holddown_expires,
+			  reinit,
+			  area->spf_delay_ietf[level-1]->holddown);
+  }
+
+  // We check if SPF is already scheduled
+  if (area->spf_delay_ietf[level-1]->family[family]->pending) {
+    if  (isis->debugs & DEBUG_SPF_IETF) {	
+      zlog_debug ("ISIS-Spf (%s) L%d F%d IETF SPF already scheduled, due in %ld msec",
+                  area->area_tag,
+		  level,
+		  family,
+		  timeval_elapsed(area->spf_delay_ietf[level-1]->family[family]->next_spf, 
+                                  time_now) / 1000);	
+    }
+
+    return ISIS_OK;
+  }
+
+  // We deactivate current SPT
+  if (isis->debugs & DEBUG_SPF_IETF)
+    zlog_debug ("ISIS-Spf (%s) L%d F%d IETF SPF delay disabling SPF timer %p",
+		area->area_tag, level, family,	
+		area->spf_delay_ietf[level-1]->family[family]->t_spf);
+ 
+  THREAD_TIMER_OFF(area->spf_delay_ietf[level-1]->family[family]->t_spf);
+ 
+  if (isis->debugs & DEBUG_SPF_IETF)
+    zlog_debug ("ISIS-Spf (%s) L%d F%d IETF SPF delay move from state %d (%s) to state %d (%s)\n",
+	        area->area_tag,
+		level,
+		family,
+		old_spf_state, 
+ 	        isis_spf_delay_states[old_spf_state],
+	        area->spf_delay_ietf[level-1]->family[family]->state,
+	        isis_spf_delay_states[area->spf_delay_ietf[level-1]->family[family]->state]);
+
+  area->spf_delay_ietf[level-1]->family[family]->next_spf = timeval_add_msec(time_now,
+									     current_wait_time);
+
+  if (isis->debugs & DEBUG_SPF_IETF)
+    zlog_debug ("ISIS-Spf (%s) L%d F%d IETF SPF delay : next SPF scheduled in %ld msec\n",
+	        area->area_tag,
+		level,
+		family,
+	        current_wait_time);
+
+  // Schedule SPF
+  if (level == 1) {
+    if (family == 0) // IPv4
+      THREAD_TIMER_MSEC_ON (master,
+			    area->spf_delay_ietf[level-1]->family[family]->t_spf,
+			    isis_run_spf_l1,
+			    area,
+                            current_wait_time);
+    if (family == 1) // IPv6
+      THREAD_TIMER_MSEC_ON (master,
+			    area->spf_delay_ietf[level-1]->family[family]->t_spf,
+			    isis_run_spf6_l1,
+			    area,
+                            current_wait_time);
+  } else  {
+    if (family == 0) // IPv4
+      THREAD_TIMER_MSEC_ON (master,
+			    area->spf_delay_ietf[level-1]->family[family]->t_spf,
+			    isis_run_spf_l2,
+			    area,
+                            current_wait_time);
+    if (family == 1) // IPv6
+      THREAD_TIMER_MSEC_ON (master,
+			    area->spf_delay_ietf[level-1]->family[family]->t_spf,
+			    isis_run_spf6_l2,
+			    area,
+                            current_wait_time);
+  }
+
+  area->spf_delay_ietf[level-1]->family[family]->pending = 1;
+
+  return ISIS_OK;
+}
+
+
+void
+isis_delete_spf_delay_ietf(struct isis_area *area)
+{
+  struct isis_spf_delay_ietf *s;
+	
+  if (!area)
+    return ;
+
+  s = area->spf_delay_ietf[0];
+  THREAD_TIMER_OFF(s->family[0]->t_spf);
+  THREAD_TIMER_OFF(s->family[1]->t_spf);
+  THREAD_TIMER_OFF(s->family[0]->t_holddown);
+  THREAD_TIMER_OFF(s->family[1]->t_holddown);	
+  THREAD_TIMER_OFF(s->family[0]->t_timetolearn);	
+  THREAD_TIMER_OFF(s->family[1]->t_timetolearn);	
+  XFREE(MTYPE_ISIS_SPF_DELAY_AF, s->family[0]);
+  XFREE(MTYPE_ISIS_SPF_DELAY_AF, s->family[1]);	
+  XFREE(MTYPE_ISIS_SPF_DELAY, s);
+
+  s = area->spf_delay_ietf[1];
+  THREAD_TIMER_OFF(s->family[0]->t_spf);
+  THREAD_TIMER_OFF(s->family[1]->t_spf);
+  THREAD_TIMER_OFF(s->family[0]->t_holddown);
+  THREAD_TIMER_OFF(s->family[1]->t_holddown);
+  THREAD_TIMER_OFF(s->family[0]->t_timetolearn);	
+  THREAD_TIMER_OFF(s->family[1]->t_timetolearn); 
+  XFREE(MTYPE_ISIS_SPF_DELAY_AF, s->family[0]);
+  XFREE(MTYPE_ISIS_SPF_DELAY_AF, s->family[1]);
+  XFREE(MTYPE_ISIS_SPF_DELAY, s);
+
+  area->spf_delay_ietf[0] = 0;
+  area->spf_delay_ietf[1] = 0;		
+}
+
+
+
+struct isis_spf_delay_ietf *
+isis_create_spf_delay_ietf(void) {
+
+  struct isis_spf_delay_ietf *s1; 
+  struct isis_spf_delay_ietf_af *a1; 
+  struct isis_spf_delay_ietf_af *a2; 
+  
+  s1 = XMALLOC(MTYPE_ISIS_SPF_DELAY, sizeof(struct isis_spf_delay_ietf));
+  a1 = XMALLOC(MTYPE_ISIS_SPF_DELAY_AF, sizeof(struct isis_spf_delay_ietf_af));
+  a2 = XMALLOC(MTYPE_ISIS_SPF_DELAY_AF, sizeof(struct isis_spf_delay_ietf_af));
+  
+  zlog_debug("ISIS-Spf Initialize IETF SPF algorithm\n"); 
+
+  s1->short_delay = 0;
+  s1->init_delay = 0;
+  s1->long_delay = 0;
+  s1->timetolearn = 0;
+  s1->holddown = 0;
+       
+  a1->state = ISIS_SPF_DELAY_STATE_QUIET; 
+  timerclear(&a1->first_event_time);
+  timerclear(&a1->last_event_time);
+  timerclear(&a1->next_spf);
+  a1->t_spf = NULL;
+  a1->t_holddown = NULL;
+  a1->t_timetolearn = NULL;
+  timerclear(&a1->ttl_time);
+  timerclear(&a1->resettime);
+  a1->pending = 0;	
+  s1->family[0] = a1;
+
+  a2->state = ISIS_SPF_DELAY_STATE_QUIET;
+  timerclear(&a2->first_event_time);
+  timerclear(&a2->last_event_time);
+  timerclear(&a2->next_spf);
+  a2->t_spf = NULL;
+  a2->t_holddown = NULL; 
+  a2->t_timetolearn = NULL;	
+  timerclear(&a2->ttl_time);
+  timerclear(&a2->resettime);
+  a2->pending = 0; 
+  s1->family[1] = a2;
+
+  return s1;
+}

--- a/isisd/isis_spf_delay.h
+++ b/isisd/isis_spf_delay.h
@@ -36,31 +36,22 @@ struct isis_spf_delay_reinit {
   // Struct used to store some informations needed to reinit SPF algo
   struct isis_area	*area;
   int			level;
-  int			family;
 };
-
-struct isis_spf_delay_ietf_af {
-  struct timeval	first_event_time;	// Store first event timestamp msec
-  struct timeval	last_event_time;	// Store last event received timestamp msec
-  unsigned char         state;			// Store state of algo
-  struct thread         *t_spf;			// Thread for SPF schedule timer
-  int		        pending;		// Store 1 if SPF is pending, 0 instead	
-  struct thread         *t_holddown;		// Thread for HOLDDOWN timer
-  struct thread	        *t_timetolearn;		// Thread for TIMETOLEARN timer
-	
-};
-
 
 
 struct isis_spf_delay_ietf
 {
-	unsigned int	short_delay;
-	unsigned int	init_delay;
-	unsigned int	long_delay;
-	unsigned int	holddown;
-	unsigned int	timetolearn;
-	struct isis_spf_delay_ietf_af	*family[2];	// One struct per AF (AF_INET and AF_INET6)
-							// 0 is IPv4 , 1 is IPv6
+  unsigned int		short_delay;
+  unsigned int		init_delay;
+  unsigned int		long_delay;
+  unsigned int		holddown;
+  unsigned int		timetolearn;
+  struct timeval        first_event_time;       // Store first event timestamp msec
+  struct timeval        last_event_time;        // Store last event received timestamp msec
+  unsigned char         state;                  // Store state of algo
+  struct thread         *t_holddown;            // Thread for HOLDDOWN timer
+  struct thread         *t_timetolearn;         // Thread for TIMETOLEARN timer
+	
 };
 
 int
@@ -73,7 +64,7 @@ struct isis_spf_delay_ietf *
 isis_create_spf_delay_ietf(void);
 
 int
-isis_spf_delay_ietf_schedule (struct isis_area *area, int level, int family);
+isis_spf_delay_ietf_schedule (struct isis_area *area, int level);
 
 void
 isis_delete_spf_delay_ietf(struct isis_area *area);

--- a/isisd/isis_spf_delay.h
+++ b/isisd/isis_spf_delay.h
@@ -42,9 +42,6 @@ struct isis_spf_delay_reinit {
 struct isis_spf_delay_ietf_af {
   struct timeval	first_event_time;	// Store first event timestamp msec
   struct timeval	last_event_time;	// Store last event received timestamp msec
-  struct timeval	next_spf;		// Store monotonic timestamp of next spf run
-  struct timeval	resettime;		// Store monotonic timestamp of holddown firing
-  struct timeval	ttl_time;		// Store monotonic timestamp of timetolearn firing	
   unsigned char         state;			// Store state of algo
   struct thread         *t_spf;			// Thread for SPF schedule timer
   int		        pending;		// Store 1 if SPF is pending, 0 instead	

--- a/isisd/isis_spf_delay.h
+++ b/isisd/isis_spf_delay.h
@@ -1,0 +1,86 @@
+/*
+ * This is an implementation of the IETF SPF delay algorithm
+ * as explain in draft-ietf-rtgwg-backoff-algo
+ *
+ * Module name: isis_spf_delay.h 
+ * Version:     0.1
+ * Created:     25-01-2017 by S. Litkowski
+ * Copyright (C) 2017 Orange Labs http://www.orange.com/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+ * MA 02110-1301 USA
+ */
+
+#ifndef ISIS_SPF_DELAY_H
+#define ISIS_SPF_DELAY_H
+
+#define	ISIS_SPF_DELAY_STATE_QUIET				0
+#define ISIS_SPF_DELAY_STATE_SHORT_WAIT			1
+#define ISIS_SPF_DELAY_STATE_LONG_WAIT			2
+
+extern const char	*isis_spf_delay_states[3];
+	
+struct isis_spf_delay_reinit {
+  // Struct used to store some informations needed to reinit SPF algo
+  struct isis_area	*area;
+  int			level;
+  int			family;
+};
+
+struct isis_spf_delay_ietf_af {
+  struct timeval	first_event_time;	// Store first event timestamp msec
+  struct timeval	last_event_time;	// Store last event received timestamp msec
+  struct timeval	next_spf;		// Store monotonic timestamp of next spf run
+  struct timeval	resettime;		// Store monotonic timestamp of holddown firing
+  struct timeval	ttl_time;		// Store monotonic timestamp of timetolearn firing	
+  unsigned char         state;			// Store state of algo
+  struct thread         *t_spf;			// Thread for SPF schedule timer
+  int		        pending;		// Store 1 if SPF is pending, 0 instead	
+  struct thread         *t_holddown;		// Thread for HOLDDOWN timer
+  struct thread	        *t_timetolearn;		// Thread for TIMETOLEARN timer
+	
+};
+
+
+
+struct isis_spf_delay_ietf
+{
+	unsigned int	short_delay;
+	unsigned int	init_delay;
+	unsigned int	long_delay;
+	unsigned int	holddown;
+	unsigned int	timetolearn;
+	struct isis_spf_delay_ietf_af	*family[2];	// One struct per AF (AF_INET and AF_INET6)
+							// 0 is IPv4 , 1 is IPv6
+};
+
+int
+isis_spf_delay_event_holddown_expires(struct thread *);
+
+int
+isis_spf_delay_event_ttl_expires(struct thread *);
+
+struct isis_spf_delay_ietf *
+isis_create_spf_delay_ietf(void);
+
+int
+isis_spf_delay_ietf_schedule (struct isis_area *area, int level, int family);
+
+void
+isis_delete_spf_delay_ietf(struct isis_area *area);
+
+
+
+#endif

--- a/isisd/isisd.c
+++ b/isisd/isisd.c
@@ -35,6 +35,7 @@
 #include "prefix.h"
 #include "table.h"
 #include "qobj.h"
+#include "monotime.h"
 
 #include "isisd/dict.h"
 #include "isisd/isis_constants.h"
@@ -55,6 +56,7 @@
 #include "isisd/isis_zebra.h"
 #include "isisd/isis_events.h"
 #include "isisd/isis_te.h"
+#include "isisd/isis_spf_delay.h"
 
 struct isis *isis = NULL;
 
@@ -155,9 +157,16 @@ isis_area_create (const char *area_tag)
   area->lsp_frag_threshold = 90;
   area->lsp_mtu = DEFAULT_LSP_MTU;
 
+  /*
+   * Initialize IETF SPF delay
+   */
+  area->spf_delay_ietf[0] = 0;
+  area->spf_delay_ietf[1] = 0;
+
   area->area_tag = strdup (area_tag);
   listnode_add (isis->area_list, area);
   area->isis = isis;
+
 
   QOBJ_REG (area, isis_area);
 
@@ -856,9 +865,42 @@ config_write_debug (struct vty *vty)
       vty_out (vty, "debug isis lsp-sched%s", VTY_NEWLINE);
       write++;
     }
+  if (flags & DEBUG_SPF_IETF)
+    {
+      vty_out (vty, "debug isis spf-delay-ietf%s", VTY_NEWLINE);
+      write++;
+    }
 
   return write;
 }
+
+DEFUN (debug_isis_spf_ietf,
+       debug_isis_spf_ietf_cmd,
+       "debug isis spf-delay-ietf",
+       DEBUG_STR
+       "IS-IS information\n"
+       "IS-IS Shortest Path First delay IETF\n")
+{
+  isis->debugs |= DEBUG_SPF_IETF;
+  print_debug (vty, DEBUG_SPF_IETF, 1);
+
+  return CMD_SUCCESS;
+}
+
+DEFUN (no_debug_isis_spf_ietf,
+       no_debug_isis_spf_ietf_cmd,
+       "no debug isis spf-delay-ietf",
+       NO_STR 
+       UNDEBUG_STR
+       "IS-IS information\n"
+       "IS-IS Shortest Path First delay IETF\n")
+{
+  isis->debugs &= ~DEBUG_SPF_IETF;
+  print_debug (vty, DEBUG_SPF_IETF, 0);
+
+  return CMD_SUCCESS;
+}
+
 
 DEFUN (debug_isis_adj,
        debug_isis_adj_cmd,
@@ -1273,6 +1315,196 @@ vty_out_timestr(struct vty *vty, time_t uptime)
   vty_out (vty, " ago");
 }
 
+static void
+vty_out_mtimestr(struct vty *vty, time_t uptime)
+{
+
+  struct tm *tm;
+  char buf[80];
+
+  tm = gmtime (&uptime);
+  strftime(buf, sizeof(buf), "%Z %a %Y-%m-%d %H:%M:%S", tm);
+  vty_out (vty, "%s",buf);
+}
+
+DEFUN (show_isis_spf_ietf,
+       show_isis_spf_ietf_cmd,
+       "show isis spf-delay-ietf",
+       SHOW_STR 
+       "IS-IS information\n"      
+       "IS-IS SPF delay IETF information\n")
+{
+  struct listnode *node;
+  struct isis_area *area;
+  struct isis_spftree *spftree;
+  int level;
+  struct timeval time_now;
+
+  monotime(&time_now);
+
+  if (isis == NULL)
+  {
+    vty_out (vty, "ISIS is not running%s", VTY_NEWLINE);
+    return CMD_SUCCESS;
+  }
+
+  for (ALL_LIST_ELEMENTS_RO (isis->area_list, node, area))
+  {
+    vty_out (vty, "Area %s:%s", area->area_tag ? area->area_tag : "null",
+        VTY_NEWLINE);
+
+    for (level = ISIS_LEVEL1; level <= ISIS_LEVELS; level++)
+    {
+      if ((area->is_type & level) == 0)
+        continue;
+
+      vty_out (vty, "  Level-%d:%s", level, VTY_NEWLINE);
+      spftree = area->spftree[level - 1];
+      if (spftree->pending)
+        vty_out (vty, "    IPv4 SPF: (pending)%s", VTY_NEWLINE);
+      else
+        vty_out (vty, "    IPv4 SPF:%s", VTY_NEWLINE);
+
+      if (area->spf_delay_ietf[level - 1]) {
+        vty_out(vty,  "    IETF SPF delay algorithm activated%s", VTY_NEWLINE);
+        if (area->spf_delay_ietf[level - 1]->family[0]->pending) {
+          vty_out(vty,  "         (Pending, due in : %ld msec)%s",
+                  timeval_elapsed(area->spf_delay_ietf[level - 1]->family[0]->next_spf,
+                                  time_now) / 1000,
+                  VTY_NEWLINE);
+
+        }
+        vty_out(vty,  "         Current mode : %d (%s)%s",
+                area->spf_delay_ietf[level - 1]->family[0]->state,
+                isis_spf_delay_states[area->spf_delay_ietf[level - 1]->family[0]->state],
+                VTY_NEWLINE);
+        vty_out(vty,  "         Init timer : %d%s",
+                area->spf_delay_ietf[level - 1]->init_delay,
+                VTY_NEWLINE);
+        vty_out(vty,  "         Short timer : %d%s",area->spf_delay_ietf[level - 1]->short_delay,VTY_NEWLINE);
+        vty_out(vty,  "         Long timer : %d%s",area->spf_delay_ietf[level - 1]->long_delay,VTY_NEWLINE);
+        vty_out(vty,  "         Holddown timer : %d%s",area->spf_delay_ietf[level - 1]->holddown,VTY_NEWLINE);
+        if (area->spf_delay_ietf[level - 1]->family[0]->resettime.tv_sec)
+          vty_out(vty,  "             Still runs for %ld msec%s",
+                  timeval_elapsed(area->spf_delay_ietf[level - 1]->family[0]->resettime, time_now) / 1000,
+                  VTY_NEWLINE);
+        vty_out(vty,  "         TimeToLearn timer : %d%s",
+                area->spf_delay_ietf[level - 1]->timetolearn,
+                VTY_NEWLINE);
+        if (area->spf_delay_ietf[level - 1]->family[0]->ttl_time.tv_sec)
+          vty_out(vty,  "             Still runs for %ld msec%s",
+                  timeval_elapsed(area->spf_delay_ietf[level - 1]->family[0]->ttl_time,
+                                  time_now) / 1000,
+                  VTY_NEWLINE);
+
+        if (area->spf_delay_ietf[level - 1]->family[0]->first_event_time.tv_sec != 0) {
+          vty_out(vty,  "         First event time : ");
+          vty_out_mtimestr(vty,area->spf_delay_ietf[level - 1]->family[0]->first_event_time.tv_sec);
+          vty_out (vty, ".%ld%s",
+                   area->spf_delay_ietf[level - 1]->family[0]->first_event_time.tv_usec / 1000,
+                   VTY_NEWLINE);
+        } else {
+          vty_out(vty,  "         First event time : N/A%s",VTY_NEWLINE);
+        }
+        if (area->spf_delay_ietf[level - 1]->family[0]->last_event_time.tv_sec != 0) {
+          vty_out(vty,  "         Last event time : ");
+          vty_out_mtimestr(vty,
+                           area->spf_delay_ietf[level - 1]->family[0]->last_event_time.tv_sec);
+          vty_out (vty, ".%ld%s",
+                   area->spf_delay_ietf[level - 1]->family[0]->last_event_time.tv_usec/1000,
+                   VTY_NEWLINE);
+        } else {
+          vty_out(vty,  "         Last event time : N/A%s",VTY_NEWLINE);
+        }
+        if (spftree->pending)
+          vty_out(vty,  "         Next SPF due in : %ld msec%s",
+                  timeval_elapsed(area->spf_delay_ietf[level - 1]->family[0]->next_spf,
+                                  time_now) / 1000,
+                  VTY_NEWLINE);
+      } else {
+        vty_out(vty,  "    IETF SPF delay algorithm deactivated%s",
+                VTY_NEWLINE);
+
+      }
+
+      spftree = area->spftree6[level - 1];
+      if (spftree->pending)
+        vty_out (vty, "    IPv6 SPF: (pending)%s", VTY_NEWLINE);
+      else
+        vty_out (vty, "    IPv6 SPF:%s", VTY_NEWLINE);
+
+      if (area->spf_delay_ietf[level - 1]) {
+        vty_out(vty,  "    IETF SPF delay algorithm activated%s",
+                VTY_NEWLINE);
+        if (area->spf_delay_ietf[level - 1]->family[1]->pending)
+          vty_out(vty,  "         (Pending, due in : %ld msec)%s",
+                  timeval_elapsed(area->spf_delay_ietf[level-1]->family[1]->next_spf,
+                                  time_now) / 1000,
+                  VTY_NEWLINE);
+        vty_out(vty,  "         Current mode : %d (%s)%s",
+                area->spf_delay_ietf[level - 1]->family[1]->state,
+                isis_spf_delay_states[area->spf_delay_ietf[level - 1]->family[1]->state],
+                VTY_NEWLINE);
+        vty_out(vty,  "         Init timer : %d%s",
+                area->spf_delay_ietf[level - 1]->init_delay,
+                VTY_NEWLINE);
+        vty_out(vty,  "         Short timer : %d%s",
+                area->spf_delay_ietf[level - 1]->short_delay,
+                VTY_NEWLINE);
+        vty_out(vty,  "         Long timer : %d%s",
+                area->spf_delay_ietf[level - 1]->long_delay,
+                VTY_NEWLINE);
+        vty_out(vty,  "         Holddown timer : %d%s",
+                area->spf_delay_ietf[level - 1]->holddown,
+                VTY_NEWLINE);
+        if (area->spf_delay_ietf[level - 1]->family[1]->resettime.tv_sec)
+          vty_out(vty,  "             Still runs for %ld msec%s",
+                  timeval_elapsed(area->spf_delay_ietf[level - 1]->family[1]->resettime,
+                                  time_now) / 1000,
+                  VTY_NEWLINE);
+        vty_out(vty,  "         TimeToLearn timer : %d%s",
+                area->spf_delay_ietf[level - 1]->timetolearn,
+                VTY_NEWLINE);
+        if (area->spf_delay_ietf[level - 1]->family[1]->ttl_time.tv_sec)
+          vty_out(vty,  "             Still runs for %ld msec%s",
+                  timeval_elapsed(area->spf_delay_ietf[level - 1]->family[1]->ttl_time,
+                                  time_now) / 1000,
+                  VTY_NEWLINE);
+        if (area->spf_delay_ietf[level - 1]->family[1]->first_event_time.tv_sec != 0) {
+          vty_out(vty,  "         First event time : ");
+          vty_out_mtimestr(vty,
+                           area->spf_delay_ietf[level - 1]->family[1]->first_event_time.tv_sec);
+          vty_out (vty, ".%ld%s",
+                   area->spf_delay_ietf[level - 1]->family[1]->first_event_time.tv_usec / 1000,
+                   VTY_NEWLINE);
+        } else {
+          vty_out(vty,  "         First event time : N/A%s",VTY_NEWLINE);
+        }
+        if (area->spf_delay_ietf[level - 1]->family[1]->last_event_time.tv_sec != 0) {
+          vty_out(vty,  "         Last event time : ");
+          vty_out_mtimestr(vty,
+                           area->spf_delay_ietf[level - 1]->family[1]->last_event_time.tv_sec );
+          vty_out (vty, ".%ld%s",
+                   area->spf_delay_ietf[level - 1]->family[1]->last_event_time.tv_usec / 1000,
+                   VTY_NEWLINE);
+        } else {
+          vty_out(vty,  "         Last event time : N/A%s",VTY_NEWLINE);
+        }
+        if (spftree->pending)
+          vty_out(vty,  "         Next SPF due in : %ld msec%s",
+                  timeval_elapsed(area->spf_delay_ietf[level - 1]->family[1]->next_spf,
+                                  time_now) / 1000,
+                  VTY_NEWLINE);
+      } else {
+        vty_out(vty,  "    IETF SPF delay algorithm deactivated%s",
+                VTY_NEWLINE);
+      }
+
+   }
+  }
+  return CMD_SUCCESS;
+}
+
 DEFUN (show_isis_summary,
        show_isis_summary_cmd,
        "show isis summary",
@@ -1332,8 +1564,11 @@ DEFUN (show_isis_summary,
       else
         vty_out (vty, "    IPv4 SPF:%s", VTY_NEWLINE);
 
-      vty_out (vty, "      minimum interval  : %d%s",
-          area->min_spf_interval[level - 1], VTY_NEWLINE);
+      vty_out (vty, "      minimum interval  : %d",
+          area->min_spf_interval[level - 1]);
+      if (area->spf_delay_ietf[level - 1])
+         vty_out (vty, " (not used, IETF SPF delay activated)");
+      vty_out (vty, VTY_NEWLINE);
 
       vty_out (vty, "      last run elapsed  : ");
       vty_out_timestr(vty, spftree->last_run_timestamp);
@@ -1351,8 +1586,11 @@ DEFUN (show_isis_summary,
       else
         vty_out (vty, "    IPv6 SPF:%s", VTY_NEWLINE);
 
-      vty_out (vty, "      minimum interval  : %d%s",
-          area->min_spf_interval[level - 1], VTY_NEWLINE);
+      vty_out (vty, "      minimum interval  : %d",
+          area->min_spf_interval[level - 1]);
+      if (area->spf_delay_ietf[level - 1])
+         vty_out (vty, " (not used, IETF SPF delay activated)");
+      vty_out (vty, VTY_NEWLINE);
 
       vty_out (vty, "      last run elapsed  : ");
       vty_out_timestr(vty, spftree->last_run_timestamp);
@@ -2010,7 +2248,20 @@ isis_config_write (struct vty *vty)
 		write++;
 	      }
 	  }
-	/* Authentication passwords. */
+        /* IETF SPF interval */
+        if (area->spf_delay_ietf[0])
+          {
+            vty_out (vty, " spf-delay-ietf init-delay %d short-delay %d long-delay %d holddown %d time-to-learn %d%s",
+                     area->spf_delay_ietf[0]->init_delay,
+                     area->spf_delay_ietf[0]->short_delay,
+                     area->spf_delay_ietf[0]->long_delay,
+                     area->spf_delay_ietf[0]->holddown,
+                     area->spf_delay_ietf[0]->timetolearn,
+                     VTY_NEWLINE);
+            write++;
+          }
+	
+        /* Authentication passwords. */
 	if (area->area_passwd.type == ISIS_PASSWD_TYPE_HMAC_MD5)
 	  {
 	    vty_out(vty, " area-password md5 %s", area->area_passwd.passwd);
@@ -2097,6 +2348,8 @@ isis_init ()
 
   install_element (VIEW_NODE, &show_isis_summary_cmd);
 
+  install_element (VIEW_NODE, &show_isis_spf_ietf_cmd);
+
   install_element (VIEW_NODE, &show_isis_interface_cmd);
   install_element (VIEW_NODE, &show_isis_interface_detail_cmd);
   install_element (VIEW_NODE, &show_isis_interface_arg_cmd);
@@ -2142,6 +2395,8 @@ isis_init ()
   install_element (ENABLE_NODE, &no_debug_isis_lsp_gen_cmd);
   install_element (ENABLE_NODE, &debug_isis_lsp_sched_cmd);
   install_element (ENABLE_NODE, &no_debug_isis_lsp_sched_cmd);
+  install_element (ENABLE_NODE, &debug_isis_spf_ietf_cmd);
+  install_element (ENABLE_NODE, &no_debug_isis_spf_ietf_cmd);
 
   install_element (CONFIG_NODE, &debug_isis_adj_cmd);
   install_element (CONFIG_NODE, &no_debug_isis_adj_cmd);
@@ -2171,6 +2426,8 @@ isis_init ()
   install_element (CONFIG_NODE, &no_debug_isis_lsp_gen_cmd);
   install_element (CONFIG_NODE, &debug_isis_lsp_sched_cmd);
   install_element (CONFIG_NODE, &no_debug_isis_lsp_sched_cmd);
+  install_element (CONFIG_NODE, &debug_isis_spf_ietf_cmd);
+  install_element (CONFIG_NODE, &no_debug_isis_spf_ietf_cmd);
 
   install_element (CONFIG_NODE, &router_isis_cmd);
   install_element (CONFIG_NODE, &no_router_isis_cmd);

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -129,6 +129,7 @@ struct isis_area
 
   struct isis_spf_delay_ietf *spf_delay_ietf[ISIS_LEVELS]; /*Structure with IETF SPF algo parameters*/
   u_int16_t spf_delay_ietf_enabled[ISIS_LEVELS];
+  struct isis_spfstate *spfstate[ISIS_LEVELS]; /* Structure containing next SPF state */
 
   QOBJ_FIELDS
 };

--- a/isisd/isisd.h
+++ b/isisd/isisd.h
@@ -127,6 +127,9 @@ struct isis_area
                                     [ZEBRA_ROUTE_MAX + 1][ISIS_LEVELS];
   struct route_table *ext_reach[REDIST_PROTOCOL_COUNT][ISIS_LEVELS];
 
+  struct isis_spf_delay_ietf *spf_delay_ietf[ISIS_LEVELS]; /*Structure with IETF SPF algo parameters*/
+  u_int16_t spf_delay_ietf_enabled[ISIS_LEVELS];
+
   QOBJ_FIELDS
 };
 DECLARE_QOBJ_TYPE(isis_area)
@@ -175,6 +178,7 @@ extern struct thread_master *master;
 #define DEBUG_PACKET_DUMP                (1<<12)
 #define DEBUG_LSP_GEN                    (1<<13)
 #define DEBUG_LSP_SCHED                  (1<<14)
+#define DEBUG_SPF_IETF                   (1<<15)
 
 #define lsp_debug(...) \
   do \

--- a/lib/monotime.h
+++ b/lib/monotime.h
@@ -74,4 +74,18 @@ static inline int64_t monotime_until(const struct timeval *ref,
 	return (int64_t)tv.tv_sec * 1000000LL + tv.tv_usec;
 }
 
+static inline struct timeval
+timeval_add_msec(struct timeval a, unsigned long msec)
+{
+  struct timeval ret;
+  struct timeval addtime;
+
+  addtime.tv_sec = msec / 1000;
+  addtime.tv_usec = (msec % 1000 ) * 1000;
+  timeradd(&a,&addtime,&ret);
+
+  return ret;
+}
+
+
 #endif /* _FRR_MONOTIME_H */

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -44,7 +44,7 @@ DEFINE_MTYPE_STATIC(LIB, THREAD_STATS,  "Thread stats")
 /* Relative time, since startup */
 static struct hash *cpu_record = NULL;
 
-unsigned long
+static unsigned long
 timeval_elapsed (struct timeval a, struct timeval b)
 {
   return (((a.tv_sec - b.tv_sec) * TIMER_SECOND_MICRO)

--- a/lib/thread.c
+++ b/lib/thread.c
@@ -44,7 +44,7 @@ DEFINE_MTYPE_STATIC(LIB, THREAD_STATS,  "Thread stats")
 /* Relative time, since startup */
 static struct hash *cpu_record = NULL;
 
-static unsigned long
+unsigned long
 timeval_elapsed (struct timeval a, struct timeval b)
 {
   return (((a.tv_sec - b.tv_sec) * TIMER_SECOND_MICRO)

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -241,7 +241,6 @@ extern unsigned long thread_timer_remain_second (struct thread *);
 extern struct timeval thread_timer_remain(struct thread*);
 extern int thread_should_yield (struct thread *);
 
-extern unsigned long timeval_elapsed (struct timeval a, struct timeval b);
 
 
 /* set yield time for thread */

--- a/lib/thread.h
+++ b/lib/thread.h
@@ -240,6 +240,10 @@ extern void thread_call (struct thread *);
 extern unsigned long thread_timer_remain_second (struct thread *);
 extern struct timeval thread_timer_remain(struct thread*);
 extern int thread_should_yield (struct thread *);
+
+extern unsigned long timeval_elapsed (struct timeval a, struct timeval b);
+
+
 /* set yield time for thread */
 extern void thread_set_yield_time (struct thread *, unsigned long);
 


### PR DESCRIPTION
Add new timeval function in monotime.h
- timeval_add_msec (based on timeradd)

Add new functions and structures to support the backoff algo
- New scheduling function supported
- New datastructure created to host the algorithm parameters and states
- Add some constants for algo min and max values
- Algo timer reinit when SPF runs

Add CLI commands
- Added a debug command
- Added a show command
- Added a configuration command
- Added our datastructure in the ISIS area structure
- Initialization datastructures

Signed-off-by: Stephane Litkowski <stephane.litkowski@orange.com>