### PR TITLE
lib: use fsync() for config writes, plug fd leak

### DIFF
--- a/lib/vty.c
+++ b/lib/vty.c
@@ -2254,9 +2254,16 @@ vty_close (struct vty *vty)
   /* Unset vector. */
   vector_unset (vtyvec, vty->fd);
 
+  if (vty->wfd > 0 && vty->type == VTY_FILE)
+    fsync (vty->wfd);
+
   /* Close socket. */
   if (vty->fd > 0)
-    close (vty->fd);
+    {
+      close (vty->fd);
+      if (vty->wfd > 0 && vty->wfd != vty->fd)
+        close (vty->wfd);
+    }
   else
     was_stdio = true;
 


### PR DESCRIPTION
sync() has a HUGE impact on systems that perform actual I/O, i.e. real
servers...

Also, we were leaking a fd on each config write ever since
c5e69a0 "lib/vty: add separate output fd support to VTYs"
(by myself :( ...)

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>