### PR TITLE
debian: Fix to not auto-install snmp MIB

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -85,7 +85,11 @@ override_dh_auto_install:
 	perl -pi -e 's#^!log file #!log file /var/log/frr/#' debian/tmp/usr/share/doc/frr/examples/*sample*
 
 	# installing the Frr specific SNMP MIB
+ifeq ($(WANT_SNMP), 1)
 	install -D -m 644 ./zebra/GNOME-PRODUCT-ZEBRA-MIB debian/tmp/usr/share/snmp/mibs/GNOME-PRODUCT-ZEBRA-MIB
+else
+	mkdir -p debian/tmp/usr/share/snmp/mibs/
+endif
 
 	# cleaning .la files
 	sed -i "/dependency_libs/ s/'.*'/''/" debian/tmp/usr/lib/*.la


### PR DESCRIPTION
Only install the snmp MIB for zebra if we
are building the debian package with SNMP.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>