### PR TITLE
Fix OSPF API client linking errors

### DIFF
--- a/ospfclient/Makefile.am
+++ b/ospfclient/Makefile.am
@@ -6,7 +6,7 @@ AM_CFLAGS = $(WERROR)
 
 lib_LTLIBRARIES = libfrrospfapiclient.la
 libfrrospfapiclient_la_LDFLAGS = -version-info 0:0:0
-libfrrospfapiclient_la_LIBADD = ../lib/libfrr.la
+libfrrospfapiclient_la_LIBADD = ../lib/libfrr.la ../ospfd/libfrrospf.la
 
 sbin_PROGRAMS = ospfclient
 
@@ -22,7 +22,7 @@ ospfclient_SOURCES = \
 	ospfclient.c
 
 ospfclient_LDADD = libfrrospfapiclient.la \
-	../lib/libfrr.la @LIBCAP@
+	../lib/libfrr.la ../ospfd/libfrrospf.la @LIBCAP@
 
 ospfclient_CFLAGS = $(AM_CFLAGS)
 ospfclient_LDFLAGS = $(AM_LDFLAGS)

--- a/ospfd/Makefile.am
+++ b/ospfd/Makefile.am
@@ -5,10 +5,10 @@ AM_CFLAGS = $(WERROR)
 DEFS = @DEFS@ $(LOCAL_OPTS) -DSYSCONFDIR=\"$(sysconfdir)/\"
 INSTALL_SDATA=@INSTALL@ -m 600
 
-noinst_LIBRARIES = libfrrospf.a
+lib_LTLIBRARIES = libfrrospf.la
 sbin_PROGRAMS = ospfd
 
-libfrrospf_a_SOURCES = \
+libfrrospf_la_SOURCES = \
 	ospfd.c ospf_zebra.c ospf_interface.c ospf_ism.c ospf_neighbor.c \
 	ospf_nsm.c ospf_dump.c ospf_network.c ospf_packet.c ospf_lsa.c \
 	ospf_spf.c ospf_route.c ospf_ase.c ospf_abr.c ospf_ia.c ospf_flood.c \
@@ -31,7 +31,7 @@ noinst_HEADERS = \
 
 ospfd_SOURCES = ospf_main.c
 
-ospfd_LDADD = libfrrospf.a ../lib/libfrr.la @LIBCAP@ @LIBM@
+ospfd_LDADD = libfrrospf.la ../lib/libfrr.la @LIBCAP@ @LIBM@
 
 EXTRA_DIST = OSPF-MIB.txt OSPF-TRAP-MIB.txt ChangeLog.opaque.txt
 


### PR DESCRIPTION
When linking it was complaining about missint missing references to some
OSPF MTYPEs.

ospfclient-ospfclient.o:(.data.rel.ro+0x18): undefined reference to `_mt_OSPF_TOP'
ospfclient-ospfclient.o:(.data.rel.ro+0x20): undefined reference to `_mt_OSPF_AREA'
ospfclient-ospfclient.o:(.data.rel.ro+0x28): undefined reference to `_mt_OSPF_AREA_RANGE'
ospfclient-ospfclient.o:(.data.rel.ro+0x30): undefined reference to `_mt_OSPF_NETWORK'
ospfclient-ospfclient.o:(.data.rel.ro+0x38): undefined reference to `_mt_OSPF_NEIGHBOR_STATIC'
ospfclient-ospfclient.o:(.data.rel.ro+0x40): undefined reference to `_mt_OSPF_IF'
ospfclient-ospfclient.o:(.data.rel.ro+0x48): undefined reference to `_mt_OSPF_NEIGHBOR'
ospfclient-ospfclient.o:(.data.rel.ro+0x50): undefined reference to `_mt_OSPF_ROUTE'
ospfclient-ospfclient.o:(.data.rel.ro+0x58): undefined reference to `_mt_OSPF_TMP'
ospfclient-ospfclient.o:(.data.rel.ro+0x60): undefined reference to `_mt_OSPF_LSA'
ospfclient-ospfclient.o:(.data.rel.ro+0x68): undefined reference to `_mt_OSPF_LSA_DATA'
ospfclient-ospfclient.o:(.data.rel.ro+0x70): undefined reference to `_mt_OSPF_LSDB'
ospfclient-ospfclient.o:(.data.rel.ro+0x78): undefined reference to `_mt_OSPF_PACKET'
ospfclient-ospfclient.o:(.data.rel.ro+0x80): undefined reference to `_mt_OSPF_FIFO'
ospfclient-ospfclient.o:(.data.rel.ro+0x88): undefined reference to `_mt_OSPF_VERTEX'
ospfclient-ospfclient.o:(.data.rel.ro+0x90): undefined reference to `_mt_OSPF_VERTEX_PARENT'
ospfclient-ospfclient.o:(.data.rel.ro+0x98): undefined reference to `_mt_OSPF_NEXTHOP'
ospfclient-ospfclient.o:(.data.rel.ro+0xa0): undefined reference to `_mt_OSPF_PATH'
ospfclient-ospfclient.o:(.data.rel.ro+0xa8): undefined reference to `_mt_OSPF_VL_DATA'
ospfclient-ospfclient.o:(.data.rel.ro+0xb0): undefined reference to `_mt_OSPF_CRYPT_KEY'
ospfclient-ospfclient.o:(.data.rel.ro+0xb8): undefined reference to `_mt_OSPF_EXTERNAL_INFO'
ospfclient-ospfclient.o:(.data.rel.ro+0xc0): undefined reference to `_mt_OSPF_DISTANCE'
ospfclient-ospfclient.o:(.data.rel.ro+0xc8): undefined reference to `_mt_OSPF_IF_INFO'
ospfclient-ospfclient.o:(.data.rel.ro+0xd0): undefined reference to `_mt_OSPF_IF_PARAMS'
ospfclient-ospfclient.o:(.data.rel.ro+0xd8): undefined reference to `_mt_OSPF_MESSAGE'
ospfclient-ospfclient.o:(.data.rel.ro+0xe0): undefined reference to `_mt_OSPF_MPLS_TE'
ospfclient-ospfclient.o:(.data.rel.ro+0xe8): undefined reference to `_mt_OSPF_PCE_PARAMS'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x40): undefined reference to `_mt_OSPF_TOP'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x48): undefined reference to `_mt_OSPF_AREA'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x50): undefined reference to `_mt_OSPF_AREA_RANGE'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x58): undefined reference to `_mt_OSPF_NETWORK'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x60): undefined reference to `_mt_OSPF_NEIGHBOR_STATIC'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x68): undefined reference to `_mt_OSPF_IF'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x70): undefined reference to `_mt_OSPF_NEIGHBOR'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x78): undefined reference to `_mt_OSPF_ROUTE'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x80): undefined reference to `_mt_OSPF_TMP'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x88): undefined reference to `_mt_OSPF_LSA'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x90): undefined reference to `_mt_OSPF_LSA_DATA'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x98): undefined reference to `_mt_OSPF_LSDB'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0xa0): undefined reference to `_mt_OSPF_PACKET'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0xa8): undefined reference to `_mt_OSPF_FIFO'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0xb0): undefined reference to `_mt_OSPF_VERTEX'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0xb8): undefined reference to `_mt_OSPF_VERTEX_PARENT'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0xc0): undefined reference to `_mt_OSPF_NEXTHOP'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0xc8): undefined reference to `_mt_OSPF_PATH'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0xd0): undefined reference to `_mt_OSPF_VL_DATA'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0xd8): undefined reference to `_mt_OSPF_CRYPT_KEY'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0xe0): undefined reference to `_mt_OSPF_EXTERNAL_INFO'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0xe8): undefined reference to `_mt_OSPF_DISTANCE'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0xf0): undefined reference to `_mt_OSPF_IF_INFO'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0xf8): undefined reference to `_mt_OSPF_IF_PARAMS'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x100): undefined reference to `_mt_OSPF_MESSAGE'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x108): undefined reference to `_mt_OSPF_MPLS_TE'
./.libs/libfrrospfapiclient.a(ospf_apiclient.o):(.data.rel.ro+0x110): undefined reference to `_mt_OSPF_PCE_PARAMS'
collect2: error: ld returned 1 exit status
Makefile:549: recipe for target 'ospfclient' failed
make[2]: *** [ospfclient] Error 1
make[2]: Leaving directory '/home/bingen/Documents/trabajo/Volta/workspace/frr/ospfclient'
Makefile:478: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/home/bingen/Documents/trabajo/Volta/workspace/frr'
Makefile:410: recipe for target 'all' failed
make: *** [all] Error 2
