### PR TITLE
ospfclient: fix gcc -O0 build

### DIFF
--- a/ospfclient/ospf_apiclient.c
+++ b/ospfclient/ospf_apiclient.c
@@ -36,6 +36,9 @@
 #include "log.h"
 #include "memory.h"
 
+/* work around gcc bug 69981, disable MTYPEs in libospf */
+#define _QUAGGA_OSPF_MEMORY_H
+
 #include "ospfd/ospfd.h"
 #include "ospfd/ospf_interface.h"
 #include "ospfd/ospf_asbr.h"

--- a/ospfclient/ospfclient.c
+++ b/ospfclient/ospfclient.c
@@ -32,6 +32,9 @@
 #include "privs.h"
 #include "log.h"
 
+/* work around gcc bug 69981, disable MTYPEs in libospf */
+#define _QUAGGA_OSPF_MEMORY_H
+
 #include "ospfd/ospfd.h"
 #include "ospfd/ospf_asbr.h"
 #include "ospfd/ospf_lsa.h"


### PR DESCRIPTION
the "static const" inside DECLARE_MTYPE still causes issues on gcc -O0
(re. gcc bug 69981).  Work around by disabling MTYPE declarations for
ospfclient.

Signed-off-by: David Lamparter <equinox@opensourcerouting.org>