### PR TITLE
*: remove QUAGGA_NO_DEPRECATED_INTERFACES

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1651,14 +1651,6 @@ AC_SUBST(CFG_SYSCONF)
 AC_SUBST(CFG_SBIN)
 AC_SUBST(CFG_STATE)
 
-dnl -------------------------------
-dnl Quagga sources should always be 
-dnl current wrt interfaces. Dont
-dnl allow deprecated interfaces to
-dnl be exposed.
-dnl -------------------------------
-AC_DEFINE(QUAGGA_NO_DEPRECATED_INTERFACES, 1, Hide deprecated interfaces)
-
 dnl ---------------------------
 dnl Check htonl works correctly
 dnl ---------------------------

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -135,15 +135,4 @@ extern void list_add_list (struct list *, struct list *);
     (L)->count--; \
   } while (0)
 
-/* Deprecated: 20050406 */
-#if !defined(QUAGGA_NO_DEPRECATED_INTERFACES)
-#warning "Using deprecated libfrr interfaces"
-#define LISTNODE_ADD(L,N) LISTNODE_ATTACH(L,N)
-#define LISTNODE_DELETE(L,N) LISTNODE_DETACH(L,N)
-#define nextnode(X) ((X) = (X)->next)
-#define getdata(X) listgetdata(X)
-#define LIST_LOOP(L,V,N) \
-  for (ALL_LIST_ELEMENTS_RO (L,N,V))
-#endif /* QUAGGA_NO_DEPRECATED_INTERFACES */
-
 #endif /* _ZEBRA_LINKLIST_H */


### PR DESCRIPTION
This define is used only to guard macros in lib/linklist.h which
themselves are not used anywhere in the codebase and have been marked
deprecated since anno domini 2005

Signed-off-by: Quentin Young <qlyoung@cumulusnetworks.com>