### PR TITLE
Fix bgp_info_addpath_{rx,tx}_str if addpath info is not present

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2281,6 +2281,8 @@ bgp_info_addpath_rx_str(u_int32_t addpath_id, char *buf)
 {
   if (addpath_id)
     sprintf(buf, " with addpath ID %d", addpath_id);
+  else
+    buf[0] = '\0';
 }
 
 

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -619,6 +619,8 @@ bgp_info_addpath_tx_str (int addpath_encode, u_int32_t addpath_tx_id,
 {
   if (addpath_encode)
     sprintf(buf, " with addpath ID %d", addpath_tx_id);
+  else
+    buf[0] = '\0';
 }
 
 /* Make BGP update packet.  */


### PR DESCRIPTION
The buffer needs to be set to length 0 if nothing is written into
it, otherwise bgpd will log uninitialized memory, disclosing information
and possibly leading to a crash.

Signed-off-by: Christian Franke <chris@opensourcerouting.org>