### PR TITLE
bgpd: Fix issue #218

### DIFF
--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -546,7 +546,7 @@ bpacket_reformat_for_peer (struct bpacket *pkt, struct peer_af *paf)
 	    }
 
           if (gnh_modified)
-            stream_put_in6_addr_at (s, vec->offset + 1 + (nhlen-IPV6_MAX_BYTELEN), mod_v6nhg);
+            stream_put_in6_addr_at (s, vec->offset + 1, mod_v6nhg);
           if (lnh_modified)
             stream_put_in6_addr_at (s, vec->offset + 1 + (nhlen-IPV6_MAX_BYTELEN), mod_v6nhl);
 


### PR DESCRIPTION
 bgpd: Fix issue #218
     Wrong NH offset was used when using global V6 address in place of
      v6 LL.  (Introduced in earlier fix of broken RD advertisement.)

      Tested by @dslice in master.
