### PR TITLE
Pim patches feb

### DIFF
--- a/pimd/pim_assert.c
+++ b/pimd/pim_assert.c
@@ -379,9 +379,7 @@ int pim_assert_build_msg(uint8_t *pim_msg, int buf_size,
 
   /* Encode group */
   remain = buf_pastend - pim_msg_curr;
-  pim_msg_curr = pim_msg_addr_encode_ipv4_group(pim_msg_curr,
-						remain,
-						group_addr);
+  pim_msg_curr = pim_msg_addr_encode_ipv4_group(pim_msg_curr, group_addr);
   if (!pim_msg_curr) {
     char group_str[INET_ADDRSTRLEN];
     pim_inet4_dump("<grp?>", group_addr, group_str, sizeof(group_str));
@@ -392,9 +390,7 @@ int pim_assert_build_msg(uint8_t *pim_msg, int buf_size,
 
   /* Encode source */
   remain = buf_pastend - pim_msg_curr;
-  pim_msg_curr = pim_msg_addr_encode_ipv4_ucast(pim_msg_curr,
-						remain,
-						source_addr);
+  pim_msg_curr = pim_msg_addr_encode_ipv4_ucast(pim_msg_curr, source_addr);
   if (!pim_msg_curr) {
     char source_str[INET_ADDRSTRLEN];
     pim_inet4_dump("<src?>", source_addr, source_str, sizeof(source_str));

--- a/pimd/pim_iface.h
+++ b/pimd/pim_iface.h
@@ -98,6 +98,7 @@ struct pim_interface {
   uint16_t       pim_override_interval_msec; /* config */
   struct list   *pim_neighbor_list; /* list of struct pim_neighbor */
   struct list   *pim_ifchannel_list; /* list of struct pim_ifchannel */
+  struct hash   *pim_ifchannel_hash;
 
   /* neighbors without lan_delay */
   int            pim_number_of_nonlandelay_neighbors;

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -597,8 +597,13 @@ static int on_ifjoin_prune_pending_timer(struct thread *t)
       /* from here ch may have been deleted */
 
       if (send_prune_echo)
-	pim_joinprune_send (ifp, pim_ifp->primary_address,
-			    ch->upstream, 0);
+        {
+          struct pim_rpf rpf;
+
+          rpf.source_nexthop.interface = ifp;
+          rpf.rpf_addr.u.prefix4 = pim_ifp->primary_address;
+          pim_joinprune_send (&rpf, ch->upstream, 0);
+        }
     }
   else
     {

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -678,12 +678,13 @@ static void check_recv_upstream(int is_join,
   pim_upstream_join_timer_decrease_to_t_override("Prune(S,G)", up);
 }
 
-static int nonlocal_upstream(int is_join,
-			     struct interface *recv_ifp,
-			     struct in_addr upstream,
-			     struct prefix_sg *sg,
-			     uint8_t source_flags,
-			     uint16_t holdtime)
+static int
+nonlocal_upstream(int is_join,
+                  struct interface *recv_ifp,
+                  struct in_addr upstream,
+                  struct prefix_sg *sg,
+                  uint8_t source_flags,
+                  uint16_t holdtime)
 {
   struct pim_interface *recv_pim_ifp;
   int is_local; /* boolean */
@@ -692,27 +693,26 @@ static int nonlocal_upstream(int is_join,
   zassert(recv_pim_ifp);
 
   is_local = (upstream.s_addr == recv_pim_ifp->primary_address.s_addr);
-  
-  if (PIM_DEBUG_PIM_TRACE_DETAIL) {
-    char up_str[INET_ADDRSTRLEN];
-    pim_inet4_dump("<upstream?>", upstream, up_str, sizeof(up_str));
-    zlog_warn("%s: recv %s (S,G)=%s to %s upstream=%s on %s",
-	      __PRETTY_FUNCTION__,
-	      is_join ? "join" : "prune",
-	      pim_str_sg_dump (sg),
-	      is_local ? "local" : "non-local",
-	      up_str, recv_ifp->name);
-  }
 
   if (is_local)
     return 0;
 
+  if (PIM_DEBUG_PIM_TRACE_DETAIL) {
+    char up_str[INET_ADDRSTRLEN];
+    pim_inet4_dump("<upstream?>", upstream, up_str, sizeof(up_str));
+    zlog_warn("%s: recv %s (S,G)=%s to non-local upstream=%s on %s",
+              __PRETTY_FUNCTION__,
+              is_join ? "join" : "prune",
+              pim_str_sg_dump (sg),
+              up_str, recv_ifp->name);
+  }
+
   /*
-    Since recv upstream addr was not directed to our primary
-    address, check if we should react to it in any way.
-  */
+   * Since recv upstream addr was not directed to our primary
+   * address, check if we should react to it in any way.
+   */
   check_recv_upstream(is_join, recv_ifp, upstream, sg,
-		      source_flags, holdtime);
+                      source_flags, holdtime);
 
   return 1; /* non-local */
 }

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -969,7 +969,7 @@ pim_ifchannel_local_membership_add(struct interface *ifp,
 		       __FILE__, __PRETTY_FUNCTION__,
 		       child->sg_str, ifp->name, up->sg_str);
 
-	  if (pim_upstream_evaluate_join_desired (child))
+	  if (pim_upstream_evaluate_join_desired_interface (child, ch))
 	    {
 	      pim_channel_add_oif (child->channel_oil, ifp, PIM_OIF_FLAG_PROTO_STAR);
 	      pim_upstream_switch (child, PIM_UPSTREAM_JOINED);
@@ -1016,7 +1016,7 @@ void pim_ifchannel_local_membership_del(struct interface *ifp,
 		       __FILE__, __PRETTY_FUNCTION__,
 		       up->sg_str, ifp->name, child->sg_str);
 
-	  if (c_oil && !pim_upstream_evaluate_join_desired (child))
+	  if (c_oil && !pim_upstream_evaluate_join_desired_interface (child, ch))
             pim_channel_del_oif (c_oil, ifp, PIM_OIF_FLAG_PROTO_STAR);
 
 	  /*

--- a/pimd/pim_ifchannel.c
+++ b/pimd/pim_ifchannel.c
@@ -665,20 +665,17 @@ static void check_recv_upstream(int is_join,
   if (source_flags & PIM_RPT_BIT_MASK) {
     if (source_flags & PIM_WILDCARD_BIT_MASK) {
       /* Prune(*,G) to RPF'(S,G) */
-      pim_upstream_join_timer_decrease_to_t_override("Prune(*,G)",
-						     up, up->rpf.rpf_addr.u.prefix4);
+      pim_upstream_join_timer_decrease_to_t_override("Prune(*,G)", up);
       return;
     }
 
     /* Prune(S,G,rpt) to RPF'(S,G) */
-    pim_upstream_join_timer_decrease_to_t_override("Prune(S,G,rpt)",
-						   up, up->rpf.rpf_addr.u.prefix4);
+    pim_upstream_join_timer_decrease_to_t_override("Prune(S,G,rpt)", up);
     return;
   }
 
   /* Prune(S,G) to RPF'(S,G) */
-  pim_upstream_join_timer_decrease_to_t_override("Prune(S,G)", up,
-						 up->rpf.rpf_addr.u.prefix4);
+  pim_upstream_join_timer_decrease_to_t_override("Prune(S,G)", up);
 }
 
 static int nonlocal_upstream(int is_join,

--- a/pimd/pim_ifchannel.h
+++ b/pimd/pim_ifchannel.h
@@ -154,4 +154,7 @@ void pim_ifchannel_scan_forward_start (struct interface *new_ifp);
 void pim_ifchannel_set_star_g_join_state (struct pim_ifchannel *ch, int eom);
 
 int pim_ifchannel_compare (struct pim_ifchannel *ch1, struct pim_ifchannel *ch2);
+
+unsigned int pim_ifchannel_hash_key (void *arg);
+int pim_ifchannel_equal (const void *arg1, const void *arg2);
 #endif /* PIM_IFCHANNEL_H */

--- a/pimd/pim_ifchannel.h
+++ b/pimd/pim_ifchannel.h
@@ -26,6 +26,7 @@
 #include "if.h"
 #include "prefix.h"
 
+struct pim_ifchannel;
 #include "pim_upstream.h"
 
 enum pim_ifmembership {

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -428,12 +428,6 @@ int pim_igmp_packet(struct igmp_sock *igmp, char *buf, size_t len)
 	       from_str, to_str, igmp->interface->name, len, ip_hlen, ip_hdr->ip_p);
   }
 
-  if (ip_hdr->ip_p != PIM_IP_PROTO_IGMP) {
-    zlog_warn("IP packet protocol=%d is not IGMP=%d",
-	      ip_hdr->ip_p, PIM_IP_PROTO_IGMP);
-    return -1;
-  }
-
   igmp_msg = buf + ip_hlen;
   msg_type = *igmp_msg;
   igmp_msg_len = len - ip_hlen;

--- a/pimd/pim_igmp.c
+++ b/pimd/pim_igmp.c
@@ -434,17 +434,6 @@ int pim_igmp_packet(struct igmp_sock *igmp, char *buf, size_t len)
     return -1;
   }
 
-  if (ip_hlen < PIM_IP_HEADER_MIN_LEN) {
-    zlog_warn("IP packet header size=%zu shorter than minimum=%d",
-	      ip_hlen, PIM_IP_HEADER_MIN_LEN);
-    return -1;
-  }
-  if (ip_hlen > PIM_IP_HEADER_MAX_LEN) {
-    zlog_warn("IP packet header size=%zu greater than maximum=%d",
-	      ip_hlen, PIM_IP_HEADER_MAX_LEN);
-    return -1;
-  }
-
   igmp_msg = buf + ip_hlen;
   msg_type = *igmp_msg;
   igmp_msg_len = len - ip_hlen;

--- a/pimd/pim_igmp.h
+++ b/pimd/pim_igmp.h
@@ -89,6 +89,7 @@ struct igmp_sock {
   int               startup_query_count;
 
   struct list      *igmp_group_list; /* list of struct igmp_group */
+  struct hash      *igmp_group_hash;
 };
 
 struct igmp_sock *pim_igmp_sock_lookup_ifaddr(struct list *igmp_sock_list,

--- a/pimd/pim_join.h
+++ b/pimd/pim_join.h
@@ -32,9 +32,8 @@ int pim_joinprune_recv(struct interface *ifp,
 		       struct in_addr src_addr,
 		       uint8_t *tlv_buf, int tlv_buf_size);
 
-int pim_joinprune_send(struct interface *ifp,
-		       struct in_addr upstream_addr,
-		       struct pim_upstream *up,
-		       int send_join);
+int pim_joinprune_send(struct pim_rpf *nexthop,
+                       struct pim_upstream *up,
+                       int send_join);
 
 #endif /* PIM_JOIN_H */

--- a/pimd/pim_msg.c
+++ b/pimd/pim_msg.c
@@ -161,25 +161,16 @@ pim_msg_addr_encode_ipv4_source(uint8_t *buf,
  */
 int
 pim_msg_join_prune_encode (uint8_t *buf, size_t buf_size, int is_join,
-			   struct pim_upstream *up,
-			   struct in_addr upstream, int holdtime)
+                           struct pim_upstream *up,
+                           struct in_addr upstream, int holdtime)
 {
-  uint8_t *pim_msg = buf;
-  uint8_t *pim_msg_curr = buf + PIM_MSG_HEADER_LEN;
-  uint8_t *end = buf + buf_size;
-  uint16_t *prunes = NULL;
-  uint16_t *joins = NULL;
+  struct pim_jp *msg = (struct pim_jp *)buf;
   struct in_addr stosend;
   uint8_t bits;
-  int remain;
-  size_t min_len = PIM_MSG_HEADER_LEN + PIM_JP_GROUP_HEADER_SIZE +
-    PIM_ENCODED_IPV4_SOURCE_SIZE;   // Only 1 source
 
-  assert(buf_size > min_len);
+  assert(buf_size > sizeof (struct pim_jp));
 
-  remain = end - pim_msg_curr;
-  pim_msg_curr = pim_msg_addr_encode_ipv4_ucast (pim_msg_curr, upstream);
-  if (!pim_msg_curr) {
+  if (!pim_msg_addr_encode_ipv4_ucast ((uint8_t *)&msg->addr, upstream)) {
     char dst_str[INET_ADDRSTRLEN];
     pim_inet4_dump("<dst?>", upstream, dst_str, sizeof(dst_str));
     zlog_warn("%s: failure encoding destination address %s",
@@ -187,40 +178,22 @@ pim_msg_join_prune_encode (uint8_t *buf, size_t buf_size, int is_join,
     return -3;
   }
 
-  *pim_msg_curr = 0; /* reserved */
-  ++pim_msg_curr;
-  *pim_msg_curr = 1; /* number of groups */
-  ++pim_msg_curr;
+  msg->reserved   = 0;
+  msg->num_groups = 1;
+  msg->holdtime   = htons(holdtime);
 
-  *((uint16_t *) pim_msg_curr) = htons(holdtime);
-  ++pim_msg_curr;
-  ++pim_msg_curr;
-
-  remain = end - pim_msg_curr;
-  pim_msg_curr = pim_msg_addr_encode_ipv4_group (pim_msg_curr, up->sg.grp);
-  if (!pim_msg_curr) {
+  if (!pim_msg_addr_encode_ipv4_group ((uint8_t *)&msg->groups[0].g, up->sg.grp)) {
     char group_str[INET_ADDRSTRLEN];
     pim_inet4_dump("<grp?>", up->sg.grp, group_str, sizeof(group_str));
     zlog_warn("%s: failure encoding group address %s",
-	      __PRETTY_FUNCTION__, group_str);
+              __PRETTY_FUNCTION__, group_str);
     return -5;
   }
 
-  remain = end - pim_msg_curr;
+  /* number of joined/pruned sources */
+  msg->groups[0].joins  = htons(is_join ? 1 : 0);
+  msg->groups[0].prunes = htons(is_join ? 0 : 1);
 
-  /* number of joined sources */
-  joins = (uint16_t *)pim_msg_curr;
-  *joins = htons(is_join ? 1 : 0);
-  ++pim_msg_curr;
-  ++pim_msg_curr;
-
-  /* number of pruned sources */
-  prunes = (uint16_t *)pim_msg_curr;
-  *prunes = htons(is_join ? 0 : 1);
-  ++pim_msg_curr;
-  ++pim_msg_curr;
-
-  remain = end - pim_msg_curr;
   if (up->sg.src.s_addr == INADDR_ANY)
     {
       struct pim_rpf *rpf = pim_rp_g (up->sg.grp);
@@ -232,15 +205,14 @@ pim_msg_join_prune_encode (uint8_t *buf, size_t buf_size, int is_join,
       bits = PIM_ENCODE_SPARSE_BIT;
       stosend = up->sg.src;
     }
-  pim_msg_curr = pim_msg_addr_encode_ipv4_source (pim_msg_curr, stosend, bits);
-  if (!pim_msg_curr) {
+
+  if (!pim_msg_addr_encode_ipv4_source ((uint8_t *)&msg->groups[0].s[0], stosend, bits)) {
     char source_str[INET_ADDRSTRLEN];
     pim_inet4_dump("<src?>", up->sg.src, source_str, sizeof(source_str));
     zlog_warn("%s: failure encoding source address %s",
-	      __PRETTY_FUNCTION__, source_str);
+              __PRETTY_FUNCTION__, source_str);
     return -7;
   }
-  remain = pim_msg_curr - pim_msg;
 
   /*
    * This is not implemented correctly at this point in time
@@ -254,61 +226,61 @@ pim_msg_join_prune_encode (uint8_t *buf, size_t buf_size, int is_join,
       int send_prune = 0;
 
       zlog_debug ("%s: Considering (%s) children for (S,G,rpt) prune",
-		  __PRETTY_FUNCTION__, up->sg_str);
+                  __PRETTY_FUNCTION__, up->sg_str);
       for (ALL_LIST_ELEMENTS_RO (up->sources, up_node, child))
-	{
-	  if (child->sptbit == PIM_UPSTREAM_SPTBIT_TRUE)
-	    {
-	      if (!pim_rpf_is_same(&up->rpf, &child->rpf))
-		{
-		  send_prune = 1;
-		  if (PIM_DEBUG_PIM_PACKETS)
-		    zlog_debug ("%s: SPT Bit and RPF'(%s) != RPF'(S,G): Add Prune (%s,rpt) to compound message",
-				__PRETTY_FUNCTION__, up->sg_str, child->sg_str);
-		}
-	      else
-		if (PIM_DEBUG_PIM_PACKETS)
-		  zlog_debug ("%s: SPT Bit and RPF'(%s) == RPF'(S,G): Not adding Prune for (%s,rpt)",
-			      __PRETTY_FUNCTION__, up->sg_str, child->sg_str);
-	    }
-	  else if (pim_upstream_is_sg_rpt (child))
-	    {
-	      if (pim_upstream_empty_inherited_olist (child))
-		{
-		  send_prune = 1;
-		  if (PIM_DEBUG_PIM_PACKETS)
-		    zlog_debug ("%s: inherited_olist(%s,rpt) is NULL, Add Prune to compound message",
-				__PRETTY_FUNCTION__, child->sg_str);
-		}
-	      else if (!pim_rpf_is_same (&up->rpf, &child->rpf))
-		{
-		  send_prune = 1;
-		  if (PIM_DEBUG_PIM_PACKETS)
-		    zlog_debug ("%s: RPF'(%s) != RPF'(%s,rpt), Add Prune to compound message",
-				__PRETTY_FUNCTION__, up->sg_str, child->sg_str);
-		}
-	      else
-		if (PIM_DEBUG_PIM_PACKETS)
-		  zlog_debug ("%s: RPF'(%s) == RPF'(%s,rpt), Do not add Prune to compound message",
-			      __PRETTY_FUNCTION__, up->sg_str, child->sg_str);
-	    }
-	  else
-	    if (PIM_DEBUG_PIM_PACKETS)
-	      zlog_debug ("%s: SPT bit is not set for (%s)",
-			  __PRETTY_FUNCTION__, child->sg_str);
-	  if (send_prune)
-	    {
-	      pim_msg_curr = pim_msg_addr_encode_ipv4_source (pim_msg_curr, remain,
-							      child->sg.src,
-							      PIM_ENCODE_SPARSE_BIT | PIM_ENCODE_RPT_BIT);
-	      remain = pim_msg_curr - pim_msg;
-	      *prunes = htons(ntohs(*prunes) + 1);
-	      send_prune = 0;
-	    }
-	}
+        {
+          if (child->sptbit == PIM_UPSTREAM_SPTBIT_TRUE)
+            {
+              if (!pim_rpf_is_same(&up->rpf, &child->rpf))
+                {
+                  send_prune = 1;
+                  if (PIM_DEBUG_PIM_PACKETS)
+                    zlog_debug ("%s: SPT Bit and RPF'(%s) != RPF'(S,G): Add Prune (%s,rpt) to compound message",
+                                __PRETTY_FUNCTION__, up->sg_str, child->sg_str);
+                }
+              else
+                if (PIM_DEBUG_PIM_PACKETS)
+                  zlog_debug ("%s: SPT Bit and RPF'(%s) == RPF'(S,G): Not adding Prune for (%s,rpt)",
+                              __PRETTY_FUNCTION__, up->sg_str, child->sg_str);
+            }
+          else if (pim_upstream_is_sg_rpt (child))
+            {
+              if (pim_upstream_empty_inherited_olist (child))
+                {
+                  send_prune = 1;
+                  if (PIM_DEBUG_PIM_PACKETS)
+                    zlog_debug ("%s: inherited_olist(%s,rpt) is NULL, Add Prune to compound message",
+                                __PRETTY_FUNCTION__, child->sg_str);
+                }
+              else if (!pim_rpf_is_same (&up->rpf, &child->rpf))
+                {
+                  send_prune = 1;
+                  if (PIM_DEBUG_PIM_PACKETS)
+                    zlog_debug ("%s: RPF'(%s) != RPF'(%s,rpt), Add Prune to compound message",
+                                __PRETTY_FUNCTION__, up->sg_str, child->sg_str);
+                }
+              else
+                if (PIM_DEBUG_PIM_PACKETS)
+                  zlog_debug ("%s: RPF'(%s) == RPF'(%s,rpt), Do not add Prune to compound message",
+                              __PRETTY_FUNCTION__, up->sg_str, child->sg_str);
+            }
+          else
+            if (PIM_DEBUG_PIM_PACKETS)
+              zlog_debug ("%s: SPT bit is not set for (%s)",
+                          __PRETTY_FUNCTION__, child->sg_str);
+          if (send_prune)
+            {
+              pim_msg_curr = pim_msg_addr_encode_ipv4_source (pim_msg_curr, remain,
+                                                              child->sg.src,
+                                                              PIM_ENCODE_SPARSE_BIT | PIM_ENCODE_RPT_BIT);
+              remain = pim_msg_curr - pim_msg;
+              *prunes = htons(ntohs(*prunes) + 1);
+              send_prune = 0;
+            }
+        }
     }
 #endif
-  pim_msg_build_header (pim_msg, remain, PIM_MSG_TYPE_JOIN_PRUNE);
+  pim_msg_build_header (buf, sizeof (struct pim_jp), PIM_MSG_TYPE_JOIN_PRUNE);
 
-  return remain;
+  return sizeof (struct pim_jp);
 }

--- a/pimd/pim_msg.c
+++ b/pimd/pim_msg.c
@@ -40,32 +40,27 @@
 void pim_msg_build_header(uint8_t *pim_msg, int pim_msg_size,
 			  uint8_t pim_msg_type)
 {
-  uint16_t checksum;
+  struct pim_msg_header *header = (struct pim_msg_header *)pim_msg;
 
   zassert(pim_msg_size >= PIM_PIM_MIN_LEN);
 
   /*
    * Write header
    */
+  header->ver = PIM_PROTO_VERSION;
+  header->type = pim_msg_type;
+  header->reserved = 0;
 
-  *(uint8_t *) PIM_MSG_HDR_OFFSET_VERSION(pim_msg) = (PIM_PROTO_VERSION << 4) | pim_msg_type;
-  *(uint8_t *) PIM_MSG_HDR_OFFSET_RESERVED(pim_msg) = 0;
 
-  /*
-   * Compute checksum
-   */
-
-  *(uint16_t *) PIM_MSG_HDR_OFFSET_CHECKSUM (pim_msg) = 0;
+  header->checksum = 0;
   /*
    * The checksum for Registers is done only on the first 8 bytes of the packet,
    * including the PIM header and the next 4 bytes, excluding the data packet portion
    */
   if (pim_msg_type == PIM_MSG_TYPE_REGISTER)
-    checksum = in_cksum (pim_msg, PIM_MSG_REGISTER_LEN);
+    header->checksum = in_cksum (pim_msg, PIM_MSG_REGISTER_LEN);
   else
-    checksum = in_cksum (pim_msg, pim_msg_size);
-
-  *(uint16_t *) PIM_MSG_HDR_OFFSET_CHECKSUM(pim_msg) = checksum;
+    header->checksum = in_cksum (pim_msg, pim_msg_size);
 }
 
 uint8_t *pim_msg_addr_encode_ipv4_ucast(uint8_t *buf,

--- a/pimd/pim_msg.c
+++ b/pimd/pim_msg.c
@@ -93,6 +93,106 @@ pim_msg_addr_encode_ipv4_source(uint8_t *buf,
   return buf + PIM_ENCODED_IPV4_SOURCE_SIZE;
 }
 
+static size_t
+pim_msg_build_jp_groups (struct pim_jp_groups *grp, struct pim_upstream *up, int is_join)
+{
+  struct in_addr stosend;
+  uint8_t bits;
+
+  /* number of joined/pruned sources */
+  grp->joins  = htons(is_join ? 1 : 0);
+  grp->prunes = htons(is_join ? 0 : 1);
+
+  if (up->sg.src.s_addr == INADDR_ANY)
+    {
+      struct pim_rpf *rpf = pim_rp_g (up->sg.grp);
+      bits = PIM_ENCODE_SPARSE_BIT | PIM_ENCODE_WC_BIT | PIM_ENCODE_RPT_BIT;
+      stosend = rpf->rpf_addr.u.prefix4;
+    }
+  else
+    {
+      bits = PIM_ENCODE_SPARSE_BIT;
+      stosend = up->sg.src;
+    }
+
+  if (!pim_msg_addr_encode_ipv4_source ((uint8_t *)&grp->s[0], stosend, bits)) {
+    char source_str[INET_ADDRSTRLEN];
+    pim_inet4_dump("<src?>", up->sg.src, source_str, sizeof(source_str));
+    zlog_warn("%s: failure encoding source address %s",
+              __PRETTY_FUNCTION__, source_str);
+    return 0;
+  }
+
+  /*
+   * This is not implemented correctly at this point in time
+   * Make it stop.
+   */
+#if 0
+  if (up->sg.src.s_addr == INADDR_ANY)
+    {
+      struct pim_upstream *child;
+      struct listnode *up_node;
+      int send_prune = 0;
+
+      zlog_debug ("%s: Considering (%s) children for (S,G,rpt) prune",
+                  __PRETTY_FUNCTION__, up->sg_str);
+      for (ALL_LIST_ELEMENTS_RO (up->sources, up_node, child))
+        {
+          if (child->sptbit == PIM_UPSTREAM_SPTBIT_TRUE)
+            {
+              if (!pim_rpf_is_same(&up->rpf, &child->rpf))
+                {
+                  send_prune = 1;
+                  if (PIM_DEBUG_PIM_PACKETS)
+                    zlog_debug ("%s: SPT Bit and RPF'(%s) != RPF'(S,G): Add Prune (%s,rpt) to compound message",
+                                __PRETTY_FUNCTION__, up->sg_str, child->sg_str);
+                }
+              else
+                if (PIM_DEBUG_PIM_PACKETS)
+                  zlog_debug ("%s: SPT Bit and RPF'(%s) == RPF'(S,G): Not adding Prune for (%s,rpt)",
+                              __PRETTY_FUNCTION__, up->sg_str, child->sg_str);
+            }
+          else if (pim_upstream_is_sg_rpt (child))
+            {
+              if (pim_upstream_empty_inherited_olist (child))
+                {
+                  send_prune = 1;
+                  if (PIM_DEBUG_PIM_PACKETS)
+                    zlog_debug ("%s: inherited_olist(%s,rpt) is NULL, Add Prune to compound message",
+                                __PRETTY_FUNCTION__, child->sg_str);
+                }
+              else if (!pim_rpf_is_same (&up->rpf, &child->rpf))
+                {
+                  send_prune = 1;
+                  if (PIM_DEBUG_PIM_PACKETS)
+                    zlog_debug ("%s: RPF'(%s) != RPF'(%s,rpt), Add Prune to compound message",
+                                __PRETTY_FUNCTION__, up->sg_str, child->sg_str);
+                }
+              else
+                if (PIM_DEBUG_PIM_PACKETS)
+                  zlog_debug ("%s: RPF'(%s) == RPF'(%s,rpt), Do not add Prune to compound message",
+                              __PRETTY_FUNCTION__, up->sg_str, child->sg_str);
+            }
+          else
+            if (PIM_DEBUG_PIM_PACKETS)
+              zlog_debug ("%s: SPT bit is not set for (%s)",
+                          __PRETTY_FUNCTION__, child->sg_str);
+          if (send_prune)
+            {
+              pim_msg_curr = pim_msg_addr_encode_ipv4_source (pim_msg_curr, remain,
+                                                              child->sg.src,
+                                                              PIM_ENCODE_SPARSE_BIT | PIM_ENCODE_RPT_BIT);
+              remain = pim_msg_curr - pim_msg;
+              *prunes = htons(ntohs(*prunes) + 1);
+              send_prune = 0;
+            }
+        }
+    }
+#endif
+
+  return sizeof (*grp);
+}
+
 /*
  * J/P Message Format
  *
@@ -165,8 +265,6 @@ pim_msg_join_prune_encode (uint8_t *buf, size_t buf_size, int is_join,
                            struct in_addr upstream, int holdtime)
 {
   struct pim_jp *msg = (struct pim_jp *)buf;
-  struct in_addr stosend;
-  uint8_t bits;
 
   assert(buf_size > sizeof (struct pim_jp));
 
@@ -190,96 +288,8 @@ pim_msg_join_prune_encode (uint8_t *buf, size_t buf_size, int is_join,
     return -5;
   }
 
-  /* number of joined/pruned sources */
-  msg->groups[0].joins  = htons(is_join ? 1 : 0);
-  msg->groups[0].prunes = htons(is_join ? 0 : 1);
+  pim_msg_build_jp_groups (&msg->groups[0], up, is_join);
 
-  if (up->sg.src.s_addr == INADDR_ANY)
-    {
-      struct pim_rpf *rpf = pim_rp_g (up->sg.grp);
-      bits = PIM_ENCODE_SPARSE_BIT | PIM_ENCODE_WC_BIT | PIM_ENCODE_RPT_BIT;
-      stosend = rpf->rpf_addr.u.prefix4;
-    }
-  else
-    {
-      bits = PIM_ENCODE_SPARSE_BIT;
-      stosend = up->sg.src;
-    }
-
-  if (!pim_msg_addr_encode_ipv4_source ((uint8_t *)&msg->groups[0].s[0], stosend, bits)) {
-    char source_str[INET_ADDRSTRLEN];
-    pim_inet4_dump("<src?>", up->sg.src, source_str, sizeof(source_str));
-    zlog_warn("%s: failure encoding source address %s",
-              __PRETTY_FUNCTION__, source_str);
-    return -7;
-  }
-
-  /*
-   * This is not implemented correctly at this point in time
-   * Make it stop.
-   */
-#if 0
-  if (up->sg.src.s_addr == INADDR_ANY)
-    {
-      struct pim_upstream *child;
-      struct listnode *up_node;
-      int send_prune = 0;
-
-      zlog_debug ("%s: Considering (%s) children for (S,G,rpt) prune",
-                  __PRETTY_FUNCTION__, up->sg_str);
-      for (ALL_LIST_ELEMENTS_RO (up->sources, up_node, child))
-        {
-          if (child->sptbit == PIM_UPSTREAM_SPTBIT_TRUE)
-            {
-              if (!pim_rpf_is_same(&up->rpf, &child->rpf))
-                {
-                  send_prune = 1;
-                  if (PIM_DEBUG_PIM_PACKETS)
-                    zlog_debug ("%s: SPT Bit and RPF'(%s) != RPF'(S,G): Add Prune (%s,rpt) to compound message",
-                                __PRETTY_FUNCTION__, up->sg_str, child->sg_str);
-                }
-              else
-                if (PIM_DEBUG_PIM_PACKETS)
-                  zlog_debug ("%s: SPT Bit and RPF'(%s) == RPF'(S,G): Not adding Prune for (%s,rpt)",
-                              __PRETTY_FUNCTION__, up->sg_str, child->sg_str);
-            }
-          else if (pim_upstream_is_sg_rpt (child))
-            {
-              if (pim_upstream_empty_inherited_olist (child))
-                {
-                  send_prune = 1;
-                  if (PIM_DEBUG_PIM_PACKETS)
-                    zlog_debug ("%s: inherited_olist(%s,rpt) is NULL, Add Prune to compound message",
-                                __PRETTY_FUNCTION__, child->sg_str);
-                }
-              else if (!pim_rpf_is_same (&up->rpf, &child->rpf))
-                {
-                  send_prune = 1;
-                  if (PIM_DEBUG_PIM_PACKETS)
-                    zlog_debug ("%s: RPF'(%s) != RPF'(%s,rpt), Add Prune to compound message",
-                                __PRETTY_FUNCTION__, up->sg_str, child->sg_str);
-                }
-              else
-                if (PIM_DEBUG_PIM_PACKETS)
-                  zlog_debug ("%s: RPF'(%s) == RPF'(%s,rpt), Do not add Prune to compound message",
-                              __PRETTY_FUNCTION__, up->sg_str, child->sg_str);
-            }
-          else
-            if (PIM_DEBUG_PIM_PACKETS)
-              zlog_debug ("%s: SPT bit is not set for (%s)",
-                          __PRETTY_FUNCTION__, child->sg_str);
-          if (send_prune)
-            {
-              pim_msg_curr = pim_msg_addr_encode_ipv4_source (pim_msg_curr, remain,
-                                                              child->sg.src,
-                                                              PIM_ENCODE_SPARSE_BIT | PIM_ENCODE_RPT_BIT);
-              remain = pim_msg_curr - pim_msg;
-              *prunes = htons(ntohs(*prunes) + 1);
-              send_prune = 0;
-            }
-        }
-    }
-#endif
   pim_msg_build_header (buf, sizeof (struct pim_jp), PIM_MSG_TYPE_JOIN_PRUNE);
 
   return sizeof (struct pim_jp);

--- a/pimd/pim_msg.c
+++ b/pimd/pim_msg.c
@@ -72,27 +72,23 @@ uint8_t *pim_msg_addr_encode_ipv4_ucast(uint8_t *buf,
 					int buf_size,
 					struct in_addr addr)
 {
-  const int ENCODED_IPV4_UCAST_SIZE = 6;
-
-  if (buf_size < ENCODED_IPV4_UCAST_SIZE) {
-    return 0;
+  if (buf_size < PIM_ENCODED_IPV4_UCAST_SIZE) {
+    return NULL;
   }
 
   buf[0] = PIM_MSG_ADDRESS_FAMILY_IPV4; /* addr family */
   buf[1] = '\0';    /* native encoding */
   memcpy(buf+2, &addr, sizeof(struct in_addr));
 
-  return buf + ENCODED_IPV4_UCAST_SIZE;
+  return buf + PIM_ENCODED_IPV4_UCAST_SIZE;
 }
 
 uint8_t *pim_msg_addr_encode_ipv4_group(uint8_t *buf,
 					int buf_size,
 					struct in_addr addr)
 {
-  const int ENCODED_IPV4_GROUP_SIZE = 8;
-
-  if (buf_size < ENCODED_IPV4_GROUP_SIZE) {
-    return 0;
+  if (buf_size < PIM_ENCODED_IPV4_GROUP_SIZE) {
+    return NULL;
   }
 
   buf[0] = PIM_MSG_ADDRESS_FAMILY_IPV4; /* addr family */
@@ -101,17 +97,15 @@ uint8_t *pim_msg_addr_encode_ipv4_group(uint8_t *buf,
   buf[3] = 32;      /* mask len */
   memcpy(buf+4, &addr, sizeof(struct in_addr));
 
-  return buf + ENCODED_IPV4_GROUP_SIZE;
+  return buf + PIM_ENCODED_IPV4_GROUP_SIZE;
 }
 
 uint8_t *
 pim_msg_addr_encode_ipv4_source(uint8_t *buf, int buf_size,
 				struct in_addr addr, uint8_t bits)
 {
-  const int ENCODED_IPV4_SOURCE_SIZE = 8;
-
-  if (buf_size < ENCODED_IPV4_SOURCE_SIZE) {
-    return 0;
+  if (buf_size < PIM_ENCODED_IPV4_SOURCE_SIZE) {
+    return NULL;
   }
 
   buf[0] = PIM_MSG_ADDRESS_FAMILY_IPV4; /* addr family */
@@ -120,7 +114,7 @@ pim_msg_addr_encode_ipv4_source(uint8_t *buf, int buf_size,
   buf[3] = 32;      /* mask len */
   memcpy(buf+4, &addr, sizeof(struct in_addr));
 
-  return buf + ENCODED_IPV4_SOURCE_SIZE;
+  return buf + PIM_ENCODED_IPV4_SOURCE_SIZE;
 }
 
 int

--- a/pimd/pim_msg.h
+++ b/pimd/pim_msg.h
@@ -45,25 +45,18 @@ struct pim_msg_header {
   uint16_t checksum;
 } __attribute__ ((packed));
 
-void pim_msg_build_header(uint8_t *pim_msg, int pim_msg_size,
-			  uint8_t pim_msg_type);
-uint8_t *pim_msg_addr_encode_ipv4_ucast(uint8_t *buf,
-					int buf_size,
-					struct in_addr addr);
-uint8_t *pim_msg_addr_encode_ipv4_group(uint8_t *buf,
-					int buf_size,
-					struct in_addr addr);
+void pim_msg_build_header(uint8_t *pim_msg, size_t pim_msg_size, uint8_t pim_msg_type);
+uint8_t *pim_msg_addr_encode_ipv4_ucast(uint8_t *buf, struct in_addr addr);
+uint8_t *pim_msg_addr_encode_ipv4_group(uint8_t *buf, struct in_addr addr);
 
 #define PIM_ENCODE_SPARSE_BIT      0x04
 #define PIM_ENCODE_WC_BIT          0x02
 #define PIM_ENCODE_RPT_BIT         0x01
 uint8_t *pim_msg_addr_encode_ipv4_source(uint8_t *buf,
-					 int buf_size,
-					 struct in_addr addr,
-					 uint8_t bits);
+                                         struct in_addr addr, uint8_t bits);
 
 
-int pim_msg_join_prune_encode (uint8_t *buf, int buf_size, int is_join,
-			       struct pim_upstream *up,
-			       struct in_addr upstream, int holdtime);
+int pim_msg_join_prune_encode (uint8_t *buf, size_t buf_size, int is_join,
+                               struct pim_upstream *up,
+                               struct in_addr upstream, int holdtime);
 #endif /* PIM_MSG_H */

--- a/pimd/pim_msg.h
+++ b/pimd/pim_msg.h
@@ -45,6 +45,44 @@ struct pim_msg_header {
   uint16_t checksum;
 } __attribute__ ((packed));
 
+struct pim_encoded_ipv4_unicast {
+  uint8_t  family;
+  uint8_t  reserved;
+  struct in_addr addr;
+} __attribute__ ((packed));
+
+struct pim_encoded_group_ipv4 {
+  uint8_t        ne;
+  uint8_t        family;
+  uint8_t        reserved;
+  uint8_t        mask;
+  struct in_addr addr;
+} __attribute__ ((packed));
+
+struct pim_encoded_source_ipv4 {
+  uint8_t        ne;
+  uint8_t        family;
+  uint8_t        bits;
+  uint8_t        mask;
+  struct in_addr addr;
+} __attribute__ ((packed));
+
+struct pim_jp_groups {
+  struct pim_encoded_group_ipv4  g;
+  uint16_t                       joins;
+  uint16_t                       prunes;
+  struct pim_encoded_source_ipv4 s[1];
+} __attribute__ ((packed));
+
+struct pim_jp {
+  struct pim_msg_header           header;
+  struct pim_encoded_ipv4_unicast addr;
+  uint8_t                         reserved;
+  uint8_t                         num_groups;
+  uint16_t                        holdtime;
+  struct pim_jp_groups            groups[1];
+} __attribute__ ((packed));
+
 void pim_msg_build_header(uint8_t *pim_msg, size_t pim_msg_size, uint8_t pim_msg_type);
 uint8_t *pim_msg_addr_encode_ipv4_ucast(uint8_t *buf, struct in_addr addr);
 uint8_t *pim_msg_addr_encode_ipv4_group(uint8_t *buf, struct in_addr addr);

--- a/pimd/pim_msg.h
+++ b/pimd/pim_msg.h
@@ -35,6 +35,16 @@
 */
 #define PIM_MSG_ADDRESS_FAMILY_IPV4 (1)
 
+/*
+ * Network Order pim_msg_hdr
+ */
+struct pim_msg_header {
+  uint8_t  type:4;
+  uint8_t  ver:4;
+  uint8_t  reserved;
+  uint16_t checksum;
+} __attribute__ ((packed));
+
 void pim_msg_build_header(uint8_t *pim_msg, int pim_msg_size,
 			  uint8_t pim_msg_type);
 uint8_t *pim_msg_addr_encode_ipv4_ucast(uint8_t *buf,

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -150,19 +150,6 @@ int pim_pim_packet(struct interface *ifp, uint8_t *buf, size_t len)
   ip_hdr = (struct ip *) buf;
   ip_hlen = ip_hdr->ip_hl << 2; /* ip_hl gives length in 4-byte words */
 
-  if (ip_hlen < PIM_IP_HEADER_MIN_LEN) {
-    if (PIM_DEBUG_PIM_PACKETS)
-      zlog_debug("IP packet header size=%zu shorter than minimum=%d",
-                ip_hlen, PIM_IP_HEADER_MIN_LEN);
-    return -1;
-  }
-  if (ip_hlen > PIM_IP_HEADER_MAX_LEN) {
-    if (PIM_DEBUG_PIM_PACKETS)
-      zlog_debug("IP packet header size=%zu greater than maximum=%d",
-                ip_hlen, PIM_IP_HEADER_MAX_LEN);
-    return -1;
-  }
-
   pim_msg = buf + ip_hlen;
   pim_msg_len = len - ip_hlen;
 

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -385,7 +385,6 @@ static void pim_sock_read_on(struct interface *ifp)
 	       pim_ifp->pim_sock_fd);
   }
   pim_ifp->t_pim_sock_read = NULL;
-  zassert(!pim_ifp->t_pim_sock_read);
   THREAD_READ_ON(master, pim_ifp->t_pim_sock_read, pim_sock_read, ifp,
 		 pim_ifp->pim_sock_fd);
 }

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -150,13 +150,6 @@ int pim_pim_packet(struct interface *ifp, uint8_t *buf, size_t len)
   ip_hdr = (struct ip *) buf;
   ip_hlen = ip_hdr->ip_hl << 2; /* ip_hl gives length in 4-byte words */
 
-  if (ip_hdr->ip_p != PIM_IP_PROTO_PIM) {
-    if (PIM_DEBUG_PIM_PACKETS)
-      zlog_debug("IP packet protocol=%d is not PIM=%d",
-		 ip_hdr->ip_p, PIM_IP_PROTO_PIM);
-    return -1;
-  }
-
   if (ip_hlen < PIM_IP_HEADER_MIN_LEN) {
     if (PIM_DEBUG_PIM_PACKETS)
       zlog_debug("IP packet header size=%zu shorter than minimum=%d",

--- a/pimd/pim_pim.c
+++ b/pimd/pim_pim.c
@@ -669,8 +669,7 @@ static int hello_send(struct interface *ifp,
   zassert(pim_msg_size >= PIM_PIM_MIN_LEN);
   zassert(pim_msg_size <= PIM_PIM_BUFSIZE_WRITE);
 
-  pim_msg_build_header(pim_msg, pim_msg_size,
-		       PIM_MSG_TYPE_HELLO);
+  pim_msg_build_header(pim_msg, pim_msg_size, PIM_MSG_TYPE_HELLO);
 
   if (pim_msg_send(pim_ifp->pim_sock_fd,
 		   pim_ifp->primary_address,

--- a/pimd/pim_pim.h
+++ b/pimd/pim_pim.h
@@ -48,15 +48,6 @@ enum pim_msg_type {
   PIM_MSG_TYPE_CANDIDATE
 };
 
-#define PIM_MSG_HDR_OFFSET_VERSION(pim_msg) (pim_msg)
-#define PIM_MSG_HDR_OFFSET_TYPE(pim_msg) (pim_msg)
-#define PIM_MSG_HDR_OFFSET_RESERVED(pim_msg) (((char *)(pim_msg)) + 1)
-#define PIM_MSG_HDR_OFFSET_CHECKSUM(pim_msg) (((char *)(pim_msg)) + 2)
-
-#define PIM_MSG_HDR_GET_VERSION(pim_msg) ((*(uint8_t*) PIM_MSG_HDR_OFFSET_VERSION(pim_msg)) >> 4)
-#define PIM_MSG_HDR_GET_TYPE(pim_msg) ((*(uint8_t*) PIM_MSG_HDR_OFFSET_TYPE(pim_msg)) & 0xF)
-#define PIM_MSG_HDR_GET_CHECKSUM(pim_msg) (*(uint16_t*) PIM_MSG_HDR_OFFSET_CHECKSUM(pim_msg))
-
 void pim_ifstat_reset(struct interface *ifp);
 void pim_sock_reset(struct interface *ifp);
 int pim_sock_add(struct interface *ifp);

--- a/pimd/pim_rpf.h
+++ b/pimd/pim_rpf.h
@@ -63,7 +63,7 @@ struct pim_upstream;
 extern long long nexthop_lookups_avoided;
 
 int pim_nexthop_lookup(struct pim_nexthop *nexthop, struct in_addr addr, int neighbor_needed);
-enum pim_rpf_result pim_rpf_update(struct pim_upstream *up, struct in_addr *old_rpf_addr);
+enum pim_rpf_result pim_rpf_update(struct pim_upstream *up, struct pim_rpf *old);
 
 int pim_rpf_addr_is_inaddr_none (struct pim_rpf *rpf);
 int pim_rpf_addr_is_inaddr_any (struct pim_rpf *rpf);

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -171,9 +171,7 @@ pim_upstream_del(struct pim_upstream *up, const char *name)
   THREAD_OFF(up->t_msdp_reg_timer);
 
   if (up->join_state == PIM_UPSTREAM_JOINED) {
-    pim_joinprune_send (up->rpf.source_nexthop.interface,
-                      up->rpf.rpf_addr.u.prefix4,
-                      up, 0);
+    pim_joinprune_send (&up->rpf, up, 0);
     if (up->sg.src.s_addr == INADDR_ANY) {
         /* if a (*, G) entry in the joined state is being deleted we
          * need to notify MSDP */
@@ -231,10 +229,7 @@ pim_upstream_send_join (struct pim_upstream *up)
   }
 
   /* send Join(S,G) to the current upstream neighbor */
-  pim_joinprune_send(up->rpf.source_nexthop.interface,
-  		     up->rpf.rpf_addr.u.prefix4,
-		     up,
-		     1 /* join */);
+  pim_joinprune_send(&up->rpf, up, 1 /* join */);
 }
 
 static int on_join_timer(struct thread *t)
@@ -487,10 +482,7 @@ pim_upstream_switch(struct pim_upstream *up,
     forward_off(up);
     if (old_state == PIM_UPSTREAM_JOINED)
       pim_msdp_up_join_state_changed(up);
-    pim_joinprune_send(up->rpf.source_nexthop.interface,
-		       up->rpf.rpf_addr.u.prefix4,
-		       up,
-		       0 /* prune */);
+    pim_joinprune_send(&up->rpf, up, 0 /* prune */);
     if (up->t_join_timer)
       THREAD_OFF(up->t_join_timer);
   }

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -334,8 +334,7 @@ void pim_upstream_join_suppress(struct pim_upstream *up,
 }
 
 void pim_upstream_join_timer_decrease_to_t_override(const char *debug_label,
-						    struct pim_upstream *up,
-						    struct in_addr rpf_addr)
+                                                    struct pim_upstream *up)
 {
   long join_timer_remain_msec;
   int t_override_msec;
@@ -345,7 +344,7 @@ void pim_upstream_join_timer_decrease_to_t_override(const char *debug_label,
 
   if (PIM_DEBUG_TRACE) {
     char rpf_str[INET_ADDRSTRLEN];
-    pim_inet4_dump("<rpf?>", rpf_addr, rpf_str, sizeof(rpf_str));
+    pim_inet4_dump("<rpf?>", up->rpf.rpf_addr.u.prefix4, rpf_str, sizeof(rpf_str));
     zlog_debug("%s: to RPF'%s=%s: join_timer=%ld msec t_override=%d msec",
 	       debug_label,
 	       up->sg_str, rpf_str,
@@ -803,7 +802,7 @@ void pim_upstream_rpf_genid_changed(struct in_addr neigh_addr)
       continue;
 
     pim_upstream_join_timer_decrease_to_t_override("RPF'(S,G) GenID change",
-						   up, neigh_addr);
+                                                   up);
   }
 }
 

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -661,7 +661,7 @@ struct pim_upstream *pim_upstream_add(struct prefix_sg *sg,
   return up;
 }
 
-static int
+int
 pim_upstream_evaluate_join_desired_interface (struct pim_upstream *up,
 					      struct pim_ifchannel *ch)
 {

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -134,9 +134,10 @@ void pim_upstream_update_join_desired(struct pim_upstream *up);
 void pim_upstream_join_suppress(struct pim_upstream *up,
 				struct in_addr rpf_addr,
 				int holdtime);
+
 void pim_upstream_join_timer_decrease_to_t_override(const char *debug_label,
-						    struct pim_upstream *up,
-						    struct in_addr rpf_addr);
+                                                    struct pim_upstream *up);
+
 void pim_upstream_join_timer_restart(struct pim_upstream *up);
 void pim_upstream_rpf_genid_changed(struct in_addr neigh_addr);
 void pim_upstream_rpf_interface_changed(struct pim_upstream *up,

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -129,6 +129,8 @@ struct pim_upstream *pim_upstream_add (struct prefix_sg *sg,
 void pim_upstream_del(struct pim_upstream *up, const char *name);
 
 int pim_upstream_evaluate_join_desired(struct pim_upstream *up);
+int pim_upstream_evaluate_join_desired_interface(struct pim_upstream *up,
+                                                 struct pim_ifchannel *ch);
 void pim_upstream_update_join_desired(struct pim_upstream *up);
 
 void pim_upstream_join_suppress(struct pim_upstream *up,

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -366,12 +366,11 @@ static void scan_upstream_rpf_cache()
   struct pim_upstream *up;
 
   for (ALL_LIST_ELEMENTS(pim_upstream_list, up_node, up_nextnode, up)) {
-    struct in_addr      old_rpf_addr;
-    struct interface    *old_interface;
     enum pim_rpf_result rpf_result;
+    struct pim_rpf      old;
 
-    old_interface = up->rpf.source_nexthop.interface;
-    rpf_result = pim_rpf_update(up, &old_rpf_addr);
+    old.source_nexthop.interface = up->rpf.source_nexthop.interface;
+    rpf_result = pim_rpf_update(up, &old);
     if (rpf_result == PIM_RPF_FAILURE)
       continue;
 
@@ -412,7 +411,7 @@ static void scan_upstream_rpf_cache()
 
     
 	/* send Prune(S,G) to the old upstream neighbor */
-	pim_joinprune_send(old_interface, old_rpf_addr,
+	pim_joinprune_send(old.source_nexthop.interface, old.rpf_addr.u.prefix4,
 			   up, 0 /* prune */);
 	
 	/* send Join(S,G) to the current upstream neighbor */

--- a/pimd/pim_zebra.c
+++ b/pimd/pim_zebra.c
@@ -411,14 +411,10 @@ static void scan_upstream_rpf_cache()
 
     
 	/* send Prune(S,G) to the old upstream neighbor */
-	pim_joinprune_send(old.source_nexthop.interface, old.rpf_addr.u.prefix4,
-			   up, 0 /* prune */);
+	pim_joinprune_send(&old, up, 0 /* prune */);
 	
 	/* send Join(S,G) to the current upstream neighbor */
-	pim_joinprune_send(up->rpf.source_nexthop.interface,
-			   up->rpf.rpf_addr.u.prefix4,
-			   up,
-			   1 /* join */);
+	pim_joinprune_send(&up->rpf, up, 1 /* join */);
 
 	pim_upstream_join_timer_restart(up);
       } /* up->join_state == PIM_UPSTREAM_JOINED */

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -31,8 +31,6 @@
 #define PIMD_DEFAULT_CONFIG "pimd.conf"
 #define PIMD_VTY_PORT       2611
 
-#define PIM_IP_HEADER_MIN_LEN         (20)
-#define PIM_IP_HEADER_MAX_LEN         (60)
 #define PIM_IP_PROTO_IGMP             (2)
 #define PIM_IP_PROTO_PIM              (103)
 #define PIM_IGMP_MIN_LEN              (8)

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -38,6 +38,10 @@
 #define PIM_IGMP_MIN_LEN              (8)
 #define PIM_MSG_HEADER_LEN            (4)
 #define PIM_PIM_MIN_LEN               PIM_MSG_HEADER_LEN
+
+#define PIM_ENCODED_IPV4_UCAST_SIZE    (6)
+#define PIM_ENCODED_IPV4_GROUP_SIZE    (8)
+#define PIM_ENCODED_IPV4_SOURCE_SIZE   (8)
 #define PIM_PROTO_VERSION             (2)
 
 #define MCAST_ALL_SYSTEMS      "224.0.0.1"

--- a/pimd/pimd.h
+++ b/pimd/pimd.h
@@ -36,12 +36,38 @@
 #define PIM_IP_PROTO_IGMP             (2)
 #define PIM_IP_PROTO_PIM              (103)
 #define PIM_IGMP_MIN_LEN              (8)
+
+/*
+ * PIM MSG Header Format
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |PIM Ver| Type  |   Reserved    |           Checksum            |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
 #define PIM_MSG_HEADER_LEN            (4)
 #define PIM_PIM_MIN_LEN               PIM_MSG_HEADER_LEN
 
 #define PIM_ENCODED_IPV4_UCAST_SIZE    (6)
 #define PIM_ENCODED_IPV4_GROUP_SIZE    (8)
 #define PIM_ENCODED_IPV4_SOURCE_SIZE   (8)
+
+/*
+ * J/P Message Format, Group Header
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |        Upstream Neighbor Address (Encoded-Unicast format)     |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |  Reserved     | Num groups    |          Holdtime             |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |         Multicast Group Address 1 (Encoded-Group format)      |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |   Number of Joined Sources    |   Number of Pruned Sources    |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+#define PIM_JP_GROUP_HEADER_SIZE     (PIM_ENCODED_IPV4_UCAST_SIZE + \
+                                      1 + 1 + 2 +                   \
+                                      PIM_ENCODED_IPV4_GROUP_SIZE + \
+                                      2 + 2)
+
 #define PIM_PROTO_VERSION             (2)
 
 #define MCAST_ALL_SYSTEMS      "224.0.0.1"


### PR DESCRIPTION
These commits do these things:

1) Set us up for J/P Aggregation a bit better.

2) Some Performance Fixes
  -> When figuring inheritance for a *,G only look at interesting S,G ifchannels, instead of all ifchannels
  -> When looking up a S,G for a igmp report allow the use of a hash to find it.
  -> Intelligently Drop some WRVIFWHOLE packets when we know we don't need to process them.

3) Fix static mroute displaying