### PR TITLE
tools: frr-reload.py needs to treat "mpls" as a single line context

### DIFF
--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -350,6 +350,7 @@ end
                                 "ip ",
                                 "ipv6 ",
                                 "log ",
+                                "mpls",
                                 "password ",
                                 "ptm-enable",
                                 "router-id ",

--- a/tools/frr-reload.py
+++ b/tools/frr-reload.py
@@ -351,6 +351,7 @@ end
                                 "ipv6 ",
                                 "log ",
                                 "mpls",
+                                "no ",
                                 "password ",
                                 "ptm-enable",
                                 "router-id ",


### PR DESCRIPTION
Signed-off-by: Daniel Walton <dwalton@cumulusnetworks.com>
Reviewed-by:   Donald Sharp <sharpd@cumulusnetworks.com>