### PR TITLE
Bgp memory

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2062,7 +2062,7 @@ bgp_process (struct bgp *bgp, struct bgp_node *rn, afi_t afi, safi_t safi)
     return;
 
   if (bm->process_main_queue == NULL)
-    bgp_process_queue_init ();
+    return;
 
   pqnode = XCALLOC (MTYPE_BGP_PROCESS_QUEUE, 
                     sizeof (struct bgp_process_queue));
@@ -2087,7 +2087,7 @@ bgp_add_eoiu_mark (struct bgp *bgp)
   struct bgp_process_queue *pqnode;
 
   if (bm->process_main_queue == NULL)
-    bgp_process_queue_init ();
+    return;
 
   pqnode = XCALLOC (MTYPE_BGP_PROCESS_QUEUE,
                     sizeof (struct bgp_process_queue));

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -546,7 +546,7 @@ bpacket_reformat_for_peer (struct bpacket *pkt, struct peer_af *paf)
 	    }
 
           if (gnh_modified)
-            stream_put_in6_addr_at (s, vec->offset + 1 + (nhlen-IPV6_MAX_BYTELEN), mod_v6nhg);
+            stream_put_in6_addr_at (s, vec->offset + 1, mod_v6nhg);
           if (lnh_modified)
             stream_put_in6_addr_at (s, vec->offset + 1 + (nhlen-IPV6_MAX_BYTELEN), mod_v6nhl);
 

--- a/configure.ac
+++ b/configure.ac
@@ -1574,14 +1574,6 @@ AC_SUBST(CFG_SYSCONF)
 AC_SUBST(CFG_SBIN)
 AC_SUBST(CFG_STATE)
 
-dnl -------------------------------
-dnl Quagga sources should always be 
-dnl current wrt interfaces. Dont
-dnl allow deprecated interfaces to
-dnl be exposed.
-dnl -------------------------------
-AC_DEFINE(QUAGGA_NO_DEPRECATED_INTERFACES, 1, Hide deprecated interfaces)
-
 dnl ---------------------------
 dnl Check htonl works correctly
 dnl ---------------------------

--- a/lib/linklist.h
+++ b/lib/linklist.h
@@ -135,15 +135,4 @@ extern void list_add_list (struct list *, struct list *);
     (L)->count--; \
   } while (0)
 
-/* Deprecated: 20050406 */
-#if !defined(QUAGGA_NO_DEPRECATED_INTERFACES)
-#warning "Using deprecated libfrr interfaces"
-#define LISTNODE_ADD(L,N) LISTNODE_ATTACH(L,N)
-#define LISTNODE_DELETE(L,N) LISTNODE_DETACH(L,N)
-#define nextnode(X) ((X) = (X)->next)
-#define getdata(X) listgetdata(X)
-#define LIST_LOOP(L,V,N) \
-  for (ALL_LIST_ELEMENTS_RO (L,N,V))
-#endif /* QUAGGA_NO_DEPRECATED_INTERFACES */
-
 #endif /* _ZEBRA_LINKLIST_H */


### PR DESCRIPTION
Fixes issue #95 (I hope)

I was able to reproduce massive memory loss on shutdown with valgrind.  With this patch it is no longer happening for me.