### PR TITLE
bgpd: Fix memory leaks on shutdown

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -2062,7 +2062,7 @@ bgp_process (struct bgp *bgp, struct bgp_node *rn, afi_t afi, safi_t safi)
     return;
 
   if (bm->process_main_queue == NULL)
-    bgp_process_queue_init ();
+    return;
 
   pqnode = XCALLOC (MTYPE_BGP_PROCESS_QUEUE, 
                     sizeof (struct bgp_process_queue));
@@ -2087,7 +2087,7 @@ bgp_add_eoiu_mark (struct bgp *bgp)
   struct bgp_process_queue *pqnode;
 
   if (bm->process_main_queue == NULL)
-    bgp_process_queue_init ();
+    return;
 
   pqnode = XCALLOC (MTYPE_BGP_PROCESS_QUEUE,
                     sizeof (struct bgp_process_queue));


### PR DESCRIPTION
The original code on shutdown assumed a 'forced' mode
if there was no process_main_queue.  This construct
was violated by commit 2e02b9b2d1ed29975001d6917f9f726854ec5559
due to not fully understanding the shutdown process.

If we are shutting down, don't store work to do later,
just gracefully don't do it.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>