### PR TITLE
lib, bgpd: clean up headers

### DIFF
--- a/bgpd/bgp_aspath.c
+++ b/bgpd/bgp_aspath.c
@@ -24,7 +24,6 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "hash.h"
 #include "memory.h"
 #include "vector.h"
-#include "vty.h"
 #include "log.h"
 #include "stream.h"
 #include "command.h"

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -24,7 +24,6 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "prefix.h"
 #include "memory.h"
 #include "vector.h"
-#include "vty.h"
 #include "stream.h"
 #include "log.h"
 #include "hash.h"

--- a/bgpd/bgp_bfd.c
+++ b/bgpd/bgp_bfd.c
@@ -31,7 +31,6 @@
 #include "buffer.h"
 #include "stream.h"
 #include "zclient.h"
-#include "vty.h"
 #include "bfd.h"
 #include "lib/json.h"
 #include "filter.h"

--- a/bgpd/bgp_encap_tlv.c
+++ b/bgpd/bgp_encap_tlv.c
@@ -22,7 +22,6 @@
 #include "command.h"
 #include "memory.h"
 #include "prefix.h"
-#include "vty.h"
 #include "filter.h"
 
 #include "bgpd.h"

--- a/bgpd/bgp_fsm.c
+++ b/bgpd/bgp_fsm.c
@@ -23,7 +23,6 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 
 #include "linklist.h"
 #include "prefix.h"
-#include "vty.h"
 #include "sockunion.h"
 #include "thread.h"
 #include "log.h"

--- a/bgpd/bgp_main.c
+++ b/bgpd/bgp_main.c
@@ -21,7 +21,6 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include <zebra.h>
 
 #include "vector.h"
-#include "vty.h"
 #include "command.h"
 #include "getopt.h"
 #include "thread.h"

--- a/bgpd/bgp_routemap.c
+++ b/bgpd/bgp_routemap.c
@@ -22,7 +22,6 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 
 #include "prefix.h"
 #include "filter.h"
-#include "vty.h"
 #include "routemap.h"
 #include "command.h"
 #include "linklist.h"

--- a/bgpd/bgp_table.c
+++ b/bgpd/bgp_table.c
@@ -23,7 +23,6 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "prefix.h"
 #include "memory.h"
 #include "sockunion.h"
-#include "vty.h"
 #include "queue.h"
 #include "filter.h"
 #include "command.h"

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -24,6 +24,7 @@ Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
 #include "qobj.h"
 #include "lib/json.h"
 #include "vrf.h"
+#include "vty.h"
 
 /* For union sockunion.  */
 #include "queue.h"

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -27,7 +27,6 @@
 #include "plist.h"
 #include "sockunion.h"
 #include "buffer.h"
-#include "stream.h"
 #include "log.h"
 #include "routemap.h"
 #include "lib/json.h"

--- a/lib/plist.h
+++ b/lib/plist.h
@@ -23,6 +23,11 @@
 #ifndef _QUAGGA_PLIST_H
 #define _QUAGGA_PLIST_H
 
+#include <zebra.h>
+
+#include "stream.h"
+#include "vty.h"
+
 enum prefix_list_type 
 {
   PREFIX_DENY,


### PR DESCRIPTION
* plist.h should include headers for the types it uses
* bgpd.h should include headers for the types it uses
* after these changes, removed unnecessary includes across bgpd