### PR TITLE
bgpd, zebra: Add ifindex to NEXTHOP_TYPE_IPV4

### DIFF
--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -432,6 +432,7 @@ bgp_parse_nexthop_update (int command, vrf_id_t vrf_id)
 	    {
 	    case NEXTHOP_TYPE_IPV4:
 	      nexthop->gate.ipv4.s_addr = stream_get_ipv4 (s);
+              nexthop->ifindex = stream_getl (s);
 	      break;
 	    case NEXTHOP_TYPE_IFINDEX:
 	      nexthop->ifindex = stream_getl (s);

--- a/bgpd/bgp_nht.c
+++ b/bgpd/bgp_nht.c
@@ -443,6 +443,7 @@ bgp_parse_nexthop_update (int command, vrf_id_t vrf_id)
 	      break;
             case NEXTHOP_TYPE_IPV6:
 	      stream_get (&nexthop->gate.ipv6, s, 16);
+              nexthop->ifindex = stream_getl (s);
 	      break;
             case NEXTHOP_TYPE_IPV6_IFINDEX:
 	      stream_get (&nexthop->gate.ipv6, s, 16);

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -893,6 +893,7 @@ send_client (struct rnh *rnh, struct zserv *client, rnh_type_t type, vrf_id_t vr
 	      {
 	      case NEXTHOP_TYPE_IPV4:
 		stream_put_in_addr (s, &nexthop->gate.ipv4);
+                stream_putl (s, nexthop->ifindex);
 		break;
 	      case NEXTHOP_TYPE_IFINDEX:
 		stream_putl (s, nexthop->ifindex);

--- a/zebra/zebra_rnh.c
+++ b/zebra/zebra_rnh.c
@@ -904,6 +904,7 @@ send_client (struct rnh *rnh, struct zserv *client, rnh_type_t type, vrf_id_t vr
 		break;
 	      case NEXTHOP_TYPE_IPV6:
 		stream_put (s, &nexthop->gate.ipv6, 16);
+                stream_putl (s, nexthop->ifindex);
 		break;
 	      case NEXTHOP_TYPE_IPV6_IFINDEX:
 		stream_put (s, &nexthop->gate.ipv6, 16);


### PR DESCRIPTION
When passing up NEXTHOP_TYPE_IPV4 pass up the ifindex as well
Zebra already stores this data by passing it up PIM will be
able to use NEXTHOP_TYPE_IPV4 without having to do a recursive
lookup.

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>
Reviewed-by: Don Slice <dslice@cumulusnetworks.com>
Reviewed-by: Chirag Shah <chirag@cumulusnetworks.com>