### PR TITLE
BGP Display

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -6097,7 +6097,7 @@ route_vty_out (struct vty *vty, struct prefix *p,
        * neccessarily the same as the prefix address family.
        * Both SAFI_MPLS_VPN and SAFI_ENCAP use the MP nexthop field
        */
-      if ((safi == SAFI_ENCAP) || (safi == SAFI_MPLS_VPN) || (safi = SAFI_EVPN))
+      if ((safi == SAFI_ENCAP) || (safi == SAFI_MPLS_VPN) || (safi == SAFI_EVPN))
         {
 	  if (attr->extra)
             {

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -5267,7 +5267,7 @@ bgp_aggregate_increment (struct bgp *bgp, struct prefix *p,
   struct bgp_table *table;
 
   /* MPLS-VPN aggregation is not yet supported. */
-  if ((safi == SAFI_MPLS_VPN) || (safi == SAFI_ENCAP) || (safi = SAFI_EVPN))
+  if ((safi == SAFI_MPLS_VPN) || (safi == SAFI_ENCAP) || (safi == SAFI_EVPN))
     return;
 
   table = bgp->aggregate[afi][safi];
@@ -5304,7 +5304,7 @@ bgp_aggregate_decrement (struct bgp *bgp, struct prefix *p,
   struct bgp_table *table;
 
   /* MPLS-VPN aggregation is not yet supported. */
-  if ((safi == SAFI_MPLS_VPN) || (safi == SAFI_ENCAP) || (safi = SAFI_EVPN))
+  if ((safi == SAFI_MPLS_VPN) || (safi == SAFI_ENCAP) || (safi == SAFI_EVPN))
     return;
 
   table = bgp->aggregate[afi][safi];
@@ -6129,7 +6129,7 @@ route_vty_out (struct vty *vty, struct prefix *p,
             {
               json_nexthop_global = json_object_new_object();
 
-	      if ((safi == SAFI_MPLS_VPN) || (safi = SAFI_EVPN))
+	      if ((safi == SAFI_MPLS_VPN) || (safi == SAFI_EVPN))
                 json_object_string_add(json_nexthop_global, "ip", inet_ntoa (attr->extra->mp_nexthop_global_in));
               else
                 json_object_string_add(json_nexthop_global, "ip", inet_ntoa (attr->nexthop));
@@ -6139,7 +6139,7 @@ route_vty_out (struct vty *vty, struct prefix *p,
             }
           else
             {
-	      if ((safi == SAFI_MPLS_VPN) || (safi = SAFI_EVPN))
+	      if ((safi == SAFI_MPLS_VPN) || (safi == SAFI_EVPN))
 	        vty_out (vty, "%-16s",
                          inet_ntoa (attr->extra->mp_nexthop_global_in));
 	      else

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8358,7 +8358,6 @@ DEFUN (show_ip_bgp,
        "Display route and more specific routes\n"
        JSON_STR)
 {
-  vrf_id_t vrf = VRF_DEFAULT;
   afi_t afi = AFI_IP6;
   safi_t safi = SAFI_UNICAST;
   int exact_match = 0;
@@ -8366,22 +8365,12 @@ DEFUN (show_ip_bgp,
   struct bgp *bgp = NULL;
   int idx = 0;
 
-  bgp_vty_find_and_parse_afi_safi_vrf (vty, argv, argc, &idx, &afi, &safi, &vrf);
+  bgp_vty_find_and_parse_afi_safi_bgp (vty, argv, argc, &idx, &afi, &safi, &bgp);
   if (!idx)
     return CMD_WARNING;
 
   int uj = use_json (argc, argv);
   if (uj) argc--;
-
-  bgp = bgp_lookup_by_vrf_id (vrf);
-  if (bgp == NULL)
-    {
-      if (vrf == VRF_DEFAULT)
-        vty_out (vty, "Can't find BGP instance (default)%s", VTY_NEWLINE);
-      else
-        vty_out (vty, "Can't find BGP instance %d%s", vrf, VTY_NEWLINE);
-      return CMD_WARNING;
-    }
 
   if (argv_find(argv, argc, "cidr-only", &idx))
     return bgp_show (vty, bgp, afi, safi, bgp_show_type_cidr_only, NULL, uj);
@@ -8465,7 +8454,7 @@ DEFUN (show_ip_bgp_route,
 
   afi_t afi = AFI_IP6;
   safi_t safi = SAFI_UNICAST;
-  vrf_id_t vrf = VRF_DEFAULT;;
+  //  vrf_id_t vrf = VRF_DEFAULT;;
   char *prefix = NULL;
   struct bgp *bgp = NULL;
   enum bgp_path_type path_type;
@@ -8473,20 +8462,11 @@ DEFUN (show_ip_bgp_route,
 
   int idx = 0;
 
-  bgp_vty_find_and_parse_afi_safi_vrf (vty, argv, argc, &idx, &afi, &safi, &vrf);
+  bgp_vty_find_and_parse_afi_safi_bgp (vty, argv, argc, &idx, &afi, &safi, &bgp);
   if (!idx)
     return CMD_WARNING;
 
-  if (vrf != VRF_ALL)
-    {
-      bgp = bgp_lookup_by_vrf_id (vrf);
-      if (bgp == NULL)
-        {
-          vty_out (vty, "Can't find BGP instance %s%s", argv[5]->arg, VTY_NEWLINE);
-          return CMD_WARNING;
-        }
-    }
-  else
+  if (!bgp)
     {
       vty_out (vty, "Specified 'all' vrf's but this command currently only works per view/vrf%s", VTY_NEWLINE);
       return CMD_WARNING;
@@ -8534,12 +8514,12 @@ DEFUN (show_ip_bgp_regexp,
        "Display routes matching the AS path regular expression\n"
        "A regular-expression to match the BGP AS paths\n")
 {
-  vrf_id_t vrf = VRF_DEFAULT;
   afi_t afi = AFI_IP6;
   safi_t safi = SAFI_UNICAST;
+  struct bgp *bgp = NULL;
 
   int idx = 0;
-  bgp_vty_find_and_parse_afi_safi_vrf (vty, argv, argc, &idx, &afi, &safi, &vrf);
+  bgp_vty_find_and_parse_afi_safi_bgp (vty, argv, argc, &idx, &afi, &safi, &bgp);
   if (!idx)
     return CMD_WARNING;
 
@@ -8564,12 +8544,12 @@ DEFUN (show_ip_bgp_instance_all,
        BGP_SAFI_HELP_STR
        JSON_STR)
 {
-  vrf_id_t vrf = VRF_DEFAULT;
   afi_t afi = AFI_IP;
   safi_t safi = SAFI_UNICAST;
+  struct bgp *bgp = NULL;
 
   int idx = 0;
-  bgp_vty_find_and_parse_afi_safi_vrf (vty, argv, argc, &idx, &afi, &safi, &vrf);
+  bgp_vty_find_and_parse_afi_safi_bgp (vty, argv, argc, &idx, &afi, &safi, &bgp);
   if (!idx)
     return CMD_WARNING;
 
@@ -9253,40 +9233,18 @@ DEFUN (show_ip_bgp_instance_neighbor_prefix_counts,
        "Display detailed prefix count information\n"
        JSON_STR)
 {
-  vrf_id_t vrf = VRF_DEFAULT;
   afi_t afi = AFI_IP6;
   safi_t safi = SAFI_UNICAST;
   struct peer *peer;
   int idx = 0;
   struct bgp *bgp = NULL;
 
-  bgp_vty_find_and_parse_afi_safi_vrf (vty, argv, argc, &idx, &afi, &safi, &vrf);
+  bgp_vty_find_and_parse_afi_safi_bgp (vty, argv, argc, &idx, &afi, &safi, &bgp);
   if (!idx)
     return CMD_WARNING;
 
   int uj = use_json (argc, argv);
   if (uj) argc--;
-
-  if (vrf != VRF_ALL)
-    {
-      bgp = bgp_lookup_by_vrf_id (vrf);
-      if (bgp == NULL)
-        {
-          if (uj)
-            {
-              json_object *json_no = NULL;
-              json_no = json_object_new_object();
-              json_object_string_add(json_no, "warning", "Can't find BGP view");
-              vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
-              json_object_free(json_no);
-            }
-          else
-            vty_out (vty, "Can't find BGP instance %s%s", argv[5]->arg, VTY_NEWLINE);
-          return CMD_WARNING;
-        }
-    }
-  else
-    bgp = NULL;
 
   argv_find (argv, argc, "neighbors", &idx);
   peer = peer_lookup_in_view (vty, bgp, argv[idx+1]->arg, uj);
@@ -9629,7 +9587,6 @@ DEFUN (show_ip_bgp_instance_neighbor_advertised_route,
        "Name of the route map\n"
        JSON_STR)
 {
-  vrf_id_t vrf = VRF_DEFAULT;
   afi_t afi = AFI_IP6;
   safi_t safi = SAFI_UNICAST;
   char *rmap_name = NULL;
@@ -9640,28 +9597,12 @@ DEFUN (show_ip_bgp_instance_neighbor_advertised_route,
 
   int idx = 0;
 
-  bgp_vty_find_and_parse_afi_safi_vrf (vty, argv, argc, &idx, &afi, &safi, &vrf);
+  bgp_vty_find_and_parse_afi_safi_bgp (vty, argv, argc, &idx, &afi, &safi, &bgp);
   if (!idx)
     return CMD_WARNING;
 
   int uj = use_json (argc, argv);
   if (uj) argc--;
-
-  bgp = bgp_lookup_by_vrf_id (vrf);
-  if (bgp == NULL)
-    {
-      if (uj)
-	{
-	  json_object *json_no = NULL;
-	  json_no = json_object_new_object();
-	  json_object_string_add(json_no, "warning", "Can't find BGP view");
-	  vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
-	  json_object_free(json_no);
-            }
-      else
-	vty_out (vty, "Can't find BGP instance %s%s", argv[5]->arg, VTY_NEWLINE);
-      return CMD_WARNING;
-    }
 
   /* neighbors <A.B.C.D|X:X::X:X|WORD> */
   argv_find (argv, argc, "neighbors", &idx);
@@ -9809,7 +9750,6 @@ DEFUN (show_ip_bgp_neighbor_routes,
        "Display routes learned from neighbor\n"
        JSON_STR)
 {
-  vrf_id_t vrf = VRF_DEFAULT;
   char *peerstr = NULL;
   struct bgp *bgp = NULL;
   afi_t afi = AFI_IP6;
@@ -9819,33 +9759,12 @@ DEFUN (show_ip_bgp_neighbor_routes,
 
   int idx = 0;
 
-  bgp_vty_find_and_parse_afi_safi_vrf (vty, argv, argc, &idx, &afi, &safi, &vrf);
+  bgp_vty_find_and_parse_afi_safi_bgp (vty, argv, argc, &idx, &afi, &safi, &bgp);
   if (!idx)
     return CMD_WARNING;
 
   int uj = use_json (argc, argv);
   if (uj) argc--;
-
-  if (vrf != VRF_ALL)
-    {
-      bgp = bgp_lookup_by_vrf_id (vrf);
-      if (bgp == NULL)
-        {
-          if (uj)
-            {
-              json_object *json_no = NULL;
-              json_no = json_object_new_object();
-              json_object_string_add(json_no, "warning", "Can't find BGP view");
-              vty_out (vty, "%s%s", json_object_to_json_string(json_no), VTY_NEWLINE);
-              json_object_free(json_no);
-            }
-          else
-            vty_out (vty, "Can't find BGP instance %s%s", argv[5]->arg, VTY_NEWLINE);
-          return CMD_WARNING;
-        }
-    }
-  else
-    bgp = NULL;
 
   /* neighbors <A.B.C.D|X:X::X:X|WORD> */
   argv_find (argv, argc, "neighbors", &idx);

--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8454,7 +8454,6 @@ DEFUN (show_ip_bgp_route,
 
   afi_t afi = AFI_IP6;
   safi_t safi = SAFI_UNICAST;
-  //  vrf_id_t vrf = VRF_DEFAULT;;
   char *prefix = NULL;
   struct bgp *bgp = NULL;
   enum bgp_path_type path_type;

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -64,6 +64,6 @@ extern int
 argv_find_and_parse_safi(struct cmd_token **argv, int argc, int *index, safi_t *safi);
 
 extern int
-bgp_vty_find_and_parse_afi_safi_vrf (struct vty *vty, struct cmd_token **argv, int argc, int *idx,
-                                     afi_t *afi, safi_t *safi, vrf_id_t *vrf);
+bgp_vty_find_and_parse_afi_safi_bgp (struct vty *vty, struct cmd_token **argv, int argc, int *idx,
+                                     afi_t *afi, safi_t *safi, struct bgp **bgp);
 #endif /* _QUAGGA_BGP_VTY_H */


### PR DESCRIPTION
This fixes two issues:

1) We were accidently setting the safi to SAFI_EVPN and causing issues running `show ip bgp`

2) We were not properly handling the 'show [ip] bgp view #` command. 