### PR TITLE
vtysh: Fix cli help string to have only 1 mention of vty_socket

### DIFF
--- a/vtysh/vtysh_main.c
+++ b/vtysh/vtysh_main.c
@@ -147,7 +147,6 @@ usage (int status)
 	    "-f, --inputfile          Execute commands from specific file and exit\n" \
 	    "-E, --echo               Echo prompt and command in -c mode\n" \
 	    "-C, --dryrun             Check configuration for validity and exit\n" \
-	    "    --vty_socket         Override vty socket path\n" \
 	    "-m, --markfile           Mark input file with context end\n" \
 	    "    --vty_socket         Override vty socket path\n" \
 	    "    --config_dir         Override config directory path\n" \


### PR DESCRIPTION
When you run 'vtysh -h' the option '--vty_socket' is listed twice.
Fixes issue #253

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>