### PR TITLE
vtysh: fix completion

### DIFF
--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -832,7 +832,7 @@ command_generator (const char *text, int state)
 	vector_set (vline, NULL);
 
       if (matched)
-        XFREE (MTYPE_TMP, matched);
+        vector_only_index_free (matched);
       matched = cmd_complete_command (vline, vty, &complete_status);
       cmd_free_strvec (vline);
     }


### PR DESCRIPTION
The return value from cmd_complete_command is a VECTOR_INDEX, not TMP.
Use the appropriate vector_only_index_free().

Fixes #223.

Reported-by: https://github.com/k0ste
Signed-off-by: David Lamparter <equinox@opensourcerouting.org>