### PR TITLE
debian: Allow building the .deb to know about new dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,14 +3,14 @@ Section: net
 Priority: optional
 Maintainer: Christian Hammers <ch@debian.org>
 Uploaders: Florian Weimer <fw@debian.org>
-Build-Depends: debhelper (>= 7.0.50~), libncurses5-dev, libreadline-dev, texlive-latex-base, texlive-generic-recommended, libpam0g-dev | libpam-dev, libcap-dev, texinfo (>= 4.7), imagemagick, ghostscript, groff, po-debconf, autotools-dev, hardening-wrapper, libpcre3-dev, gawk, chrpath, libsnmp-dev, git, dh-autoreconf, libjson0, libjson0-dev, dh-systemd, libsystemd-dev, python-ipaddr, bison, flex
+Build-Depends: debhelper (>= 7.0.50~), libncurses5-dev, libreadline-dev, texlive-latex-base, texlive-generic-recommended, libpam0g-dev | libpam-dev, libcap-dev, texinfo (>= 4.7), imagemagick, ghostscript, groff, po-debconf, autotools-dev, hardening-wrapper, libpcre3-dev, gawk, chrpath, libsnmp-dev, git, dh-autoreconf, libjson0, libjson0-dev, dh-systemd, libsystemd-dev, python-ipaddr, bison, flex, libc-ares-dev
 Standards-Version: 3.9.6
 Homepage: http://www.frr.net/
 XS-Testsuite: autopkgtest
 
 Package: frr
 Architecture: any
-Depends: ${shlibs:Depends}, logrotate (>= 3.2-11), iproute, ${misc:Depends}
+Depends: ${shlibs:Depends}, logrotate (>= 3.2-11), iproute, ${misc:Depends}, libc-ares2
 Pre-Depends: adduser
 Conflicts: zebra, zebra-pj
 Replaces: zebra, zebra-pj


### PR DESCRIPTION
libc-ares-dev and libc-ares2 are now dependencies to build nhrpd

Signed-off-by: Donald Sharp <sharpd@cumulusnetworks.com>