### PR TITLE
pimd: Separate the register and upstream join states

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -1692,7 +1692,7 @@ static void pim_show_upstream(struct vty *vty, u_char uj)
     pim_time_timer_to_hhmmss (msdp_reg_timer, sizeof (msdp_reg_timer), up->t_msdp_reg_timer);
 
     if (pim_if_connected_to_source (up->rpf.source_nexthop.interface, up->sg.src))
-      strcpy (state_str, pim_upstream_state2str (up->reg_state));
+      pim_reg_state2str (up->reg_state, state_str);
     else
       strcpy (state_str, pim_upstream_state2str (up->join_state));
 

--- a/pimd/pim_jp_agg.c
+++ b/pimd/pim_jp_agg.c
@@ -249,6 +249,10 @@ pim_jp_agg_single_upstream_send (struct pim_rpf *rpf,
 
   static bool first = true;
 
+  /* skip JP upstream messages if source is directly connected */
+  if (pim_if_connected_to_source (rpf->source_nexthop.interface, up->sg.src))
+      return;
+
   if (first)
     {
       groups = list_new();

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -189,7 +189,7 @@ pim_mroute_msg_nocache (int fd, struct interface *ifp, const struct igmpmsg *msg
   up->channel_oil->cc.pktcnt++;
   PIM_UPSTREAM_FLAG_SET_FHR(up->flags);
   pim_channel_add_oif (up->channel_oil, pim_regiface, PIM_OIF_FLAG_PROTO_PIM);
-  up->reg_state = PIM_UPSTREAM_JOINED;
+  up->reg_state = PIM_REG_JOIN;
 
   return 0;
 }
@@ -453,7 +453,7 @@ pim_mroute_msg_wrvifwhole (int fd, struct interface *ifp, const char *buf)
       up->channel_oil = oil;
       up->channel_oil->cc.pktcnt++;
       pim_channel_add_oif (up->channel_oil, pim_regiface, PIM_OIF_FLAG_PROTO_PIM);
-      up->reg_state = PIM_UPSTREAM_JOINED;
+      up->reg_state = PIM_REG_JOIN;
       pim_upstream_inherited_olist (up);
 
       // Send the packet to the RP

--- a/pimd/pim_mroute.c
+++ b/pimd/pim_mroute.c
@@ -189,7 +189,7 @@ pim_mroute_msg_nocache (int fd, struct interface *ifp, const struct igmpmsg *msg
   up->channel_oil->cc.pktcnt++;
   PIM_UPSTREAM_FLAG_SET_FHR(up->flags);
   pim_channel_add_oif (up->channel_oil, pim_regiface, PIM_OIF_FLAG_PROTO_PIM);
-  up->join_state = PIM_UPSTREAM_JOINED;
+  up->reg_state = PIM_UPSTREAM_JOINED;
 
   return 0;
 }
@@ -453,7 +453,7 @@ pim_mroute_msg_wrvifwhole (int fd, struct interface *ifp, const char *buf)
       up->channel_oil = oil;
       up->channel_oil->cc.pktcnt++;
       pim_channel_add_oif (up->channel_oil, pim_regiface, PIM_OIF_FLAG_PROTO_PIM);
-      up->join_state = PIM_UPSTREAM_JOINED;
+      up->reg_state = PIM_UPSTREAM_JOINED;
       pim_upstream_inherited_olist (up);
 
       // Send the packet to the RP

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -358,7 +358,7 @@ pim_register_recv (struct interface *ifp,
 	upstream->sg.src = sg.src;
 	upstream->rpf.rpf_addr = upstream->rpf.source_nexthop.mrib_nexthop_addr;
 
-	upstream->join_state = PIM_UPSTREAM_PRUNE;
+	upstream->join_state = PIM_UPSTREAM_NOTJOINED;
 
       }
 

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -122,19 +122,19 @@ pim_register_stop_recv (uint8_t *buf, int buf_size)
     zlog_debug ("Received Register stop for %s",
 		upstream->sg_str);
 
-  switch (upstream->join_state)
+  switch (upstream->reg_state)
     {
     case PIM_UPSTREAM_NOTJOINED:
     case PIM_UPSTREAM_PRUNE:
       return 0;
       break;
     case PIM_UPSTREAM_JOINED:
-      upstream->join_state = PIM_UPSTREAM_PRUNE;
+      upstream->reg_state = PIM_UPSTREAM_PRUNE;
       pim_channel_del_oif (upstream->channel_oil, pim_regiface, PIM_OIF_FLAG_PROTO_PIM);
       pim_upstream_start_register_stop_timer (upstream, 0);
       break;
     case PIM_UPSTREAM_JOIN_PENDING:
-      upstream->join_state = PIM_UPSTREAM_PRUNE;
+      upstream->reg_state = PIM_UPSTREAM_PRUNE;
       pim_upstream_start_register_stop_timer (upstream, 0);
       return 0;
       break;

--- a/pimd/pim_register.c
+++ b/pimd/pim_register.c
@@ -124,17 +124,17 @@ pim_register_stop_recv (uint8_t *buf, int buf_size)
 
   switch (upstream->reg_state)
     {
-    case PIM_UPSTREAM_NOTJOINED:
-    case PIM_UPSTREAM_PRUNE:
+    case PIM_REG_NOINFO:
+    case PIM_REG_PRUNE:
       return 0;
       break;
-    case PIM_UPSTREAM_JOINED:
-      upstream->reg_state = PIM_UPSTREAM_PRUNE;
+    case PIM_REG_JOIN:
+      upstream->reg_state = PIM_REG_PRUNE;
       pim_channel_del_oif (upstream->channel_oil, pim_regiface, PIM_OIF_FLAG_PROTO_PIM);
       pim_upstream_start_register_stop_timer (upstream, 0);
       break;
-    case PIM_UPSTREAM_JOIN_PENDING:
-      upstream->reg_state = PIM_UPSTREAM_PRUNE;
+    case PIM_REG_JOIN_PENDING:
+      upstream->reg_state = PIM_REG_PRUNE;
       pim_upstream_start_register_stop_timer (upstream, 0);
       return 0;
       break;

--- a/pimd/pim_upstream.c
+++ b/pimd/pim_upstream.c
@@ -473,26 +473,9 @@ pim_upstream_switch(struct pim_upstream *up,
 	       pim_upstream_state2str (new_state));
   }
 
-  /*
-   * This code still needs work.
-   */
-  switch (up->join_state)
-    {
-    case PIM_UPSTREAM_PRUNE:
-      if (!PIM_UPSTREAM_FLAG_TEST_FHR(up->flags))
-        {
-          up->join_state       = new_state;
-          up->state_transition = pim_time_monotonic_sec ();
-        }
-      break;
-    case PIM_UPSTREAM_NOTJOINED:
-    case PIM_UPSTREAM_JOINED:
-      up->join_state       = new_state;
-      if (old_state != new_state)
-        up->state_transition = pim_time_monotonic_sec();
-
-      break;
-    }
+  up->join_state = new_state;
+  if (old_state != new_state)
+    up->state_transition = pim_time_monotonic_sec();
 
   pim_upstream_update_assert_tracking_desired(up);
 
@@ -600,7 +583,7 @@ pim_upstream_new (struct prefix_sg *sg,
   up->t_ka_timer                 = NULL;
   up->t_rs_timer                 = NULL;
   up->t_msdp_reg_timer           = NULL;
-  up->join_state                 = 0;
+  up->join_state                 = PIM_UPSTREAM_NOTJOINED;
   up->reg_state                  = PIM_REG_NOINFO;
   up->state_transition           = pim_time_monotonic_sec();
   up->channel_oil                = NULL;
@@ -1200,9 +1183,6 @@ pim_upstream_state2str (enum pim_upstream_state join_state)
       break;
     case PIM_UPSTREAM_JOINED:
       return "Joined";
-      break;
-    case PIM_UPSTREAM_PRUNE:
-      return "Prune";
       break;
     }
   return "Unknown";

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -88,6 +88,7 @@ struct pim_upstream {
   struct list             *sources;
 
   enum pim_upstream_state  join_state;
+  enum pim_upstream_state  reg_state;
   enum pim_upstream_sptbit sptbit;
 
   int                      ref_count;
@@ -163,6 +164,8 @@ void pim_upstream_send_join (struct pim_upstream *up);
 void pim_upstream_switch (struct pim_upstream *up, enum pim_upstream_state new_state);
 
 const char *pim_upstream_state2str (enum pim_upstream_state join_state);
+#define PIM_REG_STATE_STR_LEN 12
+const char *pim_reg_state2str (enum pim_upstream_state state, char *state_str);
 
 int pim_upstream_inherited_olist_decide (struct pim_upstream *up);
 int pim_upstream_inherited_olist (struct pim_upstream *up);

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -61,8 +61,14 @@
 enum pim_upstream_state {
   PIM_UPSTREAM_NOTJOINED,
   PIM_UPSTREAM_JOINED,
-  PIM_UPSTREAM_JOIN_PENDING,
   PIM_UPSTREAM_PRUNE,
+};
+
+enum pim_reg_state {
+  PIM_REG_NOINFO,
+  PIM_REG_JOIN,
+  PIM_REG_JOIN_PENDING,
+  PIM_REG_PRUNE,
 };
 
 enum pim_upstream_sptbit {
@@ -88,7 +94,7 @@ struct pim_upstream {
   struct list             *sources;
 
   enum pim_upstream_state  join_state;
-  enum pim_upstream_state  reg_state;
+  enum pim_reg_state       reg_state;
   enum pim_upstream_sptbit sptbit;
 
   int                      ref_count;
@@ -165,7 +171,7 @@ void pim_upstream_switch (struct pim_upstream *up, enum pim_upstream_state new_s
 
 const char *pim_upstream_state2str (enum pim_upstream_state join_state);
 #define PIM_REG_STATE_STR_LEN 12
-const char *pim_reg_state2str (enum pim_upstream_state state, char *state_str);
+const char *pim_reg_state2str (enum pim_reg_state state, char *state_str);
 
 int pim_upstream_inherited_olist_decide (struct pim_upstream *up);
 int pim_upstream_inherited_olist (struct pim_upstream *up);

--- a/pimd/pim_upstream.h
+++ b/pimd/pim_upstream.h
@@ -61,7 +61,6 @@
 enum pim_upstream_state {
   PIM_UPSTREAM_NOTJOINED,
   PIM_UPSTREAM_JOINED,
-  PIM_UPSTREAM_PRUNE,
 };
 
 enum pim_reg_state {


### PR DESCRIPTION
There are four patches in this series intended to simplify the upstream state machine on the FHR.