### PR TITLE
Proto dev build

### DIFF
--- a/zebra/zebra_fpm_dt.c
+++ b/zebra/zebra_fpm_dt.c
@@ -50,8 +50,10 @@
 #include "qpb/qpb_allocator.h"
 #include "qpb/linear_allocator.h"
 
+#ifdef HAVE_PROTOBUF
 #include "qpb/qpb.h"
 #include "fpm/fpm.pb-c.h"
+#endif
 
 /*
  * Externs.

--- a/zebra/zebra_fpm_protobuf.c
+++ b/zebra/zebra_fpm_protobuf.c
@@ -53,7 +53,7 @@ create_delete_route_message (qpb_allocator_t *allocator, rib_dest_t *dest,
   }
 
   fpm__delete_route__init(msg);
-  msg->vrf_id = rib_dest_vrf(dest)->vrf_id;
+  msg->vrf_id = rib_dest_vrf(dest)->vrf->vrf_id;
 
   qpb_address_family_set(&msg->address_family, rib_dest_af(dest));
 
@@ -159,7 +159,7 @@ create_add_route_message (qpb_allocator_t *allocator, rib_dest_t *dest,
 
   fpm__add_route__init(msg);
 
-  msg->vrf_id = rib_dest_vrf(dest)->vrf_id;
+  msg->vrf_id = rib_dest_vrf(dest)->vrf->vrf_id;
 
   qpb_address_family_set (&msg->address_family, rib_dest_af(dest));
 


### PR DESCRIPTION
When compiling with `configure --dev-build` on stable/2.0 it was not working properly.

The first commit allows `configure --dev-build --enable-protobuf` to properly compile
The second commit allows `configure --dev-build` to properly compile.