### PR TITLE
ldpd: remove pseudowire LSP check

### DIFF
--- a/ldpd/l2vpn.c
+++ b/ldpd/l2vpn.c
@@ -282,9 +282,6 @@ l2vpn_pw_reset(struct l2vpn_pw *pw)
 int
 l2vpn_pw_ok(struct l2vpn_pw *pw, struct fec_nh *fnh)
 {
-	struct fec		 fec;
-	struct fec_node		*fn;
-
 	/* check for a remote label */
 	if (fnh->remote_label == NO_LABEL)
 		return (0);
@@ -297,34 +294,6 @@ l2vpn_pw_ok(struct l2vpn_pw *pw, struct fec_nh *fnh)
 	if ((pw->flags & F_PW_STATUSTLV) &&
 	    pw->remote_status != PW_FORWARDING)
 		return (0);
-
-	/* check for a working lsp to the nexthop */
-	memset(&fec, 0, sizeof(fec));
-	switch (pw->af) {
-	case AF_INET:
-		fec.type = FEC_TYPE_IPV4;
-		fec.u.ipv4.prefix = pw->addr.v4;
-		fec.u.ipv4.prefixlen = 32;
-		break;
-	case AF_INET6:
-		fec.type = FEC_TYPE_IPV6;
-		fec.u.ipv6.prefix = pw->addr.v6;
-		fec.u.ipv6.prefixlen = 128;
-		break;
-	default:
-		fatalx("l2vpn_pw_ok: unknown af");
-	}
-
-	fn = (struct fec_node *)fec_find(&ft, &fec);
-	if (fn == NULL || fn->local_label == NO_LABEL)
-		return (0);
-	/*
-	 * Need to ensure that there's a label binding for all nexthops.
-	 * Otherwise, ECMP for this route could render the pseudowire unusable.
-	 */
-	LIST_FOREACH(fnh, &fn->nexthops, entry)
-		if (fnh->remote_label == NO_LABEL)
-			return (0);
 
 	return (1);
 }


### PR DESCRIPTION
In order to bring a pseudowire up, we must make sure that there's at
least one LSP available to its remote end (otherwise the labeled frames
from the CEs wouldn't reach their destination). We were doing this
check in ldpd, but doing so is very limiting because it doesn't consider
other types of LSPs that might be available (static LSPs, RSVP-TE, SR,
etc). Thus remove this check from the l2vpn_pw_ok() function. Later
on we'll implement a pseudowire manager in zebra which will solve this
problem in a much better way (including notifying ldpd about failures
to install a pseudowire in the kernel/hardware).

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>